### PR TITLE
feat(shared/ui): ButtonComponent genérico + mejoras en tabla de facturas

### DIFF
--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
@@ -7,14 +7,14 @@
       <p class="page-header__subtitle">Supervisión y control de documentos electrónicos en tiempo real.</p>
     </div>
     <div class="page-header__actions">
-      <button class="btn btn--ghost btn--sm" (click)="onExportar()">
+      <restaurant-button variant="ghost" (click)="onExportar()">
         <span class="material-symbols-outlined">download</span>
         Exportar
-      </button>
-      <button class="btn btn--primary btn--sm" id="btn-nueva-factura" (click)="onNuevaFactura()">
+      </restaurant-button>
+      <restaurant-button variant="primary" id="btn-nueva-factura" (click)="onNuevaFactura()">
         <span class="material-symbols-outlined">add</span>
         Nueva Factura
-      </button>
+      </restaurant-button>
     </div>
   </div>
 

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
@@ -7,6 +7,10 @@
       <p class="page-header__subtitle">Supervisión y control de documentos electrónicos en tiempo real.</p>
     </div>
     <div class="page-header__actions">
+      <restaurant-button variant="surface" (click)="onImportar()">
+        <span class="material-symbols-outlined">upload</span>
+        Importar
+      </restaurant-button>
       <restaurant-button variant="ghost" (click)="onExportar()">
         <span class="material-symbols-outlined">download</span>
         Exportar

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
@@ -138,7 +138,7 @@
               <span class="material-symbols-outlined">visibility</span>
             </button>
             <button class="action-icon action-icon--danger" (click)="$event.stopPropagation(); onAnularFactura(factura)" title="Anular">
-              <span class="material-symbols-outlined">block</span>
+              <span class="material-symbols-outlined">delete</span>
             </button>
           </div>
         </td>

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
@@ -130,13 +130,17 @@
           </span>
         </td>
         <td class="cell--actions">
-          <button
-            class="icon-btn"
-            (click)="$event.stopPropagation(); onVerFactura(factura)"
-            title="Ver / Editar factura"
-          >
-            <span class="material-symbols-outlined">more_vert</span>
-          </button>
+          <div class="actions-row">
+            <button class="action-icon" (click)="$event.stopPropagation(); onEditarFactura(factura)" title="Editar">
+              <span class="material-symbols-outlined">edit</span>
+            </button>
+            <button class="action-icon" (click)="$event.stopPropagation(); onVerFactura(factura)" title="Ver detalle">
+              <span class="material-symbols-outlined">visibility</span>
+            </button>
+            <button class="action-icon action-icon--danger" (click)="$event.stopPropagation(); onAnularFactura(factura)" title="Anular">
+              <span class="material-symbols-outlined">block</span>
+            </button>
+          </div>
         </td>
       </tr>
 

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.scss
@@ -199,14 +199,10 @@
 
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Row hover — el icon-btn aparece al hacer hover en la fila
+// Row clickable
 // ─────────────────────────────────────────────────────────────────────────────
 .row-clickable {
   cursor: pointer;
-
-  &:hover .icon-btn {
-    opacity: 1;
-  }
 }
 
 // Cell variants
@@ -306,23 +302,39 @@
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Icon Button
+// Action Buttons (igual que bienes)
 // ─────────────────────────────────────────────────────────────────────────────
