### PR TITLE
fix(shell): ocultar Inventario y Reportes del topbar

### DIFF
--- a/libs/shell/shell/src/lib/nav/nav-config.ts
+++ b/libs/shell/shell/src/lib/nav/nav-config.ts
@@ -1,9 +1,6 @@
 import { BarraLateralConfig, TopNavLink } from './nav.models';
 
-export const TOP_MENU_CONFIG: TopNavLink[] = [
-  { label: 'Inventario', ruta: '/app/inventario' },
-  { label: 'Reportes',   ruta: '/app/reportes'   },
-];
+export const TOP_MENU_CONFIG: TopNavLink[] = [];
 
 export const SIDEBAR_CONFIG: BarraLateralConfig = {
   titulo:    'GastroSena',


### PR DESCRIPTION
## Summary
- Vaciado `TOP_MENU_CONFIG` en `nav-config.ts` para eliminar los links de **Inventario** y **Reportes** de la barra superior
- Esa navegación ya está disponible en el sidebar lateral, por lo que el topbar queda limpio

## Archivos modificados
- `libs/shell/shell/src/lib/nav/nav-config.ts`

## Test plan
- [ ] Verificar que la barra superior ya no muestra "Inventario" ni "Reportes"
- [ ] Verificar que la navegación desde el sidebar sigue funcionando correctamente