### PR TITLE
docs(docs): update setup guide with all Nx generators and sync removed domains

### DIFF
--- a/.ai/domains/facturacion.md
+++ b/.ai/domains/facturacion.md
@@ -1,22 +1,15 @@
-# Dominio: Facturación
+> **DOMINIO REMOVIDO** — Este dominio fue eliminado del monorepo en el commit `460fff6`.
+> Las librerías `libs/facturacion/**` ya no existen en el workspace.
+> Si este dominio se reactiva en el futuro, recrear las librerías con el generator correspondiente.
+
+# Dominio: Facturación ~~(removido)~~
 
 **Equipo propietario:** Equipo Facturación (2 personas)
 **RF relacionados:** RF-F — FEL y facturas electrónicas
+**Estado:** **REMOVIDO** — no existe en el workspace actual
 
-## Podés modificar
-- `libs/facturacion/**`
+## Componentes planeados (referencia histórica)
 
-## Solo lectura
-- `libs/shared/**` — podés importar, nunca modificar
-
-## Nunca tocás
-- Cualquier otro dominio
-- `apps/`, `tsconfig.base.json`, `.eslintrc.json`, `nx.json`
-
-## Scope de tus ramas y commits
-`feat/facturacion/...` | `fix/facturacion/...` | `chore/facturacion/...`
-
-## Componentes únicos de este dominio
 - `InvoiceListComponent` — listado de facturas emitidas
 - `FelFormComponent` — formulario de emisión FEL
 - `InvoiceDetailComponent` — detalle y descarga de factura

--- a/.ai/domains/presupuesto.md
+++ b/.ai/domains/presupuesto.md
@@ -1,22 +1,15 @@
-# Dominio: Presupuesto
+> **DOMINIO REMOVIDO** — Este dominio fue eliminado del monorepo en el commit `460fff6`.
+> Las librerías `libs/presupuesto/**` ya no existen en el workspace.
+> Si este dominio se reactiva en el futuro, recrear las librerías con el generator correspondiente.
+
+# Dominio: Presupuesto ~~(removido)~~
 
 **Equipo propietario:** Equipo Presupuesto (2 personas)
 **RF relacionados:** RF-P — techos presupuestarios y ZESE
+**Estado:** **REMOVIDO** — no existe en el workspace actual
 
-## Podés modificar
-- `libs/presupuesto/**`
+## Componentes planeados (referencia histórica)
 
-## Solo lectura
-- `libs/shared/**` — podés importar, nunca modificar
-
-## Nunca tocás
-- Cualquier otro dominio
-- `apps/`, `tsconfig.base.json`, `.eslintrc.json`, `nx.json`
-
-## Scope de tus ramas y commits
-`feat/presupuesto/...` | `fix/presupuesto/...` | `chore/presupuesto/...`
-
-## Componentes únicos de este dominio
 - `BudgetOverviewComponent` — resumen de techos por área
 - `ZeseFormComponent` — formulario ZESE
 - `BudgetAlertComponent` — alerta de techo superado

--- a/.ai/domains/requisiciones.md
+++ b/.ai/domains/requisiciones.md
@@ -1,22 +1,15 @@
-# Dominio: Requisiciones
+> **DOMINIO REMOVIDO** — Este dominio fue eliminado del monorepo en el commit `460fff6`.
+> Las librerías `libs/requisiciones/**` ya no existen en el workspace.
+> Si este dominio se reactiva en el futuro, recrear las librerías con el generator correspondiente.
+
+# Dominio: Requisiciones ~~(removido)~~
 
 **Equipo propietario:** Equipo Requisiciones (2 personas)
 **RF relacionados:** RF-Q — requisiciones y actas de entrega
+**Estado:** **REMOVIDO** — no existe en el workspace actual
 
-## Podés modificar
-- `libs/requisiciones/**`
+## Componentes planeados (referencia histórica)
 
-## Solo lectura
-- `libs/shared/**` — podés importar, nunca modificar
-
-## Nunca tocás
-- Cualquier otro dominio
-- `apps/`, `tsconfig.base.json`, `.eslintrc.json`, `nx.json`
-
-## Scope de tus ramas y commits
-`feat/requisiciones/...` | `fix/requisiciones/...` | `chore/requisiciones/...`
-
-## Componentes únicos de este dominio
 - `RequisicionFormComponent` — formulario de nueva requisición
 - `RequisicionListComponent` — listado con estados
 - `ActaEntregaComponent` — acta de entrega firmada

--- a/.ai/protocol.md
+++ b/.ai/protocol.md
@@ -7,7 +7,7 @@ No asumas nada. No empieces a codificar hasta tener todas las respuestas.
 
 1. **¿En qué dominio vas a trabajar?**
    Opciones: `shell` | `auth` | `cocina` | `bar` | `restaurante` | `inventario` |
-   `abastecimiento` | `facturacion` | `presupuesto` | `requisiciones` | `reportes` | `notificaciones` | `shared`
+   `abastecimiento` | `reportes` | `notificaciones` | `shared`
 
 2. **¿Cuál es el RF o descripción del cambio?**
    Ejemplo: "RF-C4.2.1 — agregar componente de tarjeta de receta"

--- a/.ai/rules/architecture.md
+++ b/.ai/rules/architecture.md
@@ -34,9 +34,6 @@ import { AuthService } from '../../shared/auth/src/lib/auth.service';
 | `@restaurant/restaurante` | `libs/restaurante/restaurante` |
 | `@restaurant/inventario` | `libs/inventario/inventario` |
 | `@restaurant/abastecimiento` | `libs/abastecimiento/abastecimiento` |
-| `@restaurant/facturacion` | `libs/facturacion/facturacion` |
-| `@restaurant/presupuesto` | `libs/presupuesto/presupuesto` |
-| `@restaurant/requisiciones` | `libs/requisiciones/requisiciones` |
 | `@restaurant/reportes` | `libs/reportes/reportes` |
 | `@restaurant/notificaciones` | `libs/notificaciones/notificaciones` |
 | `@restaurant/shared/auth` | `libs/shared/auth` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,4 +111,4 @@ chore(shared/models): promote Pedido interface
 - `nx.json`
 - `apps/**`
 - `package.json`
-- `libs/shell/feature-shell/src/lib/shell.routes.ts`
+- `libs/shell/shell/src/lib/shell.routes.ts`

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -62,42 +62,33 @@ GastrosenaFrontend/
 ├── libs/
 │   │
 │   ├── shell/                    ← Infraestructura de navegación (no es dominio de negocio)
-│   │   ├── feature-shell/        ← Routing principal, layouts, guards, nav
-│   │   └── feature-home/         ← Landing pública del restaurante
+│   │   ├── shell/                ← Routing principal, layouts, guards, nav
+│   │   └── home/                 ← Landing pública del restaurante
 │   │
 │   ├── auth/                     ← Dominio: identidad y acceso
-│   │   ├── feature-auth/         ← Login, recuperación de contraseña
-│   │   └── feature-usuarios/     ← CRUD usuarios, roles, permisos, historial
+│   │   ├── auth/                 ← Login, recuperación de contraseña
+│   │   └── usuarios/             ← CRUD usuarios, roles, permisos, historial
 │   │
 │   ├── cocina/                   ← Dominio: operaciones de cocina