-.icon-btn {
-  opacity: 0;
+.actions-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.action-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0.5rem;
+  border-radius: 0.5rem;
   border: none;
   background: transparent;
-  border-radius: 0.5rem;
+  color: var(--color-pizarra-400);
   cursor: pointer;
-  color: #9ca3af;
-  transition: all 0.15s ease;
-  display: inline-flex;
-  align-items: center;
+  transition: all 0.2s;
+
+  .material-symbols-outlined { font-size: 20px; }
 
   &:hover {
-    background: var(--color-superficie-contenedor-mas-bajo);
     color: var(--color-primario);
+    background: rgba(0, 110, 37, 0.05);
+  }
+
+  &--danger {
+    &:hover {
+      color: var(--color-terciario);
+      background: rgba(186, 24, 48, 0.05);
+    }
   }
 }
 

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.scss
@@ -327,64 +327,6 @@
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Buttons
-// ─────────────────────────────────────────────────────────────────────────────
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  border-radius: 0.5rem;
-  border: none;
-  cursor: pointer;
-  font-family: var(--font-family-base);
-  font-weight: 600;
-  transition: all 0.15s ease;
-
-  .material-symbols-outlined {
-    font-size: 1rem;
-  }
-
-  &--filter {
-    background: var(--color-superficie-contenedor-bajo);
-    color: #374151;
-    border: 1px solid var(--color-superficie-contenedor);
-
-    &:hover {
-      background: var(--color-superficie-contenedor);
-    }
-  }
-
-  &--sm {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.75rem;
-  }
-
-  &--ghost {
-    background: transparent;
-    border: 1px solid var(--color-superficie-contenedor);
-    color: #374151;
-
-    &:hover {
-      background: var(--color-superficie-contenedor-bajo);
-    }
-  }
-
-  &--primary {
-    background: var(--color-primario);
-    color: #fff;
-    box-shadow: 0 1px 3px rgba(0, 110, 37, 0.3);
-
-    &:hover {
-      background: var(--color-primario-hover);
-    }
-
-    &:active {
-      transform: scale(0.97);
-    }
-  }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Pagination (proyectado en [dtFooter])
 // ─────────────────────────────────────────────────────────────────────────────
 .table-pagination {

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.ts
@@ -53,6 +53,14 @@ export class FacturasListPageComponent implements OnInit {
     this.router.navigate(['/app/inventario/facturas', factura.id]);
   }
 
+  onEditarFactura(factura: Factura): void {
+    this.router.navigate(['/app/inventario/facturas', factura.id], { queryParams: { modo: 'editar' } });
+  }
+
+  onAnularFactura(factura: Factura): void {
+    console.log('Anular factura:', factura.id);
+  }
+
   onExportar(): void {
     console.log('Exportando facturas...');
   }

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.ts
@@ -61,6 +61,10 @@ export class FacturasListPageComponent implements OnInit {
     console.log('Anular factura:', factura.id);
   }
 
+  onImportar(): void {
+    console.log('Importando facturas...');
+  }
+
   onExportar(): void {
     console.log('Exportando facturas...');
   }

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
-import { DataTableComponent } from '@restaurant/shared/ui';
+import { ButtonComponent, DataTableComponent } from '@restaurant/shared/ui';
 import { FacturasFacade } from '../../../data-access/facturas.facade';
 import { Factura, EstadoFactura } from '../../../models/facturas.model';
 import { FacturaFormComponent } from '../../../ui/modals/factura-form/factura-form.component';
@@ -9,7 +9,7 @@ import { FacturaFormComponent } from '../../../ui/modals/factura-form/factura-fo
 @Component({
   selector: 'restaurant-facturas-list',
   standalone: true,
-  imports: [CommonModule, DataTableComponent, FacturaFormComponent],
+  imports: [CommonModule, ButtonComponent, DataTableComponent, FacturaFormComponent],
   templateUrl: './facturas-list.component.html',
   styleUrl: './facturas-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.html
+++ b/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.html
@@ -5,18 +5,18 @@
     <p class="page-subtitle">Control exhaustivo y trazabilidad de activos de formación.</p>
   </div>
   <div class="header-actions">
-    <button class="btn-surface" (click)="onImportBienes()">
+    <restaurant-button variant="surface" (click)="onImportBienes()">
       <span class="material-symbols-outlined">file_upload</span>
       Importar
-    </button>
-    <button class="btn-surface" (click)="onExportBienes()">
+    </restaurant-button>
+    <restaurant-button variant="surface" (click)="onExportBienes()">
       <span class="material-symbols-outlined">file_download</span>
       Exportar
-    </button>
-    <button class="btn-gradient" (click)="onNuevoBien()">
+    </restaurant-button>
+    <restaurant-button variant="primary" (click)="onNuevoBien()">
       <span class="material-symbols-outlined">add</span>
       Nuevo Bien
-    </button>
+    </restaurant-button>
   </div>
 </div>
 
@@ -33,10 +33,10 @@
         <span class="material-symbols-outlined search-icon">search</span>
         <input type="text" placeholder="Buscar por código o nombre..." (input)="onSearch($any($event.target).value)" />
       </div>
-      <button class="btn-filter">
+      <restaurant-button variant="filter">
         <span class="material-symbols-outlined">filter_list</span>
         Filtros
-      </button>
+      </restaurant-button>
     </div>
   </div>
 

--- a/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.scss
+++ b/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.scss
@@ -40,52 +40,6 @@
   gap: 0.75rem;
 }
 
-/* ── Buttons ───────────────────────────────────────────────────────────────── */
-.btn-surface {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.25rem;
-  border-radius: 999px;
-  background: var(--color-superficie-contenedor);
-  color: var(--color-en-fondo);
-  font-weight: 700;
-  font-size: 0.8125rem;
-  border: none;
-  cursor: pointer;
-  transition: all 0.2s;
-
-  .material-symbols-outlined { font-size: 20px; }
-
-  &:hover {
-    background: var(--color-superficie-contenedor-alto);
-  }
-}
-
-.btn-gradient {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, #006e25 0%, #28a745 100%);
-  color: white;
-  font-weight: 700;
-  font-size: 0.8125rem;
-  border: none;
-  cursor: pointer;
-  box-shadow: 0 8px 20px rgba(0, 110, 37, 0.2);
-  transition: all 0.2s;
-
-  .material-symbols-outlined { font-size: 20px; }
-
-  &:hover {
-    transform: scale(1.02);
-    box-shadow: 0 12px 28px rgba(0, 110, 37, 0.3);
-  }
-  &:active { transform: scale(0.98); }
-}
-
 /* ── Card Container (tabla envuelta) ───────────────────────────────────────── */
 .card-container {
   background: white;
@@ -165,25 +119,6 @@
     &::placeholder { color: var(--color-pizarra-400); }
     &:focus { box-shadow: 0 0 0 2px rgba(0, 110, 37, 0.2); }
   }
-}
-
-.btn-filter {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  border-radius: 0.75rem;
-  background: var(--color-superficie-contenedor-bajo);
-  color: var(--color-en-fondo);
-  font-size: 0.8125rem;
-  font-weight: 600;
-  border: none;
-  cursor: pointer;
-  transition: all 0.2s;
-
-  .material-symbols-outlined { font-size: 18px; }
-
-  &:hover { background: var(--color-superficie-contenedor-alto); }
 }
 
 /* ── Data Table ────────────────────────────────────────────────────────────── */

--- a/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
-import { LoadingSkeletonComponent } from '@restaurant/shared/ui';
+import { ButtonComponent, LoadingSkeletonComponent } from '@restaurant/shared/ui';
 import { InventarioFacade } from '../../../data-access/inventario.facade';
 import { BienFormComponent } from '../../modals/bien-form/bien-form.component';
 import { BienImportModalComponent } from '../../modals/bien-import/bien-import.component';
@@ -13,6 +13,7 @@ import { Bien, BienFormDto } from '../../../models/inventario.model';
   standalone: true,
   imports: [
     CommonModule,
+    ButtonComponent,
     LoadingSkeletonComponent,
     BienFormComponent,
     BienImportModalComponent,

--- a/libs/shared/ui/src/index.ts
+++ b/libs/shared/ui/src/index.ts
@@ -12,6 +12,7 @@ export * from './lib/components/status-badge/status-badge.component';
 export * from './lib/components/section-title/section-title.component';
 export * from './lib/components/card/card.component';
 export * from './lib/components/alert/alert.component';
+export * from './lib/components/button/button.component';
 export * from './lib/directives/has-role.directive';
 export * from './lib/directives/auto-focus.directive';
 export * from './lib/providers/restaurant-ui.providers';

--- a/libs/shared/ui/src/lib/components/button/button.component.scss
+++ b/libs/shared/ui/src/lib/components/button/button.component.scss
@@ -1,0 +1,71 @@
+// ─── Base ────────────────────────────────────────────────────────────────────
+.app-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-family-base);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+
+  .material-symbols-outlined {
+    font-size: 20px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  // ─── Variants ──────────────────────────────────────────────────────────────
+
+  &--primary {
+    background: linear-gradient(135deg, var(--color-primario) 0%, #28a745 100%);
+    color: #fff;
+    box-shadow: 0 8px 20px rgba(0, 110, 37, 0.2);
+
+    &:hover {
+      transform: scale(1.02);
+      box-shadow: 0 12px 28px rgba(0, 110, 37, 0.3);
+    }
+
+    &:active {
+      transform: scale(0.98);
+    }
+  }
+
+  &--surface {
+    background: var(--color-superficie-contenedor);
+    color: var(--color-en-fondo);
+
+    &:hover {
+      background: var(--color-superficie-contenedor-alto);
+    }
+  }
+
+  &--ghost {
+    background: transparent;
+    border: 1px solid var(--color-superficie-contenedor);
+    color: var(--color-en-fondo);
+
+    &:hover {
+      background: var(--color-superficie-contenedor-bajo);
+    }
+  }
+
+  &--filter {
+    background: var(--color-superficie-contenedor-bajo);
+    color: var(--color-en-fondo);
+    border: 1px solid var(--color-superficie-contenedor);
+
+    &:hover {
+      background: var(--color-superficie-contenedor);
+    }
+  }
+}

--- a/libs/shared/ui/src/lib/components/button/button.component.ts
+++ b/libs/shared/ui/src/lib/components/button/button.component.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+export type ButtonVariant = 'primary' | 'surface' | 'ghost' | 'filter';
+
+@Component({
+  selector: 'restaurant-button',
+  standalone: true,
+  imports: [],
+  template: `
+    <button
+      class="app-btn"
+      [class]="'app-btn--' + variant"
+      [disabled]="disabled"
+      [type]="type"
+    >
+      <ng-content></ng-content>
+    </button>
+  `,
+  styleUrl: './button.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ButtonComponent {
+  @Input() variant: ButtonVariant = 'primary';
+  @Input() disabled = false;
+  @Input() type: 'button' | 'submit' | 'reset' = 'button';
+}


### PR DESCRIPTION
## Commits incluidos

- `feat(shared/ui)` — `ButtonComponent` genérico con variantes `primary`, `surface`, `ghost`, `filter` (forma pill, verde con tokens CSS)
- `feat(inventario)` — botones de acción `edit / visibility / delete` en tabla de facturas (igual que bienes)
- `fix(inventario)` — cambiar ícono `block` por `delete` en botón anular
- `feat(inventario)` — botón Importar en header de facturas

## Cambios

### `libs/shared/ui`
- Nuevo `ButtonComponent`: selector `<restaurant-button>`, input `variant`, soporte `ng-content` para ícono + texto
- Export agregado en `index.ts`

### `libs/inventario` — bienes-list
- Migración de `.btn-gradient / .btn-surface / .btn-filter` a `<restaurant-button>`
- Estilos locales eliminados

### `libs/inventario` — facturas-list
- Header: **Importar** (surface) + **Exportar** (ghost) + **Nueva Factura** (primary)
- Tabla: columna de acciones con `edit`, `visibility`, `delete` con hover danger
- Métodos `onImportar`, `onEditarFactura`, `onAnularFactura` agregados al componente

## Plan de pruebas

- [ ] Botón "Nueva Factura" abre el modal
- [ ] Botón "Importar" y "Exportar" disparan sus handlers (console.log por ahora)
- [ ] Íconos de acción en cada fila: edit navega con `?modo=editar`, visibility navega al detalle, delete llama `onAnularFactura`
- [ ] Hover en botón delete muestra color rojo
- [ ] Tabla de bienes no se rompió (ButtonComponent es retrocompatible)
- [ ] Variantes `primary / surface / ghost / filter` renderizan correctamente