### PR TITLE
feat(auth): implementar pagina roles y permisos con rutas completas

### DIFF
--- a/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.html
@@ -1,1 +1,20 @@
-<p>cuentas-page.component works!</p>
+<div class="cuentas-page">
+
+  <!-- Header -->
+  <div class="cuentas-page__header">
+    <h1 class="cuentas-page__title">Gestión de Cuentas</h1>
+    <p class="cuentas-page__subtitle">Bloqueo, desbloqueo e historial de accesos por usuario</p>
+  </div>
+
+  <!-- Empty state -->
+  <div class="cuentas-page__empty">
+    <div class="cuentas-page__empty-icon">
+      <lucide-icon name="shield-check" [size]="48"></lucide-icon>
+    </div>
+    <restaurant-empty-state
+      title="Funcionalidad pendiente"
+      message="Esta funcionalidad estará disponible cuando se conecte el backend. Permite bloquear/desbloquear cuentas y ver historial de accesos."
+    ></restaurant-empty-state>
+  </div>
+
+</div>

--- a/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.scss
@@ -1,0 +1,44 @@
+.cuentas-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  &__title {
+    font-family: var(--font-family-headline);
+    font-size: var(--font-size-2xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-heading);
+    margin: 0;
+  }
+
+  &__subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  &__empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+    padding: var(--space-12) var(--space-6);
+  }
+
+  &__empty-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 80px;
+    height: 80px;
+    border-radius: var(--radius-full);
+    background: var(--color-brand-primary-soft);
+    color: var(--color-brand-primary-strong);
+  }
+}