-│   │   └── feature-cocina/       ← Pedidos, recetas, tiempos, menús
+│   │   └── cocina/               ← Pedidos, recetas, tiempos, menús
 │   │
 │   ├── bar/                      ← Dominio: operaciones de bar
-│   │   └── feature-bar/          ← Pedidos bar, recetas de bebidas, alertas
+│   │   └── bar/                  ← Pedidos bar, recetas de bebidas, alertas
 │   │
 │   ├── restaurante/              ← Dominio: salón y servicio
-│   │   └── feature-restaurante/  ← Mesas, pedidos de salón, comandas
+│   │   └── restaurante/          ← Mesas, pedidos de salón, comandas
 │   │
 │   ├── inventario/               ← Dominio: gestión de bienes
-│   │   └── feature-inventario/   ← Bienes, entradas/salidas, stock, conciliación
+│   │   └── inventario/           ← Bienes, entradas/salidas, stock, conciliación
 │   │
 │   ├── abastecimiento/           ← Dominio: abastecimiento y GIL
-│   │   └── feature-abastecimiento/ ← GIL-F-014, consolidados, paquete probatorio
-│   │
-│   ├── facturacion/              ← Dominio: facturación electrónica
-│   │   └── feature-facturacion/  ← FEL, CUFE, ciclo de vida de facturas
-│   │
-│   ├── presupuesto/              ← Dominio: presupuesto y ZESE
-│   │   └── feature-presupuesto/  ← Techos presupuestales, ejecución
-│   │
-│   ├── requisiciones/            ← Dominio: requisiciones y actas
-│   │   └── feature-requisiciones/ ← Requisiciones diarias, actas de legalización
+│   │   └── abastecimiento/       ← GIL-F-014, consolidados, paquete probatorio
 │   │
 │   ├── reportes/                 ← Dominio: reportería
-│   │   └── feature-reportes/     ← Reportes exportables (PDF/Excel)
+│   │   └── reportes/             ← Reportes exportables (PDF/Excel)
 │   │
 │   ├── notificaciones/           ← Dominio: alertas y notificaciones
-│   │   └── feature-notificaciones/ ← Panel, historial, alertas de stock en tiempo real
+│   │   └── notificaciones/       ← Panel, historial, alertas de stock en tiempo real
 │   │
 │   └── shared/                   ← Código reutilizable cross-dominio
 │       ├── auth/                 ← AuthService, guards de sesión, current-user signal
@@ -116,7 +107,7 @@ GastrosenaFrontend/
 └── docs/arquitectura.md          ← Este archivo (arquitectura y reglas)
 ```
 
-> **Convención de crecimiento:** cuando un dominio necesite una segunda feature (ej. `feature-cocina-recetas`), se crea dentro de `libs/cocina/feature-cocina-recetas/` — nunca en la raíz de `libs/`.
+> **Convención de crecimiento:** cuando un dominio necesite una segunda librería (ej. `cocina-recetas`), se crea dentro de `libs/cocina/cocina-recetas/` — nunca en la raíz de `libs/`.
 
 ---
 
@@ -140,7 +131,7 @@ La app shell **no contiene** routing, guards, layouts ni lógica de negocio. Su 
 ### 3.2 Feature Shell
 
 ```
-libs/feature-shell/
+libs/shell/shell/
   └── src/lib/
       ├── shell.routes.ts        ← Rutas principales con lazy loading
       ├── shell-layout/
@@ -173,27 +164,27 @@ export const shellRoutes: Routes = [
         path: 'cocina',
         canActivate: [roleGuard(['CHEF', 'ADMIN_COCINA', 'AUXILIAR_COCINA'])],
         loadChildren: () =>
-          import('@restaurant/feature-cocina').then(m => m.COCINA_ROUTES),
+          import('@restaurant/cocina').then(m => m.COCINA_ROUTES),
       },
       {
         path: 'bar',
         canActivate: [roleGuard(['LIDER_BAR', 'ADMIN_BAR', 'BARTENDER'])],
         loadChildren: () =>
-          import('@restaurant/feature-bar').then(m => m.BAR_ROUTES),
+          import('@restaurant/bar').then(m => m.BAR_ROUTES),
       },
       {
         path: 'inventario',
         canActivate: [roleGuard(['ADMINISTRADOR', 'CONTADORA'])],
         loadChildren: () =>
-          import('@restaurant/feature-inventario').then(m => m.INVENTARIO_ROUTES),
+          import('@restaurant/inventario').then(m => m.INVENTARIO_ROUTES),
       },
-      // ... demás features
+      // ... demás dominios
     ],
   },
   {
     path: 'auth',
     loadChildren: () =>
-      import('@restaurant/feature-auth').then(m => m.AUTH_ROUTES),
+      import('@restaurant/auth').then(m => m.AUTH_ROUTES),
   },
 ];
 ```
@@ -247,7 +238,7 @@ shared/state/src/lib/
       └── hydration.metareducer.ts  ← Persistencia en localStorage
 ```
 
-> El estado **específico de cada feature** (pedidos de cocina, bienes del inventario) vive en `feature-*/data-access/`, no aquí. En `shared/state` solo va el estado verdaderamente global.
+> El estado **específico de cada dominio** (pedidos de cocina, bienes del inventario) vive en `{dominio}/{dominio}/src/lib/data-access/`, no aquí. En `shared/state` solo va el estado verdaderamente global.
 
 #### `shared/ui`
 
@@ -308,17 +299,18 @@ shared/models/src/lib/
 
 ### 3.4 Feature Layer
 
-Cada librería de feature tiene la misma anatomía interna de cuatro sublibrerías. La consistencia entre features es lo que permite que cualquier dev pueda moverse entre dominios sin curva de aprendizaje.
+Cada librería de dominio tiene la misma anatomía interna de cuatro carpetas. La consistencia entre dominios es lo que permite que cualquier dev pueda moverse entre ellos sin curva de aprendizaje.
 
 ```
-feature-cocina/
+libs/cocina/cocina/src/lib/
   ├── ui/              ← Componentes visuales exclusivos de cocina
+  ├── pages/           ← Componentes con routing (una carpeta por ruta)
   ├── data-access/     ← Services, NgRx Store+Effects propios de cocina
   ├── util/            ← Helpers específicos de cocina (no van a shared)
   └── models/          ← Interfaces propias (RecetaCocina, TiempoPreparacion...)
 ```
 
-Regla: si una interfaz de `feature-cocina/models` empieza a ser necesaria en `feature-restaurante`, se **promueve** a `shared/models`. Nunca se importa entre features directamente.
+Regla: si una interfaz de `cocina/models` empieza a ser necesaria en `restaurante`, se **promueve** a `shared/models`. Nunca se importa entre dominios directamente.
 
 ---
 
@@ -327,9 +319,9 @@ Regla: si una interfaz de `feature-cocina/models` empieza a ser necesaria en `fe
 ```
 ┌─────────────────────────────────────────────────────┐
 │                                                     │
