### PR TITLE
docs: actualizar arquitectura y dominios con estructura real de carpetas y pages

### DIFF
--- a/.ai/domains/auth.md
+++ b/.ai/domains/auth.md
@@ -14,3 +14,26 @@
 
 ## Scope
 `feat/auth/...` | `fix/auth/...` | `feat/usuarios/...`
+
+## Estructura de carpetas
+
+```
+libs/auth/usuarios/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── lista-page/
+│   ├── roles-page/
+│   └── cuentas-page/
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── usuarios.facade.ts
+├── models/
+├── pipes/
+├── validators/
+└── util/
+```

--- a/.ai/domains/bar.md
+++ b/.ai/domains/bar.md
@@ -18,3 +18,26 @@
 ## Componentes únicos de este dominio
 - `DrinkQueueComponent` — cola de bebidas
 - `BarStatsComponent` — estadísticas de tiempos del bar
+
+## Estructura de carpetas
+
+```
+libs/bar/bar/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── comandas-page/
+│   ├── recetas-page/
+│   └── menu-page/
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── bar.facade.ts
+├── models/
+├── pipes/
+├── validators/
+└── util/
+```

--- a/.ai/domains/cocina.md
+++ b/.ai/domains/cocina.md
@@ -21,3 +21,26 @@
 - `KitchenBoardComponent` — tablero de pedidos en tiempo real
 - `OrderTimerComponent` — contador de tiempo por pedido
 - `RecipeStepsComponent` — pasos de preparación
+
+## Estructura de carpetas
+
+```
+libs/cocina/cocina/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── comandas-page/
+│   ├── recetas-page/
+│   └── menu-page/
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── cocina.facade.ts
+├── models/
+├── pipes/
+├── validators/
+└── util/
+```

--- a/.ai/domains/inventario.md
+++ b/.ai/domains/inventario.md
@@ -19,3 +19,34 @@
 - `StockAlertBannerComponent` — alerta visual de stock crítico
 - `StockLevelIndicatorComponent`
 - `BienDetailCardComponent`
+
+## Estructura de carpetas
+
+```
+libs/inventario/inventario/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── bienes-page/
+│   ├── facturas-page/
+│   ├── solicitudes-page/
+│   ├── consolidado-page/
+│   ├── kardex-page/
+│   ├── alertas-page/
+│   ├── presupuesto-page/
+│   ├── conciliacion-page/
+│   ├── requisiciones-page/
+│   ├── actas-page/
+│   └── paquete-probatorio-page/
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── inventario.facade.ts
+├── models/
+├── pipes/
+├── validators/
+└── util/
+```

--- a/.ai/domains/reportes.md
+++ b/.ai/domains/reportes.md
@@ -20,3 +20,25 @@
 - `ReportSelectorComponent` — selección de tipo de reporte
 - `PdfExportService` — generación de PDF
 - `ExcelExportService` — generación de Excel
+
+## Estructura de carpetas
+
+```
+libs/reportes/reportes/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── ventas-page/
+│   └── inventario-reportes-page/
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── reportes.facade.ts
+├── models/
+├── pipes/
+├── validators/
+└── util/
+```

--- a/.ai/domains/restaurante.md
+++ b/.ai/domains/restaurante.md
@@ -11,3 +11,26 @@
 
 ## Scope
 `feat/restaurante/...` | `fix/restaurante/...`
+
+## Estructura de carpetas
+
+```
+libs/restaurante/restaurante/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── mesas-page/
+│   ├── pedidos-page/
+│   └── caja-page/
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── restaurante.facade.ts
+├── models/
+├── pipes/
+├── validators/
+└── util/
+```

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -95,7 +95,10 @@ GastrosenaFrontend/
 │       ├── api/                  ← BaseHttpService, interceptores, error handling
 │       ├── state/                ← NgRx root store, metareducers globales
 │       ├── ui/                   ← Design system: botones, tablas, modales, tokens
-│       ├── util/                 ← Pipes, validators, formatters, constantes
+│       ├── pipes/                ← Pipes globales reutilizables en todos los dominios
+│       ├── directives/           ← Directivas globales (hasRole, autoFocus, etc.)
+│       ├── validators/           ← Validadores de formularios globales (NIT, CUFE, etc.)
+│       ├── util/                 ← Helpers, formatters y constantes puras
 │       └── models/               ← Interfaces globales (Usuario, Rol, Paginacion...)
 │
 ├── remotes/                      ← Proyectos standalone de referencia (no son parte del monorepo)
