### PR TITLE
feat(auth): implementar vista lista de usuarios con modales importar/exportar

### DIFF
--- a/libs/auth/usuarios/src/lib/components/exportar-usuarios/exportar-usuarios.component.html
+++ b/libs/auth/usuarios/src/lib/components/exportar-usuarios/exportar-usuarios.component.html
@@ -1,0 +1,91 @@
+<div class="modal-backdrop" (click)="cerrar.emit()" (keydown.escape)="cerrar.emit()" role="dialog" aria-modal="true" tabindex="-1">
+  <div class="modal" (click)="$event.stopPropagation()">
+
+    <!-- Header -->
+    <div class="modal__header">
+      <div class="modal__header-icon modal__header-icon--export">
+        <lucide-icon name="download" [size]="20"></lucide-icon>
+      </div>
+      <div>
+        <h2 class="modal__title">Exportar Usuarios</h2>
+        <p class="modal__subtitle">Descargá el listado en el formato que necesitás</p>
+      </div>
+      <button class="modal__close" type="button" (click)="cerrar.emit()" aria-label="Cerrar">
+        <lucide-icon name="x" [size]="18"></lucide-icon>
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div class="modal__body">
+
+      <!-- Formato -->
+      <div class="modal__field">
+        <label class="modal__label" for="exp-formato">Formato de exportación</label>
+        <div class="modal__select-wrapper">
+          <select
+            id="exp-formato"
+            class="modal__select"
+            [value]="formato()"
+            (change)="onFormatoChange($event)"
+          >
+            <option value="excel">Excel (.xlsx)</option>
+            <option value="csv">CSV (.csv)</option>
+          </select>
+          <lucide-icon name="chevron-down" [size]="16" class="modal__select-icon"></lucide-icon>
+        </div>
+      </div>
+
+      <!-- Filtro por rol -->
+      <div class="modal__field">
+        <label class="modal__label" for="exp-rol">Filtrar por rol</label>
+        <div class="modal__select-wrapper">
+          <select
+            id="exp-rol"
+            class="modal__select"
+            [value]="filtroRol()"
+            (change)="onRolChange($event)"
+          >
+            @for (opcion of rolOpciones; track opcion.value) {
+              <option [value]="opcion.value">{{ opcion.label }}</option>
+            }
+          </select>
+          <lucide-icon name="chevron-down" [size]="16" class="modal__select-icon"></lucide-icon>
+        </div>
+      </div>
+
+      <!-- Incluir inactivos -->
+      <label class="modal__checkbox">
+        <input
+          type="checkbox"
+          class="modal__checkbox-input"
+          [checked]="incluirInactivos()"
+          (change)="onInactivosChange($event)"
+        />
+        <span class="modal__checkbox-label">Incluir usuarios inactivos</span>
+      </label>
+
+      <!-- Info -->
+      <div class="modal__info">
+        <lucide-icon name="info" [size]="16" class="modal__info-icon"></lucide-icon>
+        <p class="modal__info-text">
+          Se exportarán
+          <strong>{{ totalUsuarios }} usuario{{ totalUsuarios === 1 ? '' : 's' }}</strong>
+          con los filtros seleccionados.
+        </p>
+      </div>
+
+    </div>
+
+    <!-- Footer -->
+    <div class="modal__footer">
+      <button class="modal__btn modal__btn--ghost" type="button" (click)="cerrar.emit()">
+        Cancelar
+      </button>
+      <button class="modal__btn modal__btn--primary" type="button" (click)="onExportar()">
+        <lucide-icon name="download" [size]="16"></lucide-icon>
+        Exportar
+      </button>
+    </div>
+
+  </div>
+</div>

--- a/libs/auth/usuarios/src/lib/components/exportar-usuarios/exportar-usuarios.component.scss
+++ b/libs/auth/usuarios/src/lib/components/exportar-usuarios/exportar-usuarios.component.scss
@@ -1,0 +1,220 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--color-backdrop);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--space-4);
+}
+
+.modal {
+  background: var(--color-surface-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+    padding: var(--space-5) var(--space-6);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  &__header-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-md);
+    flex-shrink: 0;
+
+    &--export {
+      background: var(--color-brand-primary-soft);
+      color: var(--color-brand-primary-strong);
+    }
+  }
+
+  &__title {
+    font-family: var(--font-family-headline);
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-heading);
+    margin: 0;
+    line-height: 1.2;
+  }
+
+  &__subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    margin: var(--space-1) 0 0;
+  }
+
+  &__close {
+    margin-left: auto;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-1);
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+    transition: background var(--duration-fast) var(--ease-standard),
+                color    var(--duration-fast) var(--ease-standard);
+
+    &:hover {
+      background: var(--color-superficie-contenedor);
+      color: var(--color-text-primary);
+    }
+  }
+
+  &__body {
+    padding: var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  &__label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+  }
+
+  &__select-wrapper {
+    position: relative;
+  }
+
+  &__select {
+    width: 100%;
+    appearance: none;
+    padding: var(--space-2) var(--space-8) var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-primary);
+    background: var(--color-surface-primary);
+    cursor: pointer;
+    transition: border-color var(--duration-fast) var(--ease-standard);
+    font-family: var(--font-family-base);
+
+    &:focus {
+      outline: none;
+      border-color: var(--color-primario);
+      box-shadow: var(--focus-ring);
+    }
+  }
+
+  &__select-icon {
+    position: absolute;
+    right: var(--space-3);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-text-secondary);
+    pointer-events: none;
+  }
+
+  &__checkbox {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    cursor: pointer;
+  }
+
+  &__checkbox-input {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--color-primario);
+    cursor: pointer;
+  }
+
+  &__checkbox-label {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-primary);
+    user-select: none;
+  }
+
+  &__info {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    padding: var(--space-3);
+    background: var(--color-info-bg);
+    border: 1px solid var(--color-info-border);
+    border-radius: var(--radius-md);
+  }
+
+  &__info-icon {
+    color: var(--color-info-text);
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+
+  &__info-text {
+    font-size: var(--font-size-sm);
+    color: var(--color-info-text);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-6);
+    border-top: 1px solid var(--color-border);
+    background: var(--color-superficie-contenedor-bajo);
+    border-radius: 0 0 var(--radius-xl) var(--radius-xl);
+  }
+
+  &__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-5);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    font-family: var(--font-family-base);
+    cursor: pointer;
+    border: none;
+    transition: background var(--duration-fast) var(--ease-standard),
+                box-shadow  var(--duration-fast) var(--ease-standard);
+
+    &--ghost {
+      background: transparent;
+      color: var(--color-text-secondary);
+      border: 1px solid var(--color-border);
+
+      &:hover {
+        background: var(--color-superficie-contenedor);
+        color: var(--color-text-primary);
+      }
+    }
+
+    &--primary {
+      background: var(--color-primario);
+      color: var(--color-en-primario);
+
+      &:hover {
+        background: var(--color-primario-hover);
+        box-shadow: var(--shadow-primary);
+      }
+    }
+  }
+}