-│  feature-*   →  puede importar de  shared/*         │
-│  feature-*   →  NUNCA importa de otro  feature-*    │
-│  shared/*    →  NUNCA importa de  feature-*         │
+│  {dominio}  →  puede importar de  shared/*          │
+│  {dominio}  →  NUNCA importa de otro  {dominio}     │
+│  shared/*   →  NUNCA importa de  {dominio}          │
 │                                                     │
 └─────────────────────────────────────────────────────┘
 ```
@@ -349,51 +341,49 @@ Esta jerarquía se enforza automáticamente con ESLint (ver sección 11).
 
 ---
 
-## 5. Anatomía Interna de un Feature
+## 5. Anatomía Interna de un Dominio
 
-Tomando `feature-inventario` como ejemplo completo:
+Tomando `inventario` como ejemplo completo:
 
 ```
-libs/feature-inventario/
+libs/inventario/inventario/src/lib/
 │
-├── ui/
-│   └── src/lib/
-│       ├── catalog/
-│       │   ├── catalog-list.component.ts
-│       │   └── catalog-filter.component.ts
-│       ├── stock/
-│       │   ├── stock-alert-banner.component.ts    ← Solo existe en inventario
-│       │   └── stock-level-indicator.component.ts
-│       ├── movements/
-│       │   ├── entry-form.component.ts
-│       │   └── exit-form.component.ts
-│       └── index.ts   ← Barrel: exporta solo lo público
+├── ui/                         ← Componentes visuales (presentacionales)
+│   ├── catalog-list/
+│   │   ├── catalog-list.component.ts
+│   │   └── catalog-list.component.html
+│   ├── stock/
+│   │   ├── stock-alert-banner.component.ts    ← Solo existe en inventario
+│   │   └── stock-level-indicator.component.ts
+│   └── movements/
+│       ├── entry-form.component.ts
+│       └── exit-form.component.ts
 │
-├── data-access/
-│   └── src/lib/
-│       ├── +state/
-│       │   ├── inventario.actions.ts
-│       │   ├── inventario.reducer.ts
-│       │   ├── inventario.effects.ts
-│       │   ├── inventario.selectors.ts
-│       │   └── inventario.facade.ts    ← El único punto de entrada al store
-│       ├── services/
-│       │   ├── bienes.service.ts
-│       │   ├── movimientos.service.ts
-│       │   └── alertas-stock.service.ts
-│       └── index.ts
+├── pages/                      ← Componentes con routing (una por ruta)
+│   ├── bienes-page/
+│   │   └── bienes-page.component.ts
+│   └── movimientos-page/
+│       └── movimientos-page.component.ts
 │
-├── util/
-│   └── src/lib/
-│       ├── stock-level.calculator.ts   ← Lógica específica de umbrales
-│       └── bien-code.generator.ts      ← Generador de códigos SENA internos
+├── data-access/                ← Lógica de negocio y acceso al store
+│   ├── store/
+│   │   ├── inventario.actions.ts
+│   │   ├── inventario.reducer.ts
+│   │   ├── inventario.effects.ts
+│   │   └── inventario.selectors.ts
+│   ├── inventario.facade.ts    ← El único punto de entrada al store
+│   ├── bienes.service.ts
+│   ├── movimientos.service.ts
+│   └── alertas-stock.service.ts
 │
-└── models/
-    └── src/lib/
-        ├── bien.model.ts               ← Extiende shared/models Bien si hace falta
-        ├── movimiento.model.ts
-        ├── alerta-stock.model.ts
-        └── index.ts
+├── models/                     ← Interfaces propias del dominio
+│   ├── bien.model.ts
+│   ├── movimiento.model.ts
+│   └── alerta-stock.model.ts
+│
+└── util/                       ← Helpers específicos (no van a shared)
+    ├── stock-level.calculator.ts
+    └── bien-code.generator.ts
 ```
 
 **El Facade** (`inventario.facade.ts`) es el patrón clave: los componentes de `ui/` solo hablan con el facade, nunca con el store directamente. Esto hace que los componentes sean más testeables y desacoplados.
@@ -629,7 +619,7 @@ export interface ApiResponse<T> {
 }
 ```
 
-**Regla de promoción:** si una interfaz definida en `feature-*/models` es necesaria en más de un feature, se abre un PR para moverla a `shared/models`. Nunca se importa entre features directamente.
+**Regla de promoción:** si una interfaz definida en `{dominio}/models` es necesaria en más de un dominio, se abre un PR para moverla a `shared/models`. Nunca se importa entre dominios directamente.
 
 ---
 
@@ -637,34 +627,34 @@ export interface ApiResponse<T> {
 
 ### Regla de las 3 instancias
 
-Un componente sube a `shared/ui` únicamente cuando **3 o más features distintas lo necesitan**. Antes de eso, vive en el `feature-*/ui` que lo originó.
+Un componente sube a `shared/ui` únicamente cuando **3 o más dominios distintos lo necesitan**. Antes de eso, vive en el `{dominio}/ui` que lo originó.
 
 ```
-✅ shared/ui — usados por 3+ features
-  DataTableComponent          (Inventario, Reportes, Usuarios, Facturación...)
+✅ shared/ui — usados por 3+ dominios
+  DataTableComponent          (Inventario, Reportes, Usuarios)
   StatusBadgeComponent        (Cocina, Bar, Restaurante)
   ConfirmDialogComponent      (Todo el sistema)
   PageHeaderComponent         (Todas las vistas)
   SearchFilterComponent       (Inventario, Reportes, Usuarios)
   LoadingSkeletonComponent    (Todo el sistema)
   EmptyStateComponent         (Todo el sistema)
-  ExportButtonComponent       (Reportes, Inventario, Facturación)
+  ExportButtonComponent       (Reportes, Inventario)
 
-✅ feature-cocina/ui — únicos de cocina
+✅ cocina/ui — únicos de cocina
   KitchenBoardComponent       (Tablero de pedidos en tiempo real)
   OrderTimerComponent         (Contador de tiempo por pedido)
   RecipeStepsComponent        (Pasos de preparación)
 
-✅ feature-bar/ui — únicos de bar
+✅ bar/ui — únicos de bar
   DrinkQueueComponent         (Cola de bebidas)
   BarStatsComponent           (Estadísticas de tiempos del bar)
 
-✅ feature-inventario/ui — únicos de inventario
+✅ inventario/ui — únicos de inventario
   StockAlertBannerComponent   (Alerta visual de stock crítico)
   StockLevelIndicatorComponent
   BienDetailCardComponent
 
-✅ feature-abastecimiento/ui — únicos de GIL/abastecimiento
+✅ abastecimiento/ui — únicos de GIL/abastecimiento
   GilFormComponent
   ConsolidadoTableComponent
   PaqueteProbatorioStatusComponent