@@ -263,19 +266,43 @@ shared/ui/src/lib/
       └── auto-focus.directive.ts
 ```
 
+#### `shared/pipes`
+
+Responsabilidad única: pipes Angular reutilizables en 3 o más dominios.
+
+```
+shared/pipes/src/lib/
+  ├── currency-cop.pipe.ts   ← Formato moneda colombiana
+  ├── date-co.pipe.ts        ← Formato fecha Colombia
+  └── estado-pedido.pipe.ts  ← EstadoPedido → label legible
+```
+
+#### `shared/directives`
+
+Responsabilidad única: directivas Angular globales.
+
+```
+shared/directives/src/lib/
+  ├── has-role.directive.ts   ← *hasRole="['CHEF', 'ADMIN']"
+  └── auto-focus.directive.ts
+```
+
+#### `shared/validators`
+
+Responsabilidad única: validadores de formularios globales (usados en 3+ dominios).
+
+```
+shared/validators/src/lib/
+  ├── cufe.validator.ts      ← Valida 64 caracteres SHA-256
+  └── nit.validator.ts       ← Valida formato NIT colombiano
+```
+
 #### `shared/util`
 
-Responsabilidad única: funciones puras y sin estado.
+Responsabilidad única: helpers y formatters puros sin estado. Los pipes y validators se movieron a sus propias librerías.
 
 ```
 shared/util/src/lib/
-  ├── pipes/
-  │   ├── currency-cop.pipe.ts   ← Formato moneda colombiana
-  │   ├── date-co.pipe.ts        ← Formato fecha Colombia
-  │   └── estado-pedido.pipe.ts  ← EstadoPedido → label legible
-  ├── validators/
-  │   ├── cufe.validator.ts      ← Valida 64 caracteres SHA-256
-  │   └── nit.validator.ts       ← Valida formato NIT colombiano
   └── formatters/
       ├── iva.calculator.ts      ← Cálculos IVA 0%, 5%, 19%
       └── zese.calculator.ts     ← Retención ZESE 0.625%
@@ -329,12 +356,15 @@ Regla: si una interfaz de `cocina/models` empieza a ser necesaria en `restaurant
 Dentro de `shared/`, el orden jerárquico es:
 
 ```
-shared/ui       → puede importar: shared/models, shared/util
-shared/auth     → puede importar: shared/models, shared/api
-shared/api      → puede importar: shared/models
-shared/state    → puede importar: shared/models, shared/auth
-shared/util     → puede importar: shared/models
-shared/models   → NO importa nada (es la capa base)
+shared/ui         → puede importar: shared/models, shared/util, shared/pipes, shared/directives
+shared/auth       → puede importar: shared/models, shared/api
+shared/api        → puede importar: shared/models
+shared/state      → puede importar: shared/models, shared/auth
+shared/pipes      → puede importar: shared/models
+shared/directives → puede importar: shared/models
+shared/validators → puede importar: shared/models
+shared/util       → puede importar: shared/models
+shared/models     → NO importa nada (es la capa base)
 ```
 
 Esta jerarquía se enforza automáticamente con ESLint (ver sección 11).
@@ -347,46 +377,49 @@ Tomando `inventario` como ejemplo completo:
 
 ```
 libs/inventario/inventario/src/lib/
-│
-├── ui/                         ← Componentes visuales (presentacionales)
-│   ├── catalog-list/
-│   │   ├── catalog-list.component.ts
-│   │   └── catalog-list.component.html
-│   ├── stock/
-│   │   ├── stock-alert-banner.component.ts    ← Solo existe en inventario
-│   │   └── stock-level-indicator.component.ts
-│   └── movements/
-│       ├── entry-form.component.ts
-│       └── exit-form.component.ts
-│
-├── pages/                      ← Componentes con routing (una por ruta)
+├── pages/                    ← una carpeta por ruta del sidebar
 │   ├── bienes-page/
-│   │   └── bienes-page.component.ts
-│   └── movimientos-page/
-│       └── movimientos-page.component.ts
-│
-├── data-access/                ← Lógica de negocio y acceso al store
+│   ├── facturas-page/
+│   ├── solicitudes-page/
+│   ├── consolidado-page/
+│   ├── kardex-page/
+│   ├── alertas-page/
+│   ├── presupuesto-page/
+│   ├── conciliacion-page/
+│   ├── requisiciones-page/
+│   ├── actas-page/
+│   └── paquete-probatorio-page/
+├── ui/                       ← page raíz del módulo (landing/índice)
+│   └── inventario-page.component.ts
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
 │   ├── store/