--- a/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.ts
@@ -1,10 +1,15 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { EmptyStateComponent, LucideIconComponent } from '@restaurant/shared/ui';
 
 @Component({
-  selector: 'app-cuentas-page',
-  imports: [CommonModule],
+  selector: 'restaurant-cuentas-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [EmptyStateComponent, LucideIconComponent],
   templateUrl: './cuentas-page.component.html',
-  styleUrl: './cuentas-page.component.scss',
+  styleUrl:    './cuentas-page.component.scss',
 })
 export class CuentasPageComponent {}

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.html
@@ -1,1 +1,59 @@
-<p>roles-page.component works!</p>
+<div class="roles-page">
+
+  <!-- Header -->
+  <div class="roles-page__header">
+    <div class="roles-page__header-text">
+      <h1 class="roles-page__title">Roles y Permisos</h1>
+      <p class="roles-page__subtitle">Configuración de accesos por rol del sistema</p>
+    </div>
+    <div class="roles-page__header-stats">
+      <span class="roles-page__stat">
+        <lucide-icon name="shield" [size]="16"></lucide-icon>
+        {{ totalRoles }} roles definidos
+      </span>
+      <span class="roles-page__stat">
+        <lucide-icon name="users" [size]="16"></lucide-icon>
+        {{ totalUsuarios }} usuarios activos
+      </span>
+    </div>
+  </div>
+
+  <!-- Grid de roles -->
+  <div class="roles-page__grid">
+    @for (item of roles; track item.rol) {
+      <div class="roles-page__card roles-page__card--{{ getRolClass(item.rol) }}">
+
+        <!-- Card header -->
+        <div class="roles-page__card-header">
+          <div class="roles-page__card-icon">
+            <lucide-icon [name]="item.icono" [size]="22"></lucide-icon>
+          </div>
+          <div class="roles-page__card-meta">
+            <h3 class="roles-page__card-title">{{ item.rol }}</h3>
+            <p class="roles-page__card-desc">{{ item.descripcion }}</p>
+          </div>
+        </div>
+
+        <!-- Permisos -->
+        <ul class="roles-page__permisos">
+          @for (permiso of item.permisos; track permiso) {
+            <li class="roles-page__permiso">
+              <lucide-icon name="check" [size]="13" class="roles-page__permiso-icon"></lucide-icon>
+              <span>{{ permiso }}</span>
+            </li>
+          }
+        </ul>
+
+        <!-- Footer -->
+        <div class="roles-page__card-footer">
+          <lucide-icon name="users" [size]="14" class="roles-page__footer-icon"></lucide-icon>
+          <span class="roles-page__footer-label">
+            {{ item.totalUsuarios }} usuario{{ item.totalUsuarios === 1 ? '' : 's' }}
+          </span>
+        </div>
+
+      </div>
+    }
+  </div>
+
+</div>

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.scss
@@ -1,0 +1,190 @@
+.roles-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+
+  // ── Header ────────────────────────────────────────────────────────────────
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+  }
+
+  &__header-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  &__title {
+    font-family: var(--font-family-headline);
+    font-size: var(--font-size-2xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-heading);
+    margin: 0;
+  }
+
+  &__subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  &__header-stats {
+    display: flex;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+  }
+
+  &__stat {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    background: var(--color-superficie-contenedor-bajo);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-full);
+    padding: var(--space-1) var(--space-3);
+  }
+
+  // ── Grid ──────────────────────────────────────────────────────────────────
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-5);
+
+    @media (max-width: 1024px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media (max-width: 640px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  // ── Card ──────────────────────────────────────────────────────────────────
+
+  &__card {
+    --card-accent: var(--color-brand-primary-strong);
+
+    background: var(--color-surface-primary);
+    border-radius: var(--radius-xl);
+    border: 1px solid var(--color-border);
+    box-shadow: var(--shadow-sm);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-top: 3px solid var(--card-accent);
+    transition: box-shadow var(--duration-fast) var(--ease-standard),
+                transform   var(--duration-fast) var(--ease-standard);
+
+    &:hover {
+      box-shadow: var(--shadow-md);
+      transform: translateY(-2px);
+    }
+
+    // ── Per-role accent colors ─────────────────────────────────────────────
+
+    &--admin      { --card-accent: var(--color-rol-administrador); }
+    &--contadora  { --card-accent: var(--color-rol-contadora); }
+    &--instructor { --card-accent: var(--color-rol-instructor); }
+    &--chef       { --card-accent: var(--color-rol-chef); }
+    &--lider-bar  { --card-accent: var(--color-rol-lider-bar); }
+    &--mesero     { --card-accent: var(--color-rol-mesero); }
+    &--bartender  { --card-accent: var(--color-rol-bartender); }
+    &--auxiliar   { --card-accent: var(--color-rol-auxiliar); }
+    &--cajero     { --card-accent: var(--color-rol-cajero); }
+  }
+
+  &__card-header {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-4) var(--space-3);
+  }
+
+  &__card-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--card-accent) 12%, transparent);
+    color: var(--card-accent);
+    flex-shrink: 0;
+  }
+
+  &__card-meta {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__card-title {
+    font-family: var(--font-family-headline);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-heading);
+    margin: 0 0 var(--space-1);
+    word-break: break-word;
+  }
+
+  &__card-desc {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  // ── Permisos list ─────────────────────────────────────────────────────────
+
+  &__permisos {
+    list-style: none;
+    margin: 0;
+    padding: var(--space-1) var(--space-4) var(--space-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    flex: 1;
+  }
+
+  &__permiso {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--font-size-xs);
+    color: var(--color-text-primary);
+  }
+
+  &__permiso-icon {
+    color: var(--card-accent);
+    flex-shrink: 0;
+  }
+
+  // ── Card footer ───────────────────────────────────────────────────────────
+
+  &__card-footer {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border-top: 1px solid var(--color-border);
+    background: var(--color-superficie-contenedor-bajo);
+  }
+
+  &__footer-icon {
+    color: var(--color-text-secondary);
+    flex-shrink: 0;
+  }
+
+  &__footer-label {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-secondary);
+  }
+}

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.ts
@@ -1,10 +1,113 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { Rol } from '@restaurant/shared/models';
+import { LucideIconComponent } from '@restaurant/shared/ui';
+
+interface RolInfo {
+  readonly rol:           Rol;
+  readonly icono:         string;
+  readonly descripcion:   string;
+  readonly permisos:      readonly string[];
+  readonly totalUsuarios: number;
+}
+
+const ROL_CSS_CLASS: Record<Rol, string> = {
+  [Rol.ADMINISTRADOR]:   'admin',
+  [Rol.CONTADORA]:       'contadora',
+  [Rol.INSTRUCTOR]:      'instructor',
+  [Rol.CHEF]:            'chef',
+  [Rol.LIDER_BAR]:       'lider-bar',
+  [Rol.MESERO]:          'mesero',
+  [Rol.BARTENDER]:       'bartender',
+  [Rol.AUXILIAR_COCINA]: 'auxiliar',
+  [Rol.CAJERO]:          'cajero',
+  [Rol.ADMIN_COCINA]:    'admin-cocina',
+  [Rol.ADMIN_BAR]:       'admin-bar',
+};
+
+const MOCK_ROLES: readonly RolInfo[] = [
+  {
+    rol: Rol.ADMINISTRADOR,
+    icono: 'shield',
+    descripcion: 'Acceso total al sistema',
+    permisos: ['Gestión de usuarios', 'Reportes completos', 'Configuración del sistema', 'Inventario', 'Caja'],
+    totalUsuarios: 1,
+  },
+  {
+    rol: Rol.CONTADORA,
+    icono: 'banknote',
+    descripcion: 'Gestión financiera y reportes',
+    permisos: ['Reportes financieros', 'Presupuesto', 'Facturas', 'Caja'],
+    totalUsuarios: 1,
+  },
+  {
+    rol: Rol.INSTRUCTOR,
+    icono: 'graduation-cap',
+    descripcion: 'Gestión académica y evaluaciones',
+    permisos: ['Evaluaciones', 'Actividades', 'Recetas', 'Reportes académicos'],
+    totalUsuarios: 2,
+  },
+  {
+    rol: Rol.CHEF,
+    icono: 'chef-hat',
+    descripcion: 'Operaciones de cocina',
+    permisos: ['Comandas', 'Recetas', 'Menú', 'Ingredientes'],
+    totalUsuarios: 3,
+  },
+  {
+    rol: Rol.LIDER_BAR,
+    icono: 'coffee',
+    descripcion: 'Operaciones de bar y barismo',
+    permisos: ['Comandas bar', 'Recetas bebidas', 'Menú bar'],
+    totalUsuarios: 1,
+  },
+  {
+    rol: Rol.MESERO,
+    icono: 'utensils',
+    descripcion: 'Atención al cliente',
+    permisos: ['Mesas', 'Pedidos', 'Comandas'],
+    totalUsuarios: 3,
+  },
+  {
+    rol: Rol.BARTENDER,
+    icono: 'glass-water',
+    descripcion: 'Preparación de bebidas',
+    permisos: ['Comandas bar', 'Recetas bebidas'],
+    totalUsuarios: 2,
+  },
+  {
+    rol: Rol.AUXILIAR_COCINA,
+    icono: 'package',
+    descripcion: 'Apoyo en operaciones de cocina',
+    permisos: ['Comandas', 'Ingredientes'],
+    totalUsuarios: 2,
+  },
+  {
+    rol: Rol.CAJERO,
+    icono: 'calculator',
+    descripcion: 'Gestión de caja y pagos',
+    permisos: ['Caja', 'Pagos', 'Facturas'],
+    totalUsuarios: 2,
+  },
+];
 
 @Component({
-  selector: 'app-roles-page',
-  imports: [CommonModule],
+  selector: 'restaurant-roles-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [LucideIconComponent],
   templateUrl: './roles-page.component.html',
-  styleUrl: './roles-page.component.scss',
+  styleUrl:    './roles-page.component.scss',
 })
-export class RolesPageComponent {}
+export class RolesPageComponent {
+  readonly roles = MOCK_ROLES;
+
+  readonly totalUsuarios = MOCK_ROLES.reduce((sum, r) => sum + r.totalUsuarios, 0);
+  readonly totalRoles    = MOCK_ROLES.length;
+
+  getRolClass(rol: Rol): string {
+    return ROL_CSS_CLASS[rol] ?? 'default';
+  }
+}

--- a/libs/auth/usuarios/src/lib/usuarios.routes.ts
+++ b/libs/auth/usuarios/src/lib/usuarios.routes.ts
@@ -21,4 +21,18 @@ export const USUARIOS_ROUTES: Routes = [
     redirectTo: '',
     pathMatch: 'full',
   },
+  {
+    path: 'roles',
+    loadComponent: () =>
+      import('./pages/roles-page/roles-page.component').then(
+        m => m.RolesPageComponent,
+      ),
+  },
+  {
+    path: 'cuentas',
+    loadComponent: () =>
+      import('./pages/cuentas-page/cuentas-page.component').then(
+        m => m.CuentasPageComponent,
+      ),
+  },
 ];

--- a/libs/auth/usuarios/src/lib/usuarios.routes.ts
+++ b/libs/auth/usuarios/src/lib/usuarios.routes.ts
@@ -21,18 +21,4 @@ export const USUARIOS_ROUTES: Routes = [
     redirectTo: '',
     pathMatch: 'full',
   },
-  {
-    path: 'roles',
-    loadComponent: () =>
-      import('./pages/roles-page/roles-page.component').then(
-        m => m.RolesPageComponent,
-      ),
-  },
-  {
-    path: 'cuentas',
-    loadComponent: () =>
-      import('./pages/cuentas-page/cuentas-page.component').then(
-        m => m.CuentasPageComponent,
-      ),
-  },
 ];


### PR DESCRIPTION
## Descripción
Implementa la página de roles y permisos del módulo usuarios
y agrega las rutas faltantes de roles y cuentas.

## Tipo de cambio
- [x] `feat` — nueva funcionalidad

## Scope
- [x] `auth` · [x] `usuarios`

## Checklist obligatorio
- [x] `nx affected:lint --base=develop` → 0 errores
- [x] PR tiene menos de 400 líneas modificadas
- [x] Un solo scope tocado
- [x] Sin `any` en TypeScript
- [x] Sin estilos inline en templates
- [x] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
- Implementé roles-page con grid de cards por rol, colores, permisos e iconos
- Implementé cuentas-page con estado vacío informativo (requiere backend)
- Agregué rutas lazy para roles y cuentas en usuarios.routes.ts

## RF relacionado
RF2.x — Roles y permisos, Gestión de cuentas
