### PR TITLE
fix(tsconfig): agregar paths de shared libs en todos los remotes

### DIFF
--- a/remotes/Frontend-inventario-actualizado/tsconfig.json
+++ b/remotes/Frontend-inventario-actualizado/tsconfig.json
@@ -22,7 +22,15 @@
     "lib": [
       "ES2022",
       "dom"
-    ]
+    ],
+    "paths": {
+      "@restaurant/shared/ui": ["../../libs/shared/ui/src/index.ts"],
+      "@restaurant/shared/models": ["../../libs/shared/models/src/index.ts"],
+      "@restaurant/shared/util": ["../../libs/shared/util/src/index.ts"],
+      "@restaurant/shared/auth": ["../../libs/shared/auth/src/index.ts"],
+      "@restaurant/shared/api": ["../../libs/shared/api/src/index.ts"],
+      "@restaurant/shared/state": ["../../libs/shared/state/src/index.ts"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/remotes/cocina-frontend/tsconfig.json
+++ b/remotes/cocina-frontend/tsconfig.json
@@ -3,6 +3,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "baseUrl": "./",
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
@@ -13,7 +14,15 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "ES2022",
-    "module": "preserve"
+    "module": "preserve",
+    "paths": {
+      "@restaurant/shared/ui": ["../../libs/shared/ui/src/index.ts"],
+      "@restaurant/shared/models": ["../../libs/shared/models/src/index.ts"],
+      "@restaurant/shared/util": ["../../libs/shared/util/src/index.ts"],
+      "@restaurant/shared/auth": ["../../libs/shared/auth/src/index.ts"],
+      "@restaurant/shared/api": ["../../libs/shared/api/src/index.ts"],
+      "@restaurant/shared/state": ["../../libs/shared/state/src/index.ts"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/remotes/ga-web-inicio-general/tsconfig.json
+++ b/remotes/ga-web-inicio-general/tsconfig.json
@@ -3,6 +3,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "baseUrl": "./",
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
@@ -13,7 +14,15 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "ES2022",
-    "module": "preserve"
+    "module": "preserve",
+    "paths": {
+      "@restaurant/shared/ui": ["../../libs/shared/ui/src/index.ts"],
+      "@restaurant/shared/models": ["../../libs/shared/models/src/index.ts"],
+      "@restaurant/shared/util": ["../../libs/shared/util/src/index.ts"],
+      "@restaurant/shared/auth": ["../../libs/shared/auth/src/index.ts"],
+      "@restaurant/shared/api": ["../../libs/shared/api/src/index.ts"],
+      "@restaurant/shared/state": ["../../libs/shared/state/src/index.ts"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/remotes/ga-web-restaurante/tsconfig.json
+++ b/remotes/ga-web-restaurante/tsconfig.json
@@ -16,7 +16,15 @@
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
-    "module": "ES2022"
+    "module": "ES2022",
+    "paths": {
+      "@restaurant/shared/ui": ["../../libs/shared/ui/src/index.ts"],
+      "@restaurant/shared/models": ["../../libs/shared/models/src/index.ts"],
+      "@restaurant/shared/util": ["../../libs/shared/util/src/index.ts"],
+      "@restaurant/shared/auth": ["../../libs/shared/auth/src/index.ts"],
+      "@restaurant/shared/api": ["../../libs/shared/api/src/index.ts"],
+      "@restaurant/shared/state": ["../../libs/shared/state/src/index.ts"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/remotes/lib-gas-layout-frontend/tsconfig.json
+++ b/remotes/lib-gas-layout-frontend/tsconfig.json
@@ -18,6 +18,14 @@
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
-    "lib": ["ES2022", "dom"]
+    "lib": ["ES2022", "dom"],
+    "paths": {
+      "@restaurant/shared/ui": ["../../libs/shared/ui/src/index.ts"],
+      "@restaurant/shared/models": ["../../libs/shared/models/src/index.ts"],
+      "@restaurant/shared/util": ["../../libs/shared/util/src/index.ts"],
+      "@restaurant/shared/auth": ["../../libs/shared/auth/src/index.ts"],
+      "@restaurant/shared/api": ["../../libs/shared/api/src/index.ts"],
+      "@restaurant/shared/state": ["../../libs/shared/state/src/index.ts"]
+    }
   }
 }


### PR DESCRIPTION
Closes #48

## Tipo de cambio

- [x] Bug fix

## Resumen

- Los remotes no tenían `paths` en su `tsconfig.json` y no podían resolver los alias `@restaurant/shared/*`
- Se agrega el bloque `paths` con los 6 alias de shared en los 5 remotes del proyecto
- Se agrega `baseUrl: "./"` donde faltaba para que los paths sean válidos

## Cambios

| Archivo | Cambio |
|---------|--------|
| `remotes/cocina-frontend/tsconfig.json` | Agregar `baseUrl` y `paths` |
| `remotes/Frontend-inventario-actualizado/tsconfig.json` | Agregar `paths` |
| `remotes/ga-web-inicio-general/tsconfig.json` | Agregar `baseUrl` y `paths` |
| `remotes/ga-web-restaurante/tsconfig.json` | Agregar `paths` |
| `remotes/lib-gas-layout-frontend/tsconfig.json` | Agregar `paths` |

## Test plan

- [x] Los paths apuntan a `index.ts` existentes verificados antes del commit
- [x] No viola las module boundaries del monorepo (solo `shared/*` en remotes de dominio)
- [x] Lint pasado (hook pre-commit)