-│   │   ├── inventario.actions.ts
-│   │   ├── inventario.reducer.ts
-│   │   ├── inventario.effects.ts
-│   │   └── inventario.selectors.ts
-│   ├── inventario.facade.ts    ← El único punto de entrada al store
-│   ├── bienes.service.ts
-│   ├── movimientos.service.ts
-│   └── alertas-stock.service.ts
-│
-├── models/                     ← Interfaces propias del dominio
-│   ├── bien.model.ts
-│   ├── movimiento.model.ts
-│   └── alerta-stock.model.ts
-│
-└── util/                       ← Helpers específicos (no van a shared)
-    ├── stock-level.calculator.ts
-    └── bien-code.generator.ts
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── inventario.facade.ts
+├── models/
+├── pipes/
+├── validators/
+└── util/
 ```
 
-**El Facade** (`inventario.facade.ts`) es el patrón clave: los componentes de `ui/` solo hablan con el facade, nunca con el store directamente. Esto hace que los componentes sean más testeables y desacoplados.
+**El Facade** (`inventario.facade.ts`) es el patrón clave: los componentes de `pages/` y `components/` solo hablan con el facade, nunca con el store directamente. Esto hace que los componentes sean más testeables y desacoplados.
+
+### ¿Qué va dónde? — Referencia rápida
+
+| ¿Qué? | ¿Dónde? |
+|---|---|
+| Pantalla nueva del sidebar | `pages/` |
+| Componente reutilizable dentro del módulo | `components/` |
+| Componente reutilizable en 3+ módulos | `shared/ui/` |
+| Llamadas al backend / facade / NgRx | `data-access/` |
+| Pipe de este módulo | `pipes/` |
+| Pipe global | `shared/pipes/` |
+| Validación de formulario de este módulo | `validators/` |
+| Validación global (NIT, CUFE, etc.) | `shared/validators/` |
+| Función pura / helper | `util/` |
 
 ```typescript
 // inventario.facade.ts

--- a/libs/auth/CLAUDE.md
+++ b/libs/auth/CLAUDE.md
@@ -17,3 +17,26 @@ feat(auth): ... | fix(auth): ... | chore(auth): ...
 
 ## Si necesitás algo de shared
 No lo modificás vos — coordiná con el equipo de Arquitectura.
+
+## Estructura de carpetas
+
+```
+libs/auth/usuarios/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── lista-page/           ← listado y búsqueda de usuarios
+│   ├── roles-page/           ← gestión de roles y permisos
+│   └── cuentas-page/         ← administración de cuentas
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── usuarios.facade.ts    ← único punto de entrada al store
+├── models/                   ← interfaces propias del dominio
+├── pipes/                    ← pipes específicos del dominio
+├── validators/               ← validadores de formularios del dominio
+└── util/                     ← helpers específicos (no van a shared)
+```

--- a/libs/bar/CLAUDE.md
+++ b/libs/bar/CLAUDE.md
@@ -17,3 +17,26 @@ feat(bar): ... | fix(bar): ... | chore(bar): ...
 
 ## Si necesitás algo de shared
 No lo modificás vos — coordiná con el equipo de Arquitectura.
+
+## Estructura de carpetas
+
+```
+libs/bar/bar/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── comandas-page/        ← gestión de comandas del bar
+│   ├── recetas-page/         ← recetas de bebidas
+│   └── menu-page/            ← carta de bebidas
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── bar.facade.ts         ← único punto de entrada al store
+├── models/                   ← interfaces propias del dominio
+├── pipes/                    ← pipes específicos del bar
+├── validators/               ← validadores de formularios del dominio
+└── util/                     ← helpers específicos (no van a shared)
+```

--- a/libs/cocina/CLAUDE.md
+++ b/libs/cocina/CLAUDE.md
@@ -17,3 +17,26 @@ feat(cocina): ... | fix(cocina): ... | chore(cocina): ...
 
 ## Si necesitás algo de shared
 No lo modificás vos — coordiná con el equipo de Arquitectura.
+
+## Estructura de carpetas
+
+```
+libs/cocina/cocina/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── comandas-page/        ← gestión de comandas de cocina
+│   ├── recetas-page/         ← recetas y preparaciones
+│   └── menu-page/            ← menú del día y carta
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── cocina.facade.ts      ← único punto de entrada al store
+├── models/                   ← interfaces propias del dominio
+├── pipes/                    ← pipes específicos de cocina
+├── validators/               ← validadores de formularios del dominio
+└── util/                     ← helpers específicos (no van a shared)
+```

--- a/libs/inventario/CLAUDE.md
+++ b/libs/inventario/CLAUDE.md
@@ -17,3 +17,34 @@ feat(inventario): ... | fix(inventario): ... | chore(inventario): ...
 
 ## Si necesitás algo de shared
 No lo modificás vos — coordiná con el equipo de Arquitectura.
