### PR TITLE
docs(readme): agregar link al mapa de navegacion

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Monorepo Angular 20 + Nx para el sistema de gestión del restaurante SENA (23 de
 | [Migración inventario](docs/inventario-migracion-monorepo.md) | Notas de migración del módulo inventario |
 | [Clasificación componentes inventario](docs/clasificacion-componentes-inventario.md) | Taxonomía de componentes |
 | [Shared UI Showcase](docs/shared-ui-showcase.md) | Guía del showcase visual para documentar `shared/ui` |
+| [Mapa de navegación](.ai/nav-map.md) | Rutas, estado por módulo y progreso por RF |
 
 ## Gobernanza de IA
 


### PR DESCRIPTION
Closes #95

## Tipo de cambio
- [x] `docs` — documentación únicamente

## Cambios

| Archivo | Cambio |
|---------|--------|
| `README.md` | Una línea agregada en la tabla de documentación |

## Test plan

- [x] Link relativo `.ai/nav-map.md` funciona desde la raíz del repo en GitHub