--- a/libs/auth/usuarios/src/lib/components/exportar-usuarios/exportar-usuarios.component.ts
+++ b/libs/auth/usuarios/src/lib/components/exportar-usuarios/exportar-usuarios.component.ts
@@ -1,0 +1,61 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  signal,
+} from '@angular/core';
+import { LucideIconComponent } from '@restaurant/shared/ui';
+import { ExportarConfig } from '../../models/usuarios.model';
+
+const ROL_OPCIONES = [
+  { value: '',              label: 'Todos los roles'  },
+  { value: 'ADMINISTRADOR', label: 'Administrador'    },
+  { value: 'CHEF',          label: 'Chef'             },
+  { value: 'MESERO',        label: 'Mesero'           },
+  { value: 'BARTENDER',     label: 'Bartender'        },
+  { value: 'CAJERO',        label: 'Cajero'           },
+  { value: 'CONTADORA',     label: 'Contadora'        },
+  { value: 'INSTRUCTOR',    label: 'Instructor'       },
+];
+
+@Component({
+  selector: 'restaurant-exportar-usuarios',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [LucideIconComponent],
+  templateUrl: './exportar-usuarios.component.html',
+  styleUrl:    './exportar-usuarios.component.scss',
+})
+export class ExportarUsuariosComponent {
+  @Input({ required: true }) totalUsuarios!: number;
+  @Output() cerrar   = new EventEmitter<void>();
+  @Output() exportar = new EventEmitter<ExportarConfig>();
+
+  readonly formato          = signal<'excel' | 'csv'>('excel');
+  readonly incluirInactivos = signal(false);
+  readonly filtroRol        = signal('');
+  readonly rolOpciones      = ROL_OPCIONES;
+
+  onFormatoChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.formato.set(value as 'excel' | 'csv');
+  }
+
+  onRolChange(event: Event): void {
+    this.filtroRol.set((event.target as HTMLSelectElement).value);
+  }
+
+  onInactivosChange(event: Event): void {
+    this.incluirInactivos.set((event.target as HTMLInputElement).checked);
+  }
+
+  onExportar(): void {
+    this.exportar.emit({
+      formato:          this.formato(),
+      incluirInactivos: this.incluirInactivos(),
+      rol:              this.filtroRol(),
+    });
+  }
+}

--- a/libs/auth/usuarios/src/lib/components/importar-usuarios/importar-usuarios.component.html
+++ b/libs/auth/usuarios/src/lib/components/importar-usuarios/importar-usuarios.component.html
@@ -1,0 +1,75 @@
+<div class="modal-backdrop" (click)="cerrar.emit()" (keydown.escape)="cerrar.emit()" role="dialog" aria-modal="true" tabindex="-1">
+  <div class="modal" (click)="$event.stopPropagation()">
+
+    <!-- Header -->
+    <div class="modal__header">
+      <div class="modal__header-icon modal__header-icon--import">
+        <lucide-icon name="upload" [size]="20"></lucide-icon>
+      </div>
+      <div>
+        <h2 class="modal__title">Importar Usuarios</h2>
+        <p class="modal__subtitle">Cargá un archivo Excel con los datos del equipo</p>
+      </div>
+      <button class="modal__close" type="button" (click)="cerrar.emit()" aria-label="Cerrar">
+        <lucide-icon name="x" [size]="18"></lucide-icon>
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div class="modal__body">
+
+      <!-- Drop zone -->
+      <label
+        class="modal__dropzone"
+        [class.modal__dropzone--active]="isDragging()"
+        [class.modal__dropzone--ready]="archivo() !== null"
+        (dragover)="onDragOver($event)"
+        (dragleave)="onDragLeave()"
+        (drop)="onDrop($event)"
+      >
+        @if (archivo()) {
+          <lucide-icon name="file-check" [size]="36" class="modal__dropzone-icon modal__dropzone-icon--ready"></lucide-icon>
+          <p class="modal__dropzone-text">{{ archivo()!.name }}</p>
+          <p class="modal__dropzone-hint">Archivo listo · clic para cambiar</p>
+        } @else {
+          <lucide-icon name="file-up" [size]="36" class="modal__dropzone-icon"></lucide-icon>
+          <p class="modal__dropzone-text">Arrastrá tu archivo aquí</p>
+          <p class="modal__dropzone-hint">o hacé clic para seleccionar (.xlsx, .xls, .csv)</p>
+        }
+        <input
+          type="file"
+          accept=".xlsx,.xls,.csv"
+          class="modal__dropzone-input"
+          (change)="onFileChange($event)"
+        />
+      </label>
+
+      <!-- Yellow note -->
+      <div class="modal__note">
+        <lucide-icon name="triangle-alert" [size]="16" class="modal__note-icon"></lucide-icon>
+        <div>
+          <p class="modal__note-title">Formato esperado de columnas:</p>
+          <p class="modal__note-cols">Documento &middot; Nombre &middot; Apellidos &middot; Email &middot; Teléfono &middot; Rol</p>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Footer -->
+    <div class="modal__footer">
+      <button class="modal__btn modal__btn--ghost" type="button" (click)="cerrar.emit()">
+        Cancelar
+      </button>
+      <button
+        class="modal__btn modal__btn--primary"
+        type="button"
+        [disabled]="archivo() === null"
+        (click)="onImportar()"
+      >
+        <lucide-icon name="upload" [size]="16"></lucide-icon>
+        Iniciar Importación
+      </button>
+    </div>
+
+  </div>
+</div>