@@ -693,12 +683,12 @@ export const UiActions = createActionGroup({
 
 Cocina dispara `UiActions.showToast` cuando un pedido está listo. El shell lo escucha y muestra la notificación. Cocina no sabe nada del mecanismo de notificación.
 
-### Mecanismo 2: Facade en `feature-shell`
+### Mecanismo 2: Facade en `shell`
 
-Para coordinación de alto nivel entre features.
+Para coordinación de alto nivel entre dominios.
 
 ```typescript
-// feature-shell/src/lib/app.facade.ts
+// libs/shell/shell/src/lib/app.facade.ts
 @Injectable({ providedIn: 'root' })
 export class AppFacade {
   // Orquesta flujos que involucran múltiples features
@@ -715,10 +705,10 @@ export class AppFacade {
 Para navegación entre dominios.
 
 ```typescript
-// En feature-restaurante, al cerrar la mesa:
-this.router.navigate(['/facturacion', mesaId]);
-// feature-facturacion lee el parámetro y carga los datos.
-// Los features nunca se importan entre sí.
+// En restaurante, al cerrar la mesa, navegamos vía router:
+this.router.navigate(['/reportes', mesaId]);
+// El dominio destino lee el parámetro y carga los datos.
+// Los dominios nunca se importan entre sí.
 ```
 
 ---
@@ -747,8 +737,7 @@ main                          ← Producción. Solo recibe merges desde develop 
 
 tipo:  feat | fix | chore | refactor | test | docs
 scope: shell | auth | cocina | bar | restaurante | inventario |
-       usuarios | reportes | facturacion | abastecimiento |
-       presupuesto | requisiciones | shared
+       usuarios | reportes | abastecimiento | notificaciones | shared
 ```
 
 ### Reglas de PR
@@ -756,7 +745,7 @@ scope: shell | auth | cocina | bar | restaurante | inventario |
 | Regla | Detalle |
 |---|---|
 | **Máximo 400 líneas** por PR | Si es mayor, se divide. Sin excepciones. |
-| **Un scope por PR** | Un PR no puede tocar `feature-cocina` y `feature-bar` al mismo tiempo |
+| **Un scope por PR** | Un PR no puede tocar `cocina` y `bar` al mismo tiempo |
 | **Tests obligatorios** | Todo componente nuevo lleva su `.spec.ts` |
 | **`nx affected:lint` verde** | Requisito antes de abrir el PR |
 | **`nx affected:test` verde** | Requisito antes de abrir el PR |
@@ -786,11 +775,8 @@ Las reglas de dependencia se verifican **automáticamente en cada commit y CI**.
 ### Tags por proyecto (`project.json`)
 
 ```json
-// libs/feature-cocina/ui/project.json
-{ "tags": ["scope:cocina", "type:ui"] }
-
-// libs/feature-cocina/data-access/project.json
-{ "tags": ["scope:cocina", "type:data-access"] }
+// libs/cocina/cocina/project.json
+{ "tags": ["scope:cocina", "type:feature"] }
 
 // libs/shared/ui/project.json
 { "tags": ["scope:shared", "type:ui"] }
@@ -798,7 +784,7 @@ Las reglas de dependencia se verifican **automáticamente en cada commit y CI**.
 // libs/shared/models/project.json
 { "tags": ["scope:shared", "type:models"] }
 
-// libs/feature-shell/project.json
+// libs/shell/shell/project.json
 { "tags": ["scope:shell", "type:feature"] }
 ```
 
@@ -826,20 +812,12 @@ Las reglas de dependencia se verifican **automáticamente en cada commit y CI**.
         "onlyDependOn": ["scope:shared", "scope:inventario"]
       },
       {
-        "sourceTag": "scope:facturacion",
-        "onlyDependOn": ["scope:shared", "scope:facturacion"]
-      },
-      {
         "sourceTag": "scope:abastecimiento",
         "onlyDependOn": ["scope:shared", "scope:abastecimiento"]
       },
       {
-        "sourceTag": "scope:presupuesto",
-        "onlyDependOn": ["scope:shared", "scope:presupuesto"]
-      },
-      {
-        "sourceTag": "scope:requisiciones",
-        "onlyDependOn": ["scope:shared", "scope:requisiciones"]
+        "sourceTag": "scope:notificaciones",
+        "onlyDependOn": ["scope:shared", "scope:notificaciones"]
       },
       {
         "sourceTag": "scope:usuarios",
@@ -882,7 +860,7 @@ Las reglas de dependencia se verifican **automáticamente en cada commit y CI**.
 }
 ```
 
-Si alguien de `feature-cocina` intenta importar algo de `feature-inventario`, el linter falla con:
+Si alguien de `cocina` intenta importar algo de `inventario`, el linter falla con:
 
 ```
 A project tagged with "scope:cocina" can only depend on
@@ -897,15 +875,14 @@ Con 23 personas y la estructura de librerías definida:
 
 | Equipo | Librerías bajo su ownership | Personas | RF relacionados |
 |---|---|---|---|
-| **Arquitectura + Shell** | `apps/restaurant-app`, `feature-shell`, `shared/*` | 3 | RF1.x, RF2.x (base) |
-| **Auth + Usuarios** | `feature-auth`, `feature-usuarios` | 2 | RF1.2–1.4, RF2.x |
-| **Restaurante** | `feature-restaurante` | 3 | RF3.x completo |
-| **Cocina** | `feature-cocina` | 2 | RF-C 4.0–4.9 |
-| **Bar** | `feature-bar` | 2 | RF-C 4.10–4.19 |
-| **Inventario** | `feature-inventario` | 3 | RF-5.1, RF-5.5, RF-5.6, RF-5.8 |
-| **Abastecimiento** | `feature-abastecimiento` | 3 | RF-5.2–5.4, RF-5.9–5.11 |
-| **Presupuesto** | `feature-presupuesto` | 1 | RF-5.7 |
-| **Reportes** | `feature-reportes` | 2 | RF6.x completo |
+| **Arquitectura + Shell** | `apps/restaurant-app`, `libs/shell/*`, `libs/shared/*` | 3 | RF1.x, RF2.x (base) |
+| **Auth + Usuarios** | `libs/auth/auth`, `libs/auth/usuarios` | 2 | RF1.2–1.4, RF2.x |
+| **Restaurante** | `libs/restaurante/restaurante` | 3 | RF3.x completo |
+| **Cocina** | `libs/cocina/cocina` | 2 | RF-C 4.0–4.9 |
+| **Bar** | `libs/bar/bar` | 2 | RF-C 4.10–4.19 |
+| **Inventario** | `libs/inventario/inventario` | 3 | RF-5.1, RF-5.5, RF-5.6, RF-5.8 |
+| **Abastecimiento** | `libs/abastecimiento/abastecimiento` | 3 | RF-5.2–5.4, RF-5.9–5.11 |
+| **Reportes** | `libs/reportes/reportes` | 2 | RF6.x completo |
 | **QA + DevOps** | Transversal (CI, coverage, E2E) | 2 | Todos |
 
 > El equipo de **Arquitectura** tiene veto en cambios a `shared/*`. Cualquier PR que modifique librerías compartidas requiere su aprobación.
@@ -915,45 +892,56 @@ Con 23 personas y la estructura de librerías definida:
 ## 13. Comandos Nx del Día a Día
 
 ```bash
-# Crear una nueva feature dentro del dominio cocina
-nx g @nx/angular:library feature-cocina-recetas \
-  --directory=libs/cocina/feature-cocina-recetas \
+# Crear un componente dentro de un dominio
+nx g @nx/angular:component nombre-componente \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/ui \
+  --standalone --change-detection=OnPush
+
+# Crear un service
+nx g @nx/angular:service nombre-service \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access
+
+# Crear una nueva librería dentro de un dominio
+nx g @nx/angular:library cocina-recetas \
+  --directory=libs/cocina/cocina-recetas \
   --tags="scope:cocina,type:feature" \
   --standalone \
-  --importPath="@restaurant/feature-cocina-recetas"
+  --importPath="@restaurant/cocina-recetas"
 
-# Crear una nueva librería de UI para el dominio cocina
-nx g @nx/angular:library ui \
-  --directory=libs/cocina/feature-cocina/ui \
-  --tags="scope:cocina,type:ui" \
-  --standalone \
-  --importPath="@restaurant/feature-cocina/ui"
+# Crear store NgRx completo (actions + reducer + effects + selectors)
+nx g @ngrx/schematics:feature nombre \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access/store \
+  --module=false
 
-# Correr solo los tests afectados por mis cambios (no todo el monorepo)
+# Correr solo los tests afectados por mis cambios
 nx affected:test --base=develop
 
 # Lint solo de lo afectado
 nx affected:lint --base=develop
 
-# Build solo de lo que cambió
-nx affected:build --base=develop
-
 # Ver el grafo de dependencias (detecta acoplamientos no deseados)
 nx graph
 
-# Correr los tests de un proyecto específico
-nx test feature-cocina-ui
+# Correr los tests de un dominio específico
+nx test cocina
 
 # Correr en watch mode durante desarrollo
-nx test feature-cocina-data-access --watch
+nx test cocina --watch
 
 # Ver qué proyectos se ven afectados por mis cambios actuales
-nx affected:apps --base=develop
-nx affected:libs --base=develop
+nx affected:graph --base=develop
+
+# Listar todos los proyectos del workspace
+nx show projects
 
 # Formatear todo el código
 nx format:write
 ```
+
+Ver [`docs/setup.md`](setup.md) para la referencia completa de generators.
 
 ---
 
@@ -963,8 +951,8 @@ Antes de hacer el primer commit, cada desarrollador confirma haber leído y ente
 
 ### Reglas de arquitectura
 
-1. **No importar de otro `feature-*` directamente.** Si necesitas algo de otro dominio, sube al estado compartido o habla con el equipo de Arquitectura.
-2. **No importar de `feature-*` dentro de `shared/`.** El flujo de dependencias es unidireccional: features dependen de shared, nunca al revés.
+1. **No importar de otro dominio directamente.** Si necesitas algo de otro dominio, sube al estado compartido o habla con el equipo de Arquitectura.
+2. **No importar de dominios dentro de `shared/`.** El flujo de dependencias es unidireccional: dominios dependen de shared, nunca al revés.
 3. **No redefinir interfaces que existen en `shared/models/`.** Si necesitas extender, usa `extends`. Si necesitas un campo nuevo, abre un PR a `shared/models`.
 4. **No definir colores, espaciados ni tipografía** fuera de `libs/shared/ui/src/lib/tokens/_variables.scss`.
 

--- a/docs/bases-globales-monorepo.md
+++ b/docs/bases-globales-monorepo.md
@@ -58,7 +58,7 @@ Estas son las piezas que deben existir primero en el monorepo:
 
 ## Decisión
 Estos componentes deben convertirse en la base de:
-- `libs/feature-shell`
+- `libs/shell/shell`
 
 ## No mezclar con
 - lógica de negocio
@@ -164,7 +164,7 @@ Esto debe vivir en:
 
 ## Decisión
 Mover a:
-- `libs/feature-shell/models`
+- `libs/shell/shell/src/lib/models`
 
 ## Regla
 Los componentes de layout reciben configuración; **no conocen dominios concretos**.
@@ -232,10 +232,10 @@ Lo específico se queda dentro de su feature.
 
 ## 9. Base global #7 — Convención estructural por librería
 
-Cada feature migrada al monorepo debe respetar esta estructura:
+Cada librería migrada al monorepo debe respetar esta estructura:
 
 ```text
-libs/feature-xxx/
+libs/{dominio}/{dominio}/src/lib/
   ui/
   data-access/
   models/
@@ -367,7 +367,8 @@ apps/
   restaurant-app/
 
 libs/
-  feature-shell/
+  shell/
+    shell/
   shared/
     ui/
       tokens/
@@ -384,11 +385,13 @@ Y recién después empezar:
 
 ```text
 libs/
-  feature-inventario/
-  feature-facturacion/
-  feature-abastecimiento/
-  feature-restaurante/
-  feature-cocina/
+  inventario/inventario/
+  abastecimiento/abastecimiento/
+  restaurante/restaurante/
+  cocina/cocina/
+  bar/bar/
+  reportes/reportes/
+  notificaciones/notificaciones/
 ```
 
 ---

--- a/docs/clasificacion-componentes-inventario.md
+++ b/docs/clasificacion-componentes-inventario.md
@@ -182,7 +182,7 @@ Estos deben quedarse en su feature:
 
 ## 3. Decisiones ya aplicadas al monorepo
 
-Ya quedaron extraídos o reforzados en `shared/ui` / `feature-shell`:
+Ya quedaron extraídos o reforzados en `shared/ui` / `libs/shell/shell`:
 
 - shell global
 - navegación global

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,8 +2,8 @@
 
 ## Reglas de arquitectura
 
-1. No importar de otro `feature-*` directamente.
-2. No importar de `feature-*` dentro de `shared/`.
+1. No importar de otro dominio directamente — solo de `@restaurant/shared/*`.
+2. No importar de dominios dentro de `shared/`.
 3. No redefinir interfaces que existen en `shared/models/`.
 4. No definir colores, espaciados ni tipografía fuera de `libs/shared/ui/src/lib/tokens/_variables.scss`.
 

--- a/docs/inventario-migracion-monorepo.md
+++ b/docs/inventario-migracion-monorepo.md
@@ -58,9 +58,9 @@ Este proyecto **no aporta código migrable por ahora**. Solo aporta intención f
 
 #### Acción sugerida
 En el monorepo debe convertirse en:
-- `feature-auth` si cubre login/recuperación
-- `feature-home` o rutas públicas dentro de `feature-shell`
-- `feature-notificaciones` si luego se separan panel e historial
+- `libs/auth/auth` si cubre login/recuperación
+- `libs/shell/home` o rutas públicas dentro de `libs/shell/shell`
+- `libs/notificaciones/notificaciones` si luego se separan panel e historial
 
 ---
 
@@ -102,9 +102,9 @@ export const routes: Routes = [];
 Este proyecto hoy es **una base estructural, no una feature consolidada**. Sirve para rescatar naming y dominio, pero casi no aporta implementación real.
 
 #### Destino recomendado en monorepo
-- `libs/feature-cocina/models`
-- `libs/feature-cocina/data-access` (solo cuando exista lógica real)
-- `libs/feature-cocina/ui`
+- `libs/cocina/cocina/src/lib/models`
+- `libs/cocina/cocina/src/lib/data-access` (solo cuando exista lógica real)
+- `libs/cocina/cocina/src/lib/ui`
 
 **NO conviene migrarlo “tal cual”**. Primero hay que clasificar qué existe de verdad y qué es solo scaffolding.
 
@@ -177,11 +177,10 @@ Este proyecto hoy es **una base estructural, no una feature consolidada**. Sirve
 Este proyecto sí tiene material migrable y se debe **partir por dominios**, no copiar carpeta por carpeta.
 
 #### Destino recomendado en monorepo
-- `layout/*` → `libs/feature-shell`
-- `features/restaurante` → `libs/feature-restaurante`
-- `features/comandas` → `libs/feature-restaurante` o subdominio interno
-- `features/estadisticas` → `libs/feature-reportes` o `feature-restaurante` según ownership final
-- `features/facturacion` → `libs/feature-facturacion`
+- `layout/*` → `libs/shell/shell`
+- `features/restaurante` → `libs/restaurante/restaurante`
+- `features/comandas` → `libs/restaurante/restaurante` o subdominio interno
+- `features/estadisticas` → `libs/reportes/reportes` o `libs/restaurante/restaurante` según ownership final
 - modelos compartibles (`mesa`, `orden`, `comanda`, `user`) → evaluar promoción a `libs/shared/models`
 
 ---
@@ -277,10 +276,10 @@ Este proyecto es la **fuente principal de código migrable** para:
 - alertas
 
 #### Destino recomendado en monorepo
-- `bienes` + alertas → `libs/feature-inventario`
-- `facturas` → `libs/feature-facturacion`
-- `solicitudes-gil` + `conciliacion` → `libs/feature-abastecimiento`
-- `presupuesto` → `libs/feature-presupuesto`
+- `bienes` + alertas → `libs/inventario/inventario`
+- `facturas` → (dominio removido — evaluar con Arquitectura si se reactiva)
+- `solicitudes-gil` + `conciliacion` → `libs/abastecimiento/abastecimiento`
+- `presupuesto` → (dominio removido — evaluar con Arquitectura si se reactiva)
 - íconos/config común → `libs/shared/ui` o `libs/shared/util`
 
 #### Observación arquitectónica importante
@@ -289,7 +288,7 @@ La pantalla raíz ya usa un layout reusable:
 - `BarraLateralConfig`
 - `TopNavLink`
 
-Eso demuestra que **ya existe un embrión de `shared/ui + feature-shell`**, solo que hoy vive fuera del repo principal deseado.
+Eso demuestra que **ya existe un embrión de `shared/ui + shell`**, solo que hoy vive fuera del repo principal deseado.
 
 ---
 
@@ -316,10 +315,10 @@ Workspace Angular de librería con proyecto:
 - Integración de iconos con Lucide
 
 #### Conclusión
-Esta librería **no debe migrarse como `feature-inventario`**. Debe partirse así:
-- layout compartido → `libs/feature-shell` o `libs/shared/ui/layout`
+Esta librería **no debe migrarse como un bloque único**. Debe partirse así:
+- layout compartido → `libs/shell/shell` o `libs/shared/ui/layout`
 - tokens → `libs/shared/ui/tokens`
-- contratos de navegación → `libs/shared/models` o `libs/feature-shell/models`
+- contratos de navegación → `libs/shared/models` o `libs/shell/shell/src/lib/models`
 - provider de iconos → `libs/shared/ui/icons` o `libs/shared/util/icons`
 
 ---
@@ -437,7 +436,7 @@ Cocina debe **adoptar** el sistema compartido del monorepo; no hay nada serio pa
 
 ## 6. Componentes compartibles detectados
 
-## 6.1 Candidatos claros a `feature-shell` / `shared/ui`
+## 6.1 Candidatos claros a `libs/shell/shell` / `shared/ui`
 
 ### Desde `lib-gas-layout-frontend`
 - `MainLayoutComponent`
@@ -503,19 +502,19 @@ Lo específico se queda en cada feature.
 
 | Origen actual | Destino recomendado |
 |---|---|
-| `lib-gas-layout-frontend/projects/inventario-ui/src/lib/main-layout` | `libs/feature-shell` o `libs/shared/ui/layout` |
+| `lib-gas-layout-frontend/projects/inventario-ui/src/lib/main-layout` | `libs/shell/shell` o `libs/shared/ui/layout` |
 | `lib-gas-layout-frontend/projects/inventario-ui/src/styles/_variables.scss` | `libs/shared/ui/tokens/_variables.scss` |
-| `Frontend-inventario-actualizado/src/app/features/bienes` | `libs/feature-inventario` |
-| `Frontend-inventario-actualizado/src/app/features/alertas-stock` | `libs/feature-inventario` o `feature-notificaciones` |
-| `Frontend-inventario-actualizado/src/app/features/facturas` | `libs/feature-facturacion` |
-| `Frontend-inventario-actualizado/src/app/features/solicitudes-gil` | `libs/feature-abastecimiento` |
-| `Frontend-inventario-actualizado/src/app/features/conciliacion` | `libs/feature-abastecimiento` |
-| `Frontend-inventario-actualizado/src/app/features/presupuesto` | `libs/feature-presupuesto` |
-| `ga-web-restaurante/src/app/features/restaurante` | `libs/feature-restaurante` |
-| `ga-web-restaurante/src/app/features/comandas` | `libs/feature-restaurante` |
-| `ga-web-restaurante/src/app/features/facturacion` | `libs/feature-facturacion` |
-| `ga-web-restaurante/src/app/features/estadisticas` | `libs/feature-reportes` o `feature-restaurante` |
-| `cocina-frontend/src/app/features/*` | `libs/feature-cocina` (solo luego de validar qué no es stub) |
+| `Frontend-inventario-actualizado/src/app/features/bienes` | `libs/inventario/inventario` |
+| `Frontend-inventario-actualizado/src/app/features/alertas-stock` | `libs/inventario/inventario` o `libs/notificaciones/notificaciones` |
+| `Frontend-inventario-actualizado/src/app/features/facturas` | *(dominio removido — coordinar con Arquitectura)* |
+| `Frontend-inventario-actualizado/src/app/features/solicitudes-gil` | `libs/abastecimiento/abastecimiento` |
+| `Frontend-inventario-actualizado/src/app/features/conciliacion` | `libs/abastecimiento/abastecimiento` |
+| `Frontend-inventario-actualizado/src/app/features/presupuesto` | *(dominio removido — coordinar con Arquitectura)* |
+| `ga-web-restaurante/src/app/features/restaurante` | `libs/restaurante/restaurante` |
+| `ga-web-restaurante/src/app/features/comandas` | `libs/restaurante/restaurante` |
+| `ga-web-restaurante/src/app/features/facturacion` | *(dominio removido — coordinar con Arquitectura)* |
+| `ga-web-restaurante/src/app/features/estadisticas` | `libs/reportes/reportes` o `libs/restaurante/restaurante` |
+| `cocina-frontend/src/app/features/*` | `libs/cocina/cocina` (solo luego de validar qué no es stub) |
 | `ga-web-inicio-general` | No migrar código; redefinir desde requerimientos |
 
 ---
@@ -539,21 +538,22 @@ Lo específico se queda en cada feature.
 4. Reemplazar hardcodes de `ga-web-restaurante` por tokens comunes.
 
 ## Fase 3 — Migrar por dominio
-1. `feature-shell`
-2. `shared/ui`
-3. `shared/models`
-4. `feature-inventario`
-5. `feature-facturacion`
-6. `feature-abastecimiento`
-7. `feature-restaurante`
-8. `feature-cocina`
-9. `feature-reportes`
+1. `libs/shell/shell`
+2. `libs/shared/ui`
+3. `libs/shared/models`
+4. `libs/inventario/inventario`
+5. `libs/abastecimiento/abastecimiento`
+6. `libs/restaurante/restaurante`
+7. `libs/cocina/cocina`
+8. `libs/bar/bar`
+9. `libs/reportes/reportes`
+10. `libs/notificaciones/notificaciones`
 
 ## Fase 4 — Enforzar arquitectura
 1. Crear monorepo Nx real.
 2. Definir tags por scope/tipo.
 3. Activar `@nx/enforce-module-boundaries`.
-4. Prohibir import directo entre features.
+4. Prohibir import directo entre dominios.
 5. Promover contratos compartidos a `shared/models`.
 
 ---

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -21,11 +21,8 @@ npm install -g nx@latest
 ## 1. Instalación
 
 ```bash
-# Clonar el repositorio
 git clone https://github.com/Brian7st/GastrosenaFrontend.git
 cd GastrosenaFrontend
-
-# Instalar dependencias
 npm install
 ```
 
@@ -48,16 +45,13 @@ npm start
 
 ```
 libs/
-├── shell/          → routing, layouts, landing pública
+├── shell/          → routing principal, layouts, guards, navegación
 ├── auth/           → login, usuarios y roles
 ├── cocina/         → operaciones de cocina
 ├── bar/            → operaciones de bar
 ├── restaurante/    → salón y servicio
 ├── inventario/     → gestión de bienes y stock
 ├── abastecimiento/ → GIL, consolidados, paquete probatorio
-├── facturacion/    → FEL, CUFE, facturas electrónicas
-├── presupuesto/    → techos presupuestales, ZESE
-├── requisiciones/  → requisiciones diarias, actas
 ├── reportes/       → reportes exportables PDF/Excel
 ├── notificaciones/ → alertas de stock en tiempo real
 └── shared/         → código compartido (NO modificar sin hablar con Arquitectura)
@@ -71,11 +65,14 @@ Ver [`docs/arquitectura.md`](arquitectura.md) para la descripción completa.
 ## 4. Comandos del día a día
 
 ```bash
-# Correr solo los tests afectados por mis cambios
+# Servidor de desarrollo
+npm start
+
+# Tests afectados por mis cambios
 npm test
 # equivale a: nx affected:test --base=develop
 
-# Lint solo de lo afectado
+# Lint afectado
 npm run lint
 # equivale a: nx affected:lint --base=develop
 
@@ -86,50 +83,280 @@ npm run graph
 npm run format
 
 # Tests de un dominio específico
-nx test feature-cocina
+nx test cocina
 
 # Tests en modo watch durante desarrollo
-nx test feature-cocina --watch
+nx test cocina --watch
+
+# Tests con coverage
+nx test cocina --coverage
+
+# Correr un archivo de test específico
+nx test cocina --testFile=libs/cocina/cocina/src/lib/ui/receta-card/receta-card.component.spec.ts
+
+# Ver proyectos afectados por mis cambios (sin correrlos)
+nx affected:graph --base=develop
+
+# Build de producción
+nx build restaurant-app --configuration=production
+
+# Ver todos los proyectos del workspace
+nx show projects
 ```
 
 ---
 
-## 5. Crear una nueva feature
+## 5. Generators de Nx — todos los comandos importantes
 
-### Dentro de un dominio existente
+> Todos los comandos admiten `--dry-run` para previsualizar qué archivos se van a crear sin crear nada.
+>
+> ```bash
+> nx g @nx/angular:component mi-componente --project=cocina --dry-run
+> ```
+
+### Componente
 
 ```bash
-# Ejemplo: nueva feature dentro del dominio cocina
-nx g @nx/angular:library feature-cocina-recetas \
-  --directory=libs/cocina/feature-cocina-recetas \
+# Componente en la capa ui/ de un dominio
+nx g @nx/angular:component nombre-componente \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/ui \
+  --standalone \
+  --change-detection=OnPush
+
+# Ejemplo real
+nx g @nx/angular:component receta-card \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/ui \
+  --standalone \
+  --change-detection=OnPush
+```
+
+### Page (componente con routing)
+
+```bash
+# Las pages van en su propia carpeta dentro de lib
+nx g @nx/angular:component pages/nombre-page \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib \
+  --standalone \
+  --change-detection=OnPush
+
+# Ejemplo real
+nx g @nx/angular:component pages/recetas-page \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib \
+  --standalone \
+  --change-detection=OnPush
+```
+
+### Service
+
+```bash
+# Servicio HTTP en la capa data-access/
+nx g @nx/angular:service nombre-servicio \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access
+
+# Ejemplo real
+nx g @nx/angular:service recetas \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access
+```
+
+### Facade
+
+```bash
+# La facade es un service especial que orquesta el store
+nx g @nx/angular:service nombre-facade \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access
+
+# Renombralo manualmente a nombre-facade.ts después de generarlo
+# Ejemplo real
+nx g @nx/angular:service cocina-facade \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access
+```
+
+### Guard
+
+```bash
+# Guards van en shell o en el dominio que los necesite
+nx g @nx/angular:guard nombre-guard \
+  --project=shell \
+  --path=libs/shell/shell/src/lib/guards \
+  --implements=CanActivate
+
+# Ejemplo real
+nx g @nx/angular:guard auth \
+  --project=shell \
+  --path=libs/shell/shell/src/lib/guards \
+  --implements=CanActivate
+```
+
+### Interceptor
+
+```bash
+nx g @nx/angular:interceptor nombre-interceptor \
+  --project=shared-api \
+  --path=libs/shared/api/src/lib
+
+# Ejemplo real
+nx g @nx/angular:interceptor auth-token \
+  --project=shared-api \
+  --path=libs/shared/api/src/lib
+```
+
+### Pipe
+
+```bash
+nx g @nx/angular:pipe nombre-pipe \
+  --project=shared-util \
+  --path=libs/shared/util/src/lib \
+  --standalone
+
+# Ejemplo real
+nx g @nx/angular:pipe currency-format \
+  --project=shared-util \
+  --path=libs/shared/util/src/lib \
+  --standalone
+```
+
+### Directive
+
+```bash
+nx g @nx/angular:directive nombre-directive \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/ui \
+  --standalone
+
+# Ejemplo real
+nx g @nx/angular:directive highlight-row \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/ui \
+  --standalone
+```
+
+### Interface / Modelo
+
+```bash
+# Las interfaces van en models/ del dominio
+nx g @nx/angular:interface nombre-interface \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/models
+
+# Ejemplo real
+nx g @nx/angular:interface receta \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/models
+```
+
+### Enum
+
+```bash
+nx g @nx/angular:enum nombre-enum \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/models
+
+# Ejemplo real
+nx g @nx/angular:enum estado-pedido \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/models
+```
+
+### NgRx — Feature Store completo
+
+```bash
+# Genera actions + reducer + effects + selectors en un solo comando
+nx g @ngrx/schematics:feature nombre-feature \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access/store \
+  --module=false
+
+# Ejemplo real
+nx g @ngrx/schematics:feature recetas \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access/store \
+  --module=false
+```
+
+### NgRx — Piezas individuales
+
+```bash
+# Solo actions
+nx g @ngrx/schematics:action recetas \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access/store
+
+# Solo reducer
+nx g @ngrx/schematics:reducer recetas \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access/store
+
+# Solo effects
+nx g @ngrx/schematics:effect recetas \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access/store
+
+# Solo selectors
+nx g @ngrx/schematics:selector recetas \
+  --project=cocina \
+  --path=libs/cocina/cocina/src/lib/data-access/store
+```
+
+### Nueva librería dentro de un dominio
+
+```bash
+# Estructura: libs/{dominio}/{nombre-lib}/
+nx g @nx/angular:library nombre-lib \
+  --directory=libs/cocina/nombre-lib \
   --tags="scope:cocina,type:feature" \
   --standalone \
-  --importPath="@restaurant/feature-cocina-recetas"
+  --importPath="@restaurant/nombre-lib"
+
+# Ejemplo real
+nx g @nx/angular:library cocina-recetas \
+  --directory=libs/cocina/cocina-recetas \
+  --tags="scope:cocina,type:feature" \
+  --standalone \
+  --importPath="@restaurant/cocina-recetas"
 ```
 
-Luego agregar el alias en `tsconfig.base.json`:
+Después de crear una librería, hacer DOS cosas más:
 
+1. Agregar el alias en `tsconfig.base.json`:
 ```json
-"@restaurant/feature-cocina-recetas": ["libs/cocina/feature-cocina-recetas/src/index.ts"]
+"@restaurant/cocina-recetas": ["libs/cocina/cocina-recetas/src/index.ts"]
 ```
 
-Y agregar la ruta en `libs/shell/feature-shell/src/lib/shell.routes.ts`.
+2. Agregar la ruta en `libs/shell/shell/src/lib/shell.routes.ts`
 
-### Estructura interna de una feature
+---
+
+## 6. Estructura interna de una feature
 
 ```
-libs/cocina/feature-cocina-recetas/
-└── src/
-    └── lib/
-        ├── ui/           ← componentes visuales del dominio
-        ├── data-access/  ← facade, services, NgRx store
-        ├── models/       ← interfaces propias del dominio
-        └── util/         ← helpers específicos (no van a shared)
+libs/cocina/cocina/src/lib/
+├── ui/               ← componentes presentacionales del dominio
+│   ├── receta-card/
+│   └── pedido-list/
+├── pages/            ← componentes con routing (una page por ruta)
+│   ├── recetas-page/
+│   └── pedido-detalle-page/
+├── data-access/      ← facade, services, store NgRx
+│   ├── store/        ← actions, reducer, effects, selectors
+│   ├── cocina.facade.ts
+│   └── recetas.service.ts
+├── models/           ← interfaces y enums propios del dominio
+│   ├── receta.interface.ts
+│   └── estado-pedido.enum.ts
+└── util/             ← helpers específicos (no van a shared)
 ```
 
 ---
 
-## 6. Flujo de trabajo Git
+## 7. Flujo de trabajo Git
 
 ```bash
 # 1. Partir siempre desde develop actualizado
@@ -156,8 +383,7 @@ git push origin feat/cocina/nombre-descripcion-RF-C4.1
 
 tipo:  feat | fix | chore | refactor | test
 scope: shell | auth | cocina | bar | restaurante |
-       inventario | abastecimiento | facturacion |
-       presupuesto | requisiciones | reportes | shared
+       inventario | abastecimiento | reportes | shared
 ```
 
 ### Formato de commit
@@ -170,7 +396,7 @@ chore(models): promote RecetaItem to shared/models
 
 ---
 
-## 7. Reglas que no se negocian
+## 8. Reglas que no se negocian
 
 - **Un scope por PR** — si tocás dos dominios, son dos PRs
 - **Máximo 400 líneas por PR** — sin excepciones
@@ -179,11 +405,11 @@ chore(models): promote RecetaItem to shared/models
 - **Sin `any` en TypeScript** — usar tipos genéricos o `unknown`
 - **Sin estilos inline** — todo en el `.scss` del componente o en `_variables.scss`
 
-Ver `CONTRIBUTING.md` para la lista completa.
+Ver [`docs/contributing.md`](contributing.md) para la lista completa.
 
 ---
 
-## 8. Variables de entorno
+## 9. Variables de entorno
 
 El proyecto no requiere variables de entorno para correr en local.
 Cuando se conecte el backend, se usarán los archivos de environment de Angular:
@@ -196,11 +422,10 @@ apps/restaurant-app/src/environments/
 
 ---
 
-## 9. Problemas frecuentes
+## 10. Problemas frecuentes
 
 **El servidor no levanta / error de compilación**
 ```bash
-# Limpiar caché de Nx y Angular
 nx reset
 rm -rf .angular/cache
 npm start
@@ -208,7 +433,13 @@ npm start
 
 **El lint falla con "module boundary" error**
 Estás importando desde un dominio que no te corresponde.
-Revisá [`docs/arquitectura.md`](arquitectura.md) sección 4 — Regla de Oro de Dependencias.
+Revisá [`docs/arquitectura.md`](arquitectura.md) sección Regla de Oro de Dependencias.
 
 **Error de TypeScript con un path alias**
-Verificá que el alias esté declarado en `tsconfig.base.json` apuntando a la nueva ubicación.
+Verificá que el alias esté declarado en `tsconfig.base.json` apuntando a la ubicación correcta.
+
+**No encuentro el proyecto correcto para `--project=`**
+```bash
+# Listar todos los proyectos disponibles
+nx show projects
+```


### PR DESCRIPTION
## Summary

- **docs/setup.md** — reescritura completa: agrega todos los generators de Nx (component, page, service, guard, interceptor, pipe, directive, interface, enum, NgRx feature store + piezas individuales); elimina `facturacion/presupuesto/requisiciones` de la estructura y el scope de ramas; corrige referencias al prefijo `feature-` eliminado en #5
- **docs/arquitectura.md** — 15+ ediciones: elimina prefijo `feature-` de todos los paths, elimina dominios removidos de la tabla de ESLint y de la tabla de equipos, actualiza comandos Nx, corrige anatomía interna de dominio
- **.ai/domains/** — `facturacion.md`, `presupuesto.md`, `requisiciones.md` marcados como **DOMINIO REMOVIDO** (referencia al commit `460fff6`)
- **.ai/protocol.md, .ai/rules/architecture.md** — eliminadas entradas de dominios removidos
- **AGENTS.md** — corregido path de `shell.routes.ts`
- **docs/bases-globales-monorepo.md, inventario-migracion-monorepo.md, clasificacion-componentes-inventario.md** — paths de migración sincronizados al naming actual

## Test plan

- [ ] Revisar que los comandos de `docs/setup.md` sean correctos ejecutando `nx g @nx/angular:component --help`
- [ ] Verificar que no queden referencias a `feature-{dominio}` en los archivos MD (`git grep "feature-cocina" -- "*.md"`)
- [ ] Confirmar que los 3 domain files marcados como REMOVED tienen el aviso correcto al inicio

🤖 Generated with [Claude Code](https://claude.com/claude-code)