+
+## Estructura de carpetas
+
+```
+libs/inventario/inventario/src/lib/
+├── pages/                        ← una carpeta por ruta del sidebar
+│   ├── bienes-page/              ← listado y gestión de bienes
+│   ├── facturas-page/            ← facturas de compra
+│   ├── solicitudes-page/         ← solicitudes de bienes
+│   ├── consolidado-page/         ← consolidado de inventario
+│   ├── kardex-page/              ← tarjeta kardex por bien
+│   ├── alertas-page/             ← alertas de stock mínimo
+│   ├── presupuesto-page/         ← presupuesto de compras
+│   ├── conciliacion-page/        ← conciliación de inventario
+│   ├── requisiciones-page/       ← requisiciones internas
+│   ├── actas-page/               ← actas de entrega/recepción
+│   └── paquete-probatorio-page/  ← paquete probatorio GIL
+├── ui/                           ← page raíz del módulo (landing/índice)
+├── components/                   ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── inventario.facade.ts      ← único punto de entrada al store
+├── models/                       ← interfaces propias del dominio
+├── pipes/                        ← pipes específicos de inventario
+├── validators/                   ← validadores de formularios del dominio
+└── util/                         ← helpers específicos (no van a shared)
+```

--- a/libs/reportes/CLAUDE.md
+++ b/libs/reportes/CLAUDE.md
@@ -17,3 +17,25 @@ feat(reportes): ... | fix(reportes): ... | chore(reportes): ...
 
 ## Si necesitás algo de shared
 No lo modificás vos — coordiná con el equipo de Arquitectura.
+
+## Estructura de carpetas
+
+```
+libs/reportes/reportes/src/lib/
+├── pages/                           ← una carpeta por ruta del sidebar
+│   ├── ventas-page/                 ← reportes de ventas
+│   └── inventario-reportes-page/   ← reportes de inventario
+├── ui/                             ← page raíz del módulo (landing/índice)
+├── components/                     ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── reportes.facade.ts          ← único punto de entrada al store
+├── models/                         ← interfaces propias del dominio
+├── pipes/                          ← pipes específicos del dominio
+├── validators/                     ← validadores de formularios del dominio
+└── util/                           ← helpers específicos (no van a shared)
+```

--- a/libs/restaurante/CLAUDE.md
+++ b/libs/restaurante/CLAUDE.md
@@ -17,3 +17,26 @@ feat(restaurante): ... | fix(restaurante): ... | chore(restaurante): ...
 
 ## Si necesitás algo de shared
 No lo modificás vos — coordiná con el equipo de Arquitectura.
+
+## Estructura de carpetas
+
+```
+libs/restaurante/restaurante/src/lib/
+├── pages/                    ← una carpeta por ruta del sidebar
+│   ├── mesas-page/           ← gestión del salón y mesas
+│   ├── pedidos-page/         ← pedidos del salón
+│   └── caja-page/            ← cierre de caja y cobro
+├── ui/                       ← page raíz del módulo (landing/índice)
+├── components/               ← componentes presentacionales propios del dominio
+├── data-access/
+│   ├── store/
+│   │   ├── actions/
+│   │   ├── effects/
+│   │   ├── reducers/
+│   │   └── selectors/
+│   └── restaurante.facade.ts ← único punto de entrada al store
+├── models/                   ← interfaces propias del dominio
+├── pipes/                    ← pipes específicos del dominio
+├── validators/               ← validadores de formularios del dominio
+└── util/                     ← helpers específicos (no van a shared)
+```


### PR DESCRIPTION
## Summary

- Actualiza `docs/arquitectura.md`: sección de estructura, shared layer con `pipes/`, `directives/`, `validators/`, anatomía interna con la estructura real y tabla de referencia rápida "¿Qué va dónde?"
- Actualiza `.ai/domains/` (inventario, cocina, bar, restaurante, reportes, auth) con sección `## Estructura de carpetas` mostrando las pages específicas de cada dominio
- Actualiza `libs/**/CLAUDE.md` (6 dominios) con la misma sección para que Claude y los devs sepan donde va cada cosa

## Archivos modificados

- `docs/arquitectura.md`
- `.ai/domains/{inventario,cocina,bar,restaurante,reportes,auth}.md`
- `libs/{inventario,cocina,bar,restaurante,reportes,auth}/CLAUDE.md`

## Test plan

- [ ] Verificar que `docs/arquitectura.md` refleja la estructura real de carpetas
- [ ] Verificar que cada dominio en `.ai/domains/` muestra sus pages correctas
- [ ] Verificar que los CLAUDE.md de cada lib tienen la sección de estructura