--- a/libs/auth/usuarios/src/lib/components/importar-usuarios/importar-usuarios.component.scss
+++ b/libs/auth/usuarios/src/lib/components/importar-usuarios/importar-usuarios.component.scss
@@ -1,0 +1,230 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--color-backdrop);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--space-4);
+}
+
+.modal {
+  background: var(--color-surface-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+    padding: var(--space-5) var(--space-6);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  &__header-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-md);
+    flex-shrink: 0;
+
+    &--import {
+      background: var(--color-brand-primary-soft);
+      color: var(--color-brand-primary-strong);
+    }
+  }
+
+  &__title {
+    font-family: var(--font-family-headline);
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-heading);
+    margin: 0;
+    line-height: 1.2;
+  }
+
+  &__subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    margin: var(--space-1) 0 0;
+  }
+
+  &__close {
+    margin-left: auto;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-1);
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+    transition: background var(--duration-fast) var(--ease-standard),
+                color    var(--duration-fast) var(--ease-standard);
+
+    &:hover {
+      background: var(--color-superficie-contenedor);
+      color: var(--color-text-primary);
+    }
+  }
+
+  &__body {
+    padding: var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  &__dropzone {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    padding: var(--space-8) var(--space-6);
+    border: 2px dashed var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-superficie-contenedor-bajo);
+    cursor: pointer;
+    text-align: center;
+    transition: border-color var(--duration-fast) var(--ease-standard),
+                background   var(--duration-fast) var(--ease-standard);
+
+    &:hover {
+      border-color: var(--color-primario);
+      background: var(--color-brand-primary-soft);
+    }
+
+    &--active {
+      border-color: var(--color-primario);
+      background: var(--color-brand-primary-soft);
+    }
+
+    &--ready {
+      border-color: var(--color-success-text);
+      border-style: solid;
+      background: var(--color-success-bg);
+    }
+  }
+
+  &__dropzone-icon {
+    color: var(--color-text-secondary);
+
+    &--ready {
+      color: var(--color-success-text);
+    }
+  }
+
+  &__dropzone-text {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+    margin: 0;
+    word-break: break-all;
+  }
+
+  &__dropzone-hint {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  &__dropzone-input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+  }
+
+  &__note {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    padding: var(--space-3);
+    background: var(--color-warning-bg);
+    border: 1px solid var(--color-warning-border, var(--color-warning-text));
+    border-radius: var(--radius-md);
+  }
+
+  &__note-icon {
+    color: var(--color-warning-text);
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+
+  &__note-title {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-warning-text);
+    margin: 0 0 var(--space-1);
+  }
+
+  &__note-cols {
+    font-size: var(--font-size-sm);
+    color: var(--color-warning-text);
+    margin: 0;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-6);
+    border-top: 1px solid var(--color-border);
+    background: var(--color-superficie-contenedor-bajo);
+    border-radius: 0 0 var(--radius-xl) var(--radius-xl);
+  }
+
+  &__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-5);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    font-family: var(--font-family-base);
+    cursor: pointer;
+    border: none;
+    transition: background var(--duration-fast) var(--ease-standard),
+                box-shadow  var(--duration-fast) var(--ease-standard);
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &--ghost {
+      background: transparent;
+      color: var(--color-text-secondary);
+      border: 1px solid var(--color-border);
+
+      &:hover:not(:disabled) {
+        background: var(--color-superficie-contenedor);
+        color: var(--color-text-primary);
+      }
+    }
+
+    &--primary {
+      background: var(--color-primario);
+      color: var(--color-en-primario);
+
+      &:hover:not(:disabled) {
+        background: var(--color-primario-hover);
+        box-shadow: var(--shadow-primary);
+      }
+    }
+  }
+}

--- a/libs/auth/usuarios/src/lib/components/importar-usuarios/importar-usuarios.component.ts
+++ b/libs/auth/usuarios/src/lib/components/importar-usuarios/importar-usuarios.component.ts
@@ -1,0 +1,52 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Output,
+  signal,
+} from '@angular/core';
+import { LucideIconComponent } from '@restaurant/shared/ui';
+import { ImportarUsuariosRequest } from '../../models/usuarios.model';
+
+@Component({
+  selector: 'restaurant-importar-usuarios',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [LucideIconComponent],
+  templateUrl: './importar-usuarios.component.html',
+  styleUrl:    './importar-usuarios.component.scss',
+})
+export class ImportarUsuariosComponent {
+  @Output() cerrar   = new EventEmitter<void>();
+  @Output() importar = new EventEmitter<ImportarUsuariosRequest>();
+
+  readonly isDragging = signal(false);
+  readonly archivo    = signal<File | null>(null);
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragging.set(true);
+  }
+
+  onDragLeave(): void {
+    this.isDragging.set(false);
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragging.set(false);
+    const file = event.dataTransfer?.files[0];
+    if (file) this.archivo.set(file);
+  }
+
+  onFileChange(event: Event): void {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (file) this.archivo.set(file);
+  }
+
+  onImportar(): void {
+    const file = this.archivo();
+    if (!file) return;
+    this.importar.emit({ archivo: file, tipo: 'INSTRUCTOR' });
+  }
+}

