### PR TITLE
fix(restaurante): corregir iconos y ruta en paginas de caja

### DIFF
--- a/libs/restaurante/restaurante/src/lib/pages/caja-apertura-page/caja-apertura-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/caja-apertura-page/caja-apertura-page.component.html
@@ -34,7 +34,7 @@
           Cancelar
         </restaurant-button>
         <restaurant-button variant="primary" (click)="confirmarApertura()" [disabled]="baseInicialCtrl.invalid || facade.turnoCaja()?.estado === 'ABIERTA'">
-          <lucide-icon name="unlock" [size]="18"></lucide-icon>
+          <lucide-icon name="log-in" [size]="18"></lucide-icon>
           <span>Abrir Caja</span>
         </restaurant-button>
       </div>

--- a/libs/restaurante/restaurante/src/lib/pages/caja-movimientos-page/caja-movimientos-page.component.ts
+++ b/libs/restaurante/restaurante/src/lib/pages/caja-movimientos-page/caja-movimientos-page.component.ts
@@ -24,6 +24,6 @@ export class CajaMovimientosPageComponent {
   private router = inject(Router);
 
   volver() {
-    this.router.navigate(['/restaurante/caja']);
+    this.router.navigate(['/app/restaurante/caja']);
   }
 }

--- a/libs/restaurante/restaurante/src/lib/pages/caja-pagar-page/caja-pagar-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/caja-pagar-page/caja-pagar-page.component.html
@@ -120,7 +120,7 @@
               <div class="method-option"
                 [class.active]="metodoSeleccionado() === 'Transferencia'"
                 (click)="seleccionarMetodo('Transferencia')">
-                <lucide-icon name="smartphone" [size]="24"></lucide-icon>
+                <lucide-icon name="send" [size]="24"></lucide-icon>
                 <span>Transferencia</span>
               </div>
             </div>

--- a/libs/restaurante/restaurante/src/lib/pages/caja-page/caja-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/caja-page/caja-page.component.html
@@ -33,7 +33,7 @@
       label="Facturas Hoy"
       [value]="stats.facturasHoy.toString()"
       icon="file-text"
-      iconColor="purple"
+      iconColor="red"
     ></restaurant-kpi-card>
 
     <restaurant-kpi-card
@@ -108,12 +108,12 @@
       <!-- Action Card: Apertura -->
       <div class="action-card opening-card">
         <div class="action-header">
-          <lucide-icon name="unlock" [size]="24" class="icon-orange"></lucide-icon>
+          <lucide-icon name="log-in" [size]="24" class="icon-orange"></lucide-icon>
           <h3 class="text-orange">Apertura de Caja</h3>
         </div>
         <p class="action-desc">Definir fondo base e iniciar turno</p>
         <restaurant-button variant="primary" class="full-width" (click)="irAApertura()">
-          <lucide-icon name="unlock" [size]="18"></lucide-icon>
+          <lucide-icon name="log-in" [size]="18"></lucide-icon>
           <span>Abrir Caja</span>
         </restaurant-button>
       </div>
@@ -121,12 +121,12 @@
       <!-- Action Card: Movimientos -->
       <div class="action-card movements-card">
         <div class="action-header">
-          <lucide-icon name="arrow-right-left" [size]="24" class="icon-gray"></lucide-icon>
+          <lucide-icon name="arrow-left-right" [size]="24" class="icon-gray"></lucide-icon>
           <h3 class="text-gray">Movimientos</h3>
         </div>
         <p class="action-desc">Ingresos y egresos de caja menor</p>
         <restaurant-button variant="primary" class="full-width" (click)="irAMovimientos()" [disabled]="!facade.isCajaAbierta()">
-          <lucide-icon name="arrow-right-left" [size]="18"></lucide-icon>
+          <lucide-icon name="arrow-left-right" [size]="18"></lucide-icon>
           <span>Registrar Movimiento</span>
         </restaurant-button>
       </div>
@@ -134,12 +134,12 @@
       <!-- Action Card: Cierre -->
       <div class="action-card closing-card">
         <div class="action-header">
-          <lucide-icon name="lock" [size]="24" class="icon-red"></lucide-icon>
+          <lucide-icon name="log-out" [size]="24" class="icon-red"></lucide-icon>
           <h3 class="text-red">Cierre de Caja</h3>
         </div>
         <p class="action-desc">Arqueo ciego y reporte Z del turno</p>
         <restaurant-button variant="primary" class="full-width" (click)="irACierre()" [disabled]="!facade.isCajaAbierta()">
-          <lucide-icon name="lock" [size]="18"></lucide-icon>
+          <lucide-icon name="log-out" [size]="18"></lucide-icon>
           <span>Cerrar Caja</span>
         </restaurant-button>
       </div>


### PR DESCRIPTION
Closes #105

## Tipo de cambio
- [x] Bug fix

## Resumen
- `iconColor="purple"` cambiado a `iconColor="red"` (tipo invalido para KpiCardIconColor)
- `name="unlock"` → `name="log-in"` (no registrado en RESTAURANT_UI_BASE_ICONS)
- `name="lock"` → `name="log-out"` (no registrado en RESTAURANT_UI_BASE_ICONS)
- `name="arrow-right-left"` → `name="arrow-left-right"` (nombre de icono incorrecto)
- `name="smartphone"` → `name="send"` (no registrado en RESTAURANT_UI_BASE_ICONS)
- Ruta `/restaurante/caja` → `/app/restaurante/caja` en CajaMovimientosPageComponent

## Cambios
| Archivo | Cambio |
|---------|--------|
| `caja-page.component.html` | iconColor + 4 nombres de iconos corregidos |
| `caja-apertura-page.component.html` | unlock → log-in |
| `caja-pagar-page.component.html` | smartphone → send |
| `caja-movimientos-page.component.ts` | ruta absoluta corregida |

## Test Plan
- [x] Iconos renderizan correctamente en caja dashboard
- [x] Navegacion volver() en movimientos apunta a la ruta correcta