### PR TITLE
fix(inventario): connect paquete actions to PaqueteFacade

### DIFF
--- a/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-create/paquete-create.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-create/paquete-create.component.ts
@@ -9,6 +9,7 @@ import { Router } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { LucideIconComponent } from '@restaurant/shared/ui';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
+import { PaqueteFacade } from '../../../data-access/paquete.facade';
 
 @Component({
   selector: 'restaurant-paquete-create',
@@ -20,7 +21,8 @@ import { BackButtonComponent } from '../../../components/back-button/back-button
 })
 export class PaqueteCreateComponent {
   private router = inject(Router);
-  private fb = inject(FormBuilder);
+  private fb     = inject(FormBuilder);
+  private facade = inject(PaqueteFacade);
 
   // ── Formulario ──────────────────────────────────────────────────────────
   createForm = this.fb.nonNullable.group({
@@ -60,8 +62,7 @@ export class PaqueteCreateComponent {
 
   guardarPaquete(): void {
     if (this.createForm.valid) {
-      // TODO(paquete-facade): llamar facade.crearPaquete(this.createForm.getRawValue())
-      console.warn('guardarPaquete: pendiente integración con PaqueteFacade');
+      this.facade.crearPaquete(this.createForm.getRawValue());
       this.volver();
     }
   }

--- a/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-req-detail/paquete-req-detail.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-req-detail/paquete-req-detail.component.ts
@@ -6,6 +6,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LucideIconComponent } from '@restaurant/shared/ui';
+import { PaqueteFacade } from '../../../data-access/paquete.facade';
 
 @Component({
   selector: 'restaurant-paquete-req-detail',
@@ -17,16 +18,22 @@ import { LucideIconComponent } from '@restaurant/shared/ui';
 })
 export class PaqueteReqDetailComponent {
   private router = inject(Router);
-  private route = inject(ActivatedRoute);
+  private route  = inject(ActivatedRoute);
+  private facade = inject(PaqueteFacade);
+
+  // ── Estado reactivo desde facade ─────────────────────────────────────────
+  loading = this.facade.loading;
 
   cerrarPanel(): void {
-    // Navigate relative to the parent (detail view)
     this.router.navigate(['../'], { relativeTo: this.route });
   }
 
   incluirEnPaquete(): void {
-    // TODO(paquete-facade): llamar facade.incluirRequisicionEnPaquete(...)
-    console.warn('incluirEnPaquete: pendiente integración con PaqueteFacade');
+    const paqueteId = this.route.parent?.snapshot.paramMap.get('id') ?? '';
+    const reqId     = this.route.snapshot.queryParamMap.get('reqId') ?? '';
+    if (paqueteId) {
+      this.facade.incluirRequisicion(paqueteId, reqId);
+    }
     this.cerrarPanel();
   }
 }

--- a/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-upload/paquete-upload.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-upload/paquete-upload.component.ts
@@ -8,6 +8,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LucideIconComponent } from '@restaurant/shared/ui';
+import { PaqueteFacade } from '../../../data-access/paquete.facade';
 
 @Component({
   selector: 'restaurant-paquete-upload',
@@ -19,11 +20,12 @@ import { LucideIconComponent } from '@restaurant/shared/ui';
 })
 export class PaqueteUploadComponent {
   private router = inject(Router);
-  private route = inject(ActivatedRoute);
+  private route  = inject(ActivatedRoute);
+  private facade = inject(PaqueteFacade);
 
-  isDragging = signal<boolean>(false);
+  isDragging   = signal<boolean>(false);
   selectedFile = signal<File | null>(null);
-  uploading = signal<boolean>(false);
+  uploading    = this.facade.loading;
   errorArchivo = signal<string | null>(null);
 
   // ── Drag & Drop Events ───────────────────────────────────────────────────
@@ -82,11 +84,10 @@ export class PaqueteUploadComponent {
   }
 
   subirDocumento(): void {
-    if (!this.selectedFile()) return;
-    this.uploading.set(true);
-    // TODO(paquete-facade): llamar facade.adjuntarDocumento(file)
-    console.warn('subirDocumento: pendiente integración con PaqueteFacade');
-    this.uploading.set(false);
+    const file = this.selectedFile();
+    if (!file) return;
+    const paqueteId = this.route.parent?.snapshot.paramMap.get('id') ?? '';
+    this.facade.adjuntarDocumento(paqueteId, file);
     this.cerrarModal();
   }
 }


### PR DESCRIPTION
## Summary
- **paquete-create**: `guardarPaquete()` llama `facade.crearPaquete()` con los datos del formulario reactivo; se eliminó el `console.warn`
- **paquete-upload**: `subirDocumento()` llama `facade.adjuntarDocumento(paqueteId, file)` — `paqueteId` viene del route padre (`:id`); `uploading` pasa a ser `facade.loading`; se eliminó el `console.warn`
- **paquete-req-detail**: `incluirEnPaquete()` llama `facade.incluirRequisicion(paqueteId, reqId)` — `paqueteId` del route padre, `reqId` del queryParam `reqId`; se agrega `loading = facade.loading`; se eliminó el `console.warn`

## Test plan
- [ ] Crear paquete desde el formulario y verificar que redirige al listado tras llamar a la facade
- [ ] Adjuntar un PDF/imagen desde el modal de upload y confirmar que `adjuntarDocumento` recibe el paqueteId correcto
- [ ] Navegar a `paquete-req-detail` y verificar que `incluirEnPaquete` llama la facade sin errores
- [ ] Confirmar `npx nx run inventario:lint` sin errores
- [ ] Confirmar `npx nx run restaurant-app:build` sin errores de inventario