--- a/libs/auth/usuarios/src/lib/data-access/store/actions/usuarios.actions.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/actions/usuarios.actions.ts
@@ -1,5 +1,5 @@
 import { createActionGroup, emptyProps, props } from '@ngrx/store';
-import { Usuario, PaginatedResponse } from '@restaurant/shared/models';
+import { PaginatedResponse } from '@restaurant/shared/models';
 import {
   ActualizarUsuarioRequest,
   CrearUsuarioRequest,
@@ -7,6 +7,7 @@ import {
   ImportarUsuariosRequest,
   ImportarUsuariosResponse,
   RolOpcion,
+  UsuarioDetalle,
 } from '../../../models/usuarios.model';
 
 export const UsuariosActions = createActionGroup({
@@ -14,7 +15,7 @@ export const UsuariosActions = createActionGroup({
   events: {
     // ── Cargar lista ──────────────────────────────────────────────────────────
     'Cargar Usuarios':          props<{ filtros?: Partial<FiltrosUsuarios> }>(),
-    'Cargar Usuarios Exitoso':  props<{ response: PaginatedResponse<Usuario> }>(),
+    'Cargar Usuarios Exitoso':  props<{ response: PaginatedResponse<UsuarioDetalle> }>(),
     'Cargar Usuarios Fallido':  props<{ error: string }>(),
 
     // ── Cargar roles ──────────────────────────────────────────────────────────
@@ -24,12 +25,12 @@ export const UsuariosActions = createActionGroup({
 
     // ── Crear ─────────────────────────────────────────────────────────────────
     'Crear Usuario':            props<{ data: CrearUsuarioRequest }>(),
-    'Crear Usuario Exitoso':    props<{ usuario: Usuario }>(),
+    'Crear Usuario Exitoso':    props<{ usuario: UsuarioDetalle }>(),
     'Crear Usuario Fallido':    props<{ error: string }>(),
 
     // ── Actualizar ────────────────────────────────────────────────────────────
     'Actualizar Usuario':           props<{ id: string; data: ActualizarUsuarioRequest }>(),
-    'Actualizar Usuario Exitoso':   props<{ usuario: Usuario }>(),
+    'Actualizar Usuario Exitoso':   props<{ usuario: UsuarioDetalle }>(),
     'Actualizar Usuario Fallido':   props<{ error: string }>(),
 
     // ── Eliminar ──────────────────────────────────────────────────────────────
@@ -39,17 +40,17 @@ export const UsuariosActions = createActionGroup({
 
     // ── Activar ───────────────────────────────────────────────────────────────
     'Activar Usuario':              props<{ id: string }>(),
-    'Activar Usuario Exitoso':      props<{ usuario: Usuario }>(),
+    'Activar Usuario Exitoso':      props<{ usuario: UsuarioDetalle }>(),
     'Activar Usuario Fallido':      props<{ error: string }>(),
 
     // ── Desactivar ────────────────────────────────────────────────────────────
     'Desactivar Usuario':           props<{ id: string }>(),
-    'Desactivar Usuario Exitoso':   props<{ usuario: Usuario }>(),
+    'Desactivar Usuario Exitoso':   props<{ usuario: UsuarioDetalle }>(),
     'Desactivar Usuario Fallido':   props<{ error: string }>(),
 
     // ── Desbloquear cuenta ────────────────────────────────────────────────────
     'Desbloquear Cuenta':           props<{ id: string }>(),
-    'Desbloquear Cuenta Exitoso':   props<{ usuario: Usuario }>(),
+    'Desbloquear Cuenta Exitoso':   props<{ usuario: UsuarioDetalle }>(),
     'Desbloquear Cuenta Fallido':   props<{ error: string }>(),
 
     // ── Importar masivo ───────────────────────────────────────────────────────
@@ -63,7 +64,7 @@ export const UsuariosActions = createActionGroup({
     'Exportar Usuarios Fallido':    props<{ error: string }>(),
 
     // ── Selección local ───────────────────────────────────────────────────────
-    'Seleccionar Usuario':          props<{ usuario: Usuario }>(),
+    'Seleccionar Usuario':          props<{ usuario: UsuarioDetalle }>(),
     'Limpiar Seleccion':            emptyProps(),
   },
 });

--- a/libs/auth/usuarios/src/lib/data-access/store/reducers/usuarios.reducer.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/reducers/usuarios.reducer.ts
@@ -1,12 +1,11 @@
 import { createFeature, createReducer, on } from '@ngrx/store';
-import { Usuario } from '@restaurant/shared/models';
-import { ImportarUsuariosResponse, RolOpcion } from '../../../models/usuarios.model';
+import { ImportarUsuariosResponse, RolOpcion, UsuarioDetalle } from '../../../models/usuarios.model';
 import { UsuariosActions } from '../actions/usuarios.actions';
 
 export interface UsuariosState {
-  usuarios:            Usuario[];
+  usuarios:            UsuarioDetalle[];
   roles:               RolOpcion[];
-  usuarioSeleccionado: Usuario | null;
+  usuarioSeleccionado: UsuarioDetalle | null;
   totalElements:       number;
   totalPages:          number;
   paginaActual:        number;
@@ -53,12 +52,8 @@ export const usuariosFeature = createFeature({
     })),
 
     // ── Cargar roles ──────────────────────────────────────────────────────────
-    on(UsuariosActions.cargarRolesExitoso, (state, { roles }) => ({
-      ...state, roles,
-    })),
-    on(UsuariosActions.cargarRolesFallido, (state, { error }) => ({
-      ...state, error,
-    })),
+    on(UsuariosActions.cargarRolesExitoso, (state, { roles }) => ({ ...state, roles })),
+    on(UsuariosActions.cargarRolesFallido, (state, { error }) => ({ ...state, error })),
 
     // ── Crear ─────────────────────────────────────────────────────────────────
     on(UsuariosActions.crearUsuario, state => ({

--- a/libs/auth/usuarios/src/lib/data-access/usuarios.facade.ts
+++ b/libs/auth/usuarios/src/lib/data-access/usuarios.facade.ts
@@ -1,12 +1,12 @@
 import { inject, Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Usuario } from '@restaurant/shared/models';
 import { AppState } from '@restaurant/shared/state';
 import {
   ActualizarUsuarioRequest,
   CrearUsuarioRequest,
   FiltrosUsuarios,
   ImportarUsuariosRequest,
+  UsuarioDetalle,
 } from '../models/usuarios.model';
 import { UsuariosActions } from './store/actions/usuarios.actions';
 import { UsuariosState } from './store/reducers/usuarios.reducer';
@@ -14,8 +14,8 @@ import {
   selectError,
   selectHayError,
   selectImportando,
-  selectLoadingAccion,
   selectLoading,
+  selectLoadingAccion,
   selectResultadoImport,
   selectRoles,
   selectTotalActivos,
@@ -86,7 +86,7 @@ export class UsuariosFacade {
     this.store.dispatch(UsuariosActions.exportarUsuarios());
   }
 
-  seleccionarUsuario(usuario: Usuario): void {
+  seleccionarUsuario(usuario: UsuarioDetalle): void {
     this.store.dispatch(UsuariosActions.seleccionarUsuario({ usuario }));
   }
 

--- a/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
+++ b/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { BaseHttpService } from '@restaurant/shared/api';
-import { Usuario, PaginatedResponse } from '@restaurant/shared/models';
+import { PaginatedResponse } from '@restaurant/shared/models';
 import {
   ActualizarUsuarioRequest,
   CrearUsuarioRequest,
@@ -10,51 +10,52 @@ import {
   ImportarUsuariosRequest,
   ImportarUsuariosResponse,
   RolOpcion,
+  UsuarioDetalle,
 } from '../models/usuarios.model';
 
 @Injectable({ providedIn: 'root' })
 export class UsuariosService extends BaseHttpService {
   private readonly resource = 'usuarios';
 
-  getUsuarios(filtros?: Partial<FiltrosUsuarios>): Observable<PaginatedResponse<Usuario>> {
+  getUsuarios(filtros?: Partial<FiltrosUsuarios>): Observable<PaginatedResponse<UsuarioDetalle>> {
     let params = new HttpParams();
-    if (filtros?.busqueda) params = params.set('busqueda', filtros.busqueda);
-    if (filtros?.rol)      params = params.set('rol', filtros.rol);
+    if (filtros?.busqueda)  params = params.set('busqueda', filtros.busqueda);
+    if (filtros?.rol)       params = params.set('rol', filtros.rol);
     if (filtros?.pagina  !== undefined) params = params.set('pagina',  String(filtros.pagina));
     if (filtros?.tamano  !== undefined) params = params.set('tamano',  String(filtros.tamano));
-    return this.http.get<PaginatedResponse<Usuario>>(this.buildUrl(this.resource), { params });
+    return this.http.get<PaginatedResponse<UsuarioDetalle>>(this.buildUrl(this.resource), { params });
   }
 
-  getUsuarioPorId(id: string): Observable<Usuario> {
-    return this.http.get<Usuario>(this.buildUrl(`${this.resource}/${id}`));
+  getUsuarioPorId(id: string): Observable<UsuarioDetalle> {
+    return this.http.get<UsuarioDetalle>(this.buildUrl(`${this.resource}/${id}`));
   }
 
   getRoles(): Observable<RolOpcion[]> {
     return this.http.get<RolOpcion[]>(this.buildUrl('roles'));
   }
 
-  crearUsuario(data: CrearUsuarioRequest): Observable<Usuario> {
-    return this.http.post<Usuario>(this.buildUrl(this.resource), data);
+  crearUsuario(data: CrearUsuarioRequest): Observable<UsuarioDetalle> {
+    return this.http.post<UsuarioDetalle>(this.buildUrl(this.resource), data);
   }
 
-  actualizarUsuario(id: string, data: ActualizarUsuarioRequest): Observable<Usuario> {
-    return this.http.put<Usuario>(this.buildUrl(`${this.resource}/${id}`), data);
+  actualizarUsuario(id: string, data: ActualizarUsuarioRequest): Observable<UsuarioDetalle> {
+    return this.http.put<UsuarioDetalle>(this.buildUrl(`${this.resource}/${id}`), data);
   }
 
   eliminarUsuario(id: string): Observable<void> {
     return this.http.delete<void>(this.buildUrl(`${this.resource}/${id}`));
   }
 
-  activarUsuario(id: string): Observable<Usuario> {
-    return this.http.patch<Usuario>(this.buildUrl(`${this.resource}/${id}/activar`), {});
+  activarUsuario(id: string): Observable<UsuarioDetalle> {
+    return this.http.patch<UsuarioDetalle>(this.buildUrl(`${this.resource}/${id}/activar`), {});
   }
 
-  desactivarUsuario(id: string): Observable<Usuario> {
-    return this.http.patch<Usuario>(this.buildUrl(`${this.resource}/${id}/desactivar`), {});
+  desactivarUsuario(id: string): Observable<UsuarioDetalle> {
+    return this.http.patch<UsuarioDetalle>(this.buildUrl(`${this.resource}/${id}/desactivar`), {});
   }
 
-  desbloquearCuenta(id: string): Observable<Usuario> {
-    return this.http.patch<Usuario>(this.buildUrl(`${this.resource}/${id}/desbloquear`), {});
+  desbloquearCuenta(id: string): Observable<UsuarioDetalle> {
+    return this.http.patch<UsuarioDetalle>(this.buildUrl(`${this.resource}/${id}/desbloquear`), {});
   }
 
   importarMasivo(request: ImportarUsuariosRequest): Observable<ImportarUsuariosResponse> {

--- a/libs/auth/usuarios/src/lib/models/usuarios.model.ts
+++ b/libs/auth/usuarios/src/lib/models/usuarios.model.ts
@@ -1,3 +1,14 @@
+import { Usuario } from '@restaurant/shared/models';
+
+export interface UsuarioDetalle extends Usuario {
+  apellidos:        string;
+  documento:        string;
+  telefono:         string;
+  ultimoAcceso:     string | null;
+  cuentaBloqueada:  boolean;
+  intentosFallidos: number;
+}
+
 export interface CrearUsuarioRequest {
   documento:  string;
   nombre:     string;
@@ -36,4 +47,10 @@ export interface ImportarUsuariosResponse {
   exitosos: number;
   fallidos: number;
   errores:  string[];
+}
+
+export interface ExportarConfig {
+  formato:          'excel' | 'csv';
+  incluirInactivos: boolean;
+  rol:              string;
 }

--- a/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.html
@@ -1,1 +1,150 @@
-<p>lista-page.component works!</p>
+<div class="lista-page">
+
+  <!-- Page Header -->
+  <div class="lista-page__header">
+    <div class="lista-page__header-text">
+      <h1 class="lista-page__title">Gestión de Usuarios</h1>
+      <p class="lista-page__subtitle">Administrá los accesos y roles del equipo</p>
+    </div>
+    <div class="lista-page__header-actions">
+      <button class="lista-page__btn lista-page__btn--ghost" type="button" (click)="mostrarImportar.set(true)">
+        <lucide-icon name="upload" [size]="16"></lucide-icon>
+        Importar
+      </button>
+      <button class="lista-page__btn lista-page__btn--ghost" type="button" (click)="mostrarExportar.set(true)">
+        <lucide-icon name="download" [size]="16"></lucide-icon>
+        Exportar
+      </button>
+      <button class="lista-page__btn lista-page__btn--primary" type="button">
+        <lucide-icon name="user-plus" [size]="16"></lucide-icon>
+        Nuevo Usuario
+      </button>
+    </div>
+  </div>
+
+  <!-- KPI Cards -->
+  <div class="lista-page__kpis">
+    <restaurant-kpi-card
+      label="Total Usuarios"
+      [value]="totalElements().toString()"
+      icon="users"
+      iconColor="blue"
+    ></restaurant-kpi-card>
+    <restaurant-kpi-card
+      label="Activos"
+      [value]="totalActivos().toString()"
+      icon="user-check"
+      iconColor="green"
+    ></restaurant-kpi-card>
+    <restaurant-kpi-card
+      label="Inactivos"
+      [value]="totalInactivos().toString()"
+      icon="user-x"
+      iconColor="red"
+    ></restaurant-kpi-card>
+  </div>
+
+  <!-- Filtros -->
+  <div class="lista-page__filters">
+    <restaurant-search-filter
+      label="Buscar"
+      placeholder="Nombre, email o documento..."
+      [value]="busqueda()"
+      (valueChange)="busqueda.set($event)"
+    ></restaurant-search-filter>
+    <restaurant-select-filter
+      label="Rol"
+      [value]="rolFiltro()"
+      [options]="rolOpciones"
+      (valueChange)="rolFiltro.set($event)"
+    ></restaurant-select-filter>
+  </div>
+
+  <!-- Tabla -->
+  <restaurant-data-table>
+    <thead>
+      <tr>
+        <th>Usuario</th>
+        <th>Rol</th>
+        <th>Estado</th>
+        <th>Último acceso</th>
+        <th>Acciones</th>
+      </tr>
+    </thead>
+    <tbody>
+      @if (loading()) {
+        <tr>
+          <td colspan="5" class="lista-page__loading">
+            <lucide-icon name="loader-circle" [size]="20"></lucide-icon>
+            Cargando usuarios...
+          </td>
+        </tr>
+      } @else if (usuariosFiltrados().length === 0) {
+        <tr>
+          <td colspan="5" class="lista-page__empty">Sin resultados</td>
+        </tr>
+      } @else {
+        @for (u of usuariosFiltrados(); track u.id) {
+          <tr>
+            <td>
+              <div class="lista-page__user">
+                <div class="lista-page__avatar">{{ getIniciales(u) }}</div>
+                <div>
+                  <p class="lista-page__user-name">{{ u.nombre }} {{ u.apellidos }}</p>
+                  <p class="lista-page__user-email">{{ u.email }}</p>
+                </div>
+              </div>
+            </td>
+            <td>
+              <span class="lista-page__badge lista-page__badge--{{ getRolClass(u.rol) }}">
+                {{ u.rol }}
+              </span>
+            </td>
+            <td>
+              <span
+                class="lista-page__badge"
+                [class.lista-page__badge--activo]="u.activo"
+                [class.lista-page__badge--inactivo]="!u.activo"
+              >
+                {{ u.activo ? 'Activo' : 'Inactivo' }}
+              </span>
+            </td>
+            <td class="lista-page__last-access">{{ formatUltimoAcceso(u.ultimoAcceso) }}</td>
+            <td>
+              <div class="lista-page__actions">
+                <button class="lista-page__action-btn" type="button" aria-label="Editar">
+                  <lucide-icon name="pencil" [size]="16"></lucide-icon>
+                </button>
+                <button
+                  class="lista-page__action-btn lista-page__action-btn--danger"
+                  type="button"
+                  (click)="onEliminar(u.id)"
+                  aria-label="Eliminar"
+                >
+                  <lucide-icon name="trash-2" [size]="16"></lucide-icon>
+                </button>
+              </div>
+            </td>
+          </tr>
+        }
+      }
+    </tbody>
+  </restaurant-data-table>
+
+</div>
+
+<!-- Modals -->
+@if (mostrarExportar()) {
+  <restaurant-exportar-usuarios
+    [totalUsuarios]="totalElements()"
+    (cerrar)="mostrarExportar.set(false)"
+    (exportar)="onExportar($event)"
+  ></restaurant-exportar-usuarios>
+}
+
+@if (mostrarImportar()) {
+  <restaurant-importar-usuarios
+    (cerrar)="mostrarImportar.set(false)"
+    (importar)="onImportar($event)"
+  ></restaurant-importar-usuarios>
+}

--- a/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.scss
@@ -1,0 +1,231 @@
+.lista-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: var(--space-6);
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+  }
+
+  &__header-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  &__title {
+    font-family: var(--font-family-headline);
+    font-size: var(--font-size-2xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-heading);
+    margin: 0;
+    line-height: 1.2;
+  }
+
+  &__subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  &__header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+
+  &__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    font-family: var(--font-family-base);
+    cursor: pointer;
+    border: none;
+    transition: background var(--duration-fast) var(--ease-standard),
+                box-shadow  var(--duration-fast) var(--ease-standard);
+
+    &--ghost {
+      background: transparent;
+      color: var(--color-text-secondary);
+      border: 1px solid var(--color-border);
+
+      &:hover {
+        background: var(--color-superficie-contenedor);
+        color: var(--color-text-primary);
+      }
+    }
+
+    &--primary {
+      background: var(--color-primario);
+      color: var(--color-en-primario);
+
+      &:hover {
+        background: var(--color-primario-hover);
+        box-shadow: var(--shadow-primary);
+      }
+    }
+  }
+
+  &__kpis {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-4);
+  }
+
+  &__filters {
+    display: flex;
+    gap: var(--space-4);
+    align-items: flex-end;
+    flex-wrap: wrap;
+  }
+
+  // Table cells
+
+  &__loading,
+  &__empty {
+    text-align: center;
+    padding: var(--space-10, var(--space-8));
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+
+    lucide-icon {
+      vertical-align: middle;
+      margin-right: var(--space-1);
+    }
+  }
+
+  &__user {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  &__avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--color-primario);
+    color: var(--color-en-primario);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    flex-shrink: 0;
+    letter-spacing: 0.5px;
+  }
+
+  &__user-name {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+    margin: 0;
+  }
+
+  &__user-email {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  &__badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-full);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    white-space: nowrap;
+
+    // Status
+    &--activo {
+      background: var(--color-success-bg);
+      color: var(--color-success-text);
+    }
+
+    &--inactivo {
+      background: var(--color-error-bg);
+      color: var(--color-error-text);
+    }
+
+    // Roles
+    &--admin {
+      background: var(--color-info-bg);
+      color: var(--color-info-text);
+    }
+
+    &--contadora,
+    &--instructor {
+      background: var(--color-brand-primary-soft);
+      color: var(--color-brand-primary-strong);
+    }
+
+    &--chef,
+    &--lider-bar,
+    &--admin-cocina,
+    &--admin-bar {
+      background: var(--color-warning-bg);
+      color: var(--color-warning-text);
+    }
+
+    &--cajero {
+      background: var(--color-error-bg);
+      color: var(--color-error-text);
+    }
+
+    &--mesero,
+    &--bartender,
+    &--aux-cocina,
+    &--default {
+      background: var(--color-superficie-contenedor);
+      color: var(--color-text-secondary);
+    }
+  }
+
+  &__last-access {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+  }
+
+  &__action-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: transparent;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    transition: background var(--duration-fast) var(--ease-standard),
+                color    var(--duration-fast) var(--ease-standard);
+
+    &:hover {
+      background: var(--color-superficie-contenedor);
+      color: var(--color-text-primary);
+    }
+
+    &--danger:hover {
+      background: var(--color-error-bg);
+      color: var(--color-error-text);
+    }
+  }
+}

--- a/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.ts
@@ -1,10 +1,134 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Rol } from '@restaurant/shared/models';
+import {
+  DataTableComponent,
+  KpiCardComponent,
+  LucideIconComponent,
+  SearchFilterComponent,
+  SelectFilterComponent,
+} from '@restaurant/shared/ui';
+import { ExportarUsuariosComponent } from '../../components/exportar-usuarios/exportar-usuarios.component';
+import { ImportarUsuariosComponent } from '../../components/importar-usuarios/importar-usuarios.component';
+import { UsuariosFacade } from '../../data-access/usuarios.facade';
+import {
+  ExportarConfig,
+  ImportarUsuariosRequest,
+  UsuarioDetalle,
+} from '../../models/usuarios.model';
+
+const ROL_OPCIONES_FILTRO = [
+  { value: '',                    label: 'Todos los roles'  },
+  { value: Rol.ADMINISTRADOR,     label: 'Administrador'    },
+  { value: Rol.CHEF,              label: 'Chef'             },
+  { value: Rol.MESERO,            label: 'Mesero'           },
+  { value: Rol.BARTENDER,         label: 'Bartender'        },
+  { value: Rol.CAJERO,            label: 'Cajero'           },
+  { value: Rol.CONTADORA,         label: 'Contadora'        },
+  { value: Rol.INSTRUCTOR,        label: 'Instructor'       },
+  { value: Rol.LIDER_BAR,         label: 'Líder Bar'        },
+  { value: Rol.AUXILIAR_COCINA,   label: 'Aux. Cocina'      },
+  { value: Rol.ADMIN_COCINA,      label: 'Admin Cocina'     },
+  { value: Rol.ADMIN_BAR,         label: 'Admin Bar'        },
+];
+
+const ROL_CLASS_MAP: Record<Rol, string> = {
+  [Rol.ADMINISTRADOR]:   'admin',
+  [Rol.CONTADORA]:       'contadora',
+  [Rol.INSTRUCTOR]:      'instructor',
+  [Rol.CHEF]:            'chef',
+  [Rol.LIDER_BAR]:       'lider-bar',
+  [Rol.MESERO]:          'mesero',
+  [Rol.BARTENDER]:       'bartender',
+  [Rol.AUXILIAR_COCINA]: 'aux-cocina',
+  [Rol.CAJERO]:          'cajero',
+  [Rol.ADMIN_COCINA]:    'admin-cocina',
+  [Rol.ADMIN_BAR]:       'admin-bar',
+};
 
 @Component({
-  selector: 'app-lista-page',
-  imports: [CommonModule],
+  selector: 'restaurant-lista-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DataTableComponent,
+    KpiCardComponent,
+    LucideIconComponent,
+    SearchFilterComponent,
+    SelectFilterComponent,
+    ExportarUsuariosComponent,
+    ImportarUsuariosComponent,
+  ],
   templateUrl: './lista-page.component.html',
-  styleUrl: './lista-page.component.scss',
+  styleUrl:    './lista-page.component.scss',
 })
-export class ListaPageComponent {}
+export class ListaPageComponent implements OnInit {
+  private readonly facade = inject(UsuariosFacade);
+
+  readonly usuarios       = toSignal(this.facade.usuarios$,       { initialValue: [] as UsuarioDetalle[] });
+  readonly totalElements  = toSignal(this.facade.totalElements$,  { initialValue: 0 });
+  readonly totalActivos   = toSignal(this.facade.totalActivos$,   { initialValue: 0 });
+  readonly totalInactivos = toSignal(this.facade.totalInactivos$, { initialValue: 0 });
+  readonly loading        = toSignal(this.facade.loading$,        { initialValue: false });
+
+  readonly busqueda        = signal('');
+  readonly rolFiltro       = signal('');
+  readonly mostrarExportar = signal(false);
+  readonly mostrarImportar = signal(false);
+
+  readonly rolOpciones = ROL_OPCIONES_FILTRO;
+
+  readonly usuariosFiltrados = computed(() => {
+    const q   = this.busqueda().toLowerCase();
+    const rol = this.rolFiltro();
+    return this.usuarios().filter(u => {
+      const matchBusq = !q ||
+        u.nombre.toLowerCase().includes(q) ||
+        u.apellidos.toLowerCase().includes(q) ||
+        u.email.toLowerCase().includes(q);
+      const matchRol = !rol || u.rol === rol;
+      return matchBusq && matchRol;
+    });
+  });
+
+  ngOnInit(): void {
+    this.facade.cargarUsuarios();
+  }
+
+  getIniciales(u: UsuarioDetalle): string {
+    return (u.nombre.charAt(0) + u.apellidos.charAt(0)).toUpperCase();
+  }
+
+  getRolClass(rol: Rol): string {
+    return ROL_CLASS_MAP[rol] ?? 'default';
+  }
+
+  formatUltimoAcceso(fecha: string | null): string {
+    if (!fecha) return '—';
+    return new Date(fecha).toLocaleDateString('es-AR', {
+      day: '2-digit', month: 'short', year: 'numeric',
+    });
+  }
+
+  onExportar(config: ExportarConfig): void {
+    void config;
+    this.facade.exportarUsuarios();
+    this.mostrarExportar.set(false);
+  }
+
+  onImportar(req: ImportarUsuariosRequest): void {
+    this.facade.importarMasivo(req);
+    this.mostrarImportar.set(false);
+  }
+
+  onEliminar(id: string): void {
+    this.facade.eliminarUsuario(id);
+  }
+}

--- a/libs/auth/usuarios/src/lib/usuarios.routes.ts
+++ b/libs/auth/usuarios/src/lib/usuarios.routes.ts
@@ -1,9 +1,11 @@
 import { Routes } from '@angular/router';
-import { UsuariosPageComponent } from './ui/usuarios-page.component';
 
 export const USUARIOS_ROUTES: Routes = [
   {
     path: '',
-    component: UsuariosPageComponent,
+    loadComponent: () =>
+      import('./pages/lista-page/lista-page.component').then(
+        m => m.ListaPageComponent,
+      ),
   },
 ];


### PR DESCRIPTION
## Descripción
Implementa la página principal de gestión de usuarios con tabla,
filtros, KPIs y modales de importar/exportar.

## Tipo de cambio
- [x] `feat` — nueva funcionalidad

## Scope
- [x] `auth` · [x] `usuarios`

## Checklist obligatorio
- [x] `nx affected:lint --base=develop` → 0 errores
- [x] PR tiene menos de 400 líneas modificadas
- [x] Un solo scope tocado
- [x] Sin `any` en TypeScript
- [x] Sin estilos inline en templates
- [x] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
- Implementé lista-page con header, KPI cards, búsqueda y filtro por rol
- Tabla con avatar circular, badges de rol con colores por rol, estado, acciones
- Modal exportar con formato Excel/CSV, filtros y preview de cantidad
- Modal importar con drag & drop, nota de formato esperado
- Rutas lazy actualizadas con provideState y provideEffects

## RF relacionado
RF2.1 — Vista lista de usuarios funcional
