### PR TITLE
feat(inventario): visual tasks PRE, FEL y CON-TF

### DIFF
--- a/libs/inventario/inventario/src/lib/pages/conciliacion-page/conciliacion-detalle/conciliacion-detalle.component.html
+++ b/libs/inventario/inventario/src/lib/pages/conciliacion-page/conciliacion-detalle/conciliacion-detalle.component.html
@@ -10,12 +10,6 @@
         <inventario-back-button (clicked)="goBack()" />
         <h1 class="page-title">Detalle de Conciliación</h1>
       </div>
-      <restaurant-button variant="primary">
-        <div class="btn-icon-text">
-          <lucide-icon name="download" [size]="18"></lucide-icon>
-          Exportar Acta
-        </div>
-      </restaurant-button>
     </div>
 
     <div class="info-badges-row">

--- a/libs/inventario/inventario/src/lib/pages/conciliacion-page/conciliacion-historial/conciliacion-historial.component.html
+++ b/libs/inventario/inventario/src/lib/pages/conciliacion-page/conciliacion-historial/conciliacion-historial.component.html
@@ -12,7 +12,7 @@
       </div>
     </div>
     <div class="header-actions">
-      <restaurant-button variant="ghost">
+      <restaurant-button variant="ghost" (click)="onExportar()">
         <div class="btn-icon-text">
           <lucide-icon name="download" [size]="18"></lucide-icon>
           Exportar Reporte
@@ -197,3 +197,12 @@
   </div>
 
 </div>
+
+<!-- ── MODAL: Exportar Historial ── -->
+<inventario-exportar
+  *ngIf="showExportarModal()"
+  titulo="Exportar Historial de Conciliaciones"
+  subtitulo="Seleccione el formato de salida para el reporte de auditoría"
+  (exportar)="onConfirmarExportar($event)"
+  (cerrar)="onCerrarExportar()"
+/>

--- a/libs/inventario/inventario/src/lib/pages/conciliacion-page/conciliacion-historial/conciliacion-historial.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/conciliacion-page/conciliacion-historial/conciliacion-historial.component.ts
@@ -3,6 +3,7 @@ import { CommonModule, Location } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { LucideIconComponent, ButtonComponent, DataTableComponent, KpiCardComponent } from '@restaurant/shared/ui';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
+import { ExportarComponent } from '../../../components/exportar/exportar.component';
 import { ConciliacionFacade } from '../../../data-access/conciliacion.facade';
 
 @Component({
@@ -16,6 +17,7 @@ import { ConciliacionFacade } from '../../../data-access/conciliacion.facade';
     DataTableComponent,
     KpiCardComponent,
     BackButtonComponent,
+    ExportarComponent,
   ],
   templateUrl: './conciliacion-historial.component.html',
   styleUrl: './conciliacion-historial.component.scss',
@@ -37,11 +39,27 @@ export class ConciliacionHistorialComponent implements OnInit {
     { producto: 'Carne de Res', dif: '-5 Kg', icon: 'beef' },
   ]);
 
+  showExportarModal = signal(false);
+
   ngOnInit(): void {
     this.facade.loadAll();
   }
 
   goBack(): void {
     this.location.back();
+  }
+
+  onExportar(): void {
+    this.showExportarModal.set(true);
+  }
+
+  onConfirmarExportar(formato: string): void {
+    // TODO: integrar con servicio de descarga cuando backend confirme contrato
+    console.info('[CON-TF] Exportar historial en formato:', formato);
+    this.showExportarModal.set(false);
+  }
+
+  onCerrarExportar(): void {
+    this.showExportarModal.set(false);
   }
 }

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-edit/factura-edit.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-edit/factura-edit.component.html
@@ -274,6 +274,22 @@
   </div>
 </div>
 
+<!-- ── MODAL: Confirmar Anulación ── -->
+<restaurant-keyword-confirm-modal
+  [open]="showAnularModal()"
+  title="Anular edición de FEL"
+  description="Esta acción marcará el documento como Anulado. No podrá ser revertida."
+  keyword="ANULAR"
+  keywordLabel="Escribe ANULAR para confirmar"
+  confirmLabel="Sí, anular documento"
+  cancelLabel="Cancelar"
+  [identifierLabel]="'Documento'"
+  [identifierValue]="factura()?.numeroFEL ?? ''"
+  accent="warning"
+  (confirm)="onConfirmarAnular()"
+  (cancel)="onCancelarAnular()"
+/>
+
 <!-- Loading -->
 <ng-template #loadingTpl>
   <div class="loading-state">

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-edit/factura-edit.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-edit/factura-edit.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, inject, OnInit, signal, computed, e
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { KeywordConfirmModalComponent } from '@restaurant/shared/ui';
 import { FacturasFacade } from '../../../data-access/facturas.facade';
 import { Factura, FacturaItem, ConciliacionItem, MonedaFEL } from '../../../models/facturas.model';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
@@ -9,7 +10,7 @@ import { BackButtonComponent } from '../../../components/back-button/back-button
 @Component({
   selector: 'restaurant-factura-edit',
   standalone: true,
-  imports: [CommonModule, FormsModule, BackButtonComponent],
+  imports: [CommonModule, FormsModule, BackButtonComponent, KeywordConfirmModalComponent],
   templateUrl: './factura-edit.component.html',
   styleUrl: './factura-edit.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -30,6 +31,9 @@ export class FacturaEditPageComponent implements OnInit {
   moneda        = signal<MonedaFEL>('COP');
   notasInternas = signal('');
   localItems    = signal<FacturaItem[]>([]);
+
+  // Modal de confirmación de anulación
+  showAnularModal = signal(false);
 
   isBlocked = computed(() => {
     const f = this.factura();
@@ -89,8 +93,18 @@ export class FacturaEditPageComponent implements OnInit {
   }
 
   onAnular(): void {
+    this.showAnularModal.set(true);
+  }
+
+  onConfirmarAnular(): void {
     const id = this.factura()?.id;
     if (id) this.facade.anularFactura(id);
+    this.showAnularModal.set(false);
+    this.onVolver();
+  }
+
+  onCancelarAnular(): void {
+    this.showAnularModal.set(false);
   }
 
   onGuardar(): void {

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
@@ -181,6 +181,15 @@
   (save)="onSaveFactura($event)"
 ></restaurant-factura-form>
 
+<!-- ── MODAL: Exportar Facturas ── -->
+<inventario-exportar
+  *ngIf="showExportarModal()"
+  titulo="Exportar Panel de Facturación"
+  subtitulo="Seleccione el formato de salida para el reporte de facturas electrónicas"
+  (exportar)="onConfirmarExportar($event)"
+  (cerrar)="onCerrarExportar()"
+/>
+
 <!-- ── MODAL: Anular Factura ── -->
 <restaurant-keyword-confirm-modal
   [open]="showAnularModal()"

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.ts
@@ -5,11 +5,12 @@ import { ButtonComponent, DataTableComponent, KpiCardComponent, KeywordConfirmMo
 import { FacturasFacade } from '../../../data-access/facturas.facade';
 import { Factura, EstadoFactura } from '../../../models/facturas.model';
 import { FacturaFormComponent } from '../../../ui/modals/factura-form/factura-form.component';
+import { ExportarComponent } from '../../../components/exportar/exportar.component';
 
 @Component({
   selector: 'restaurant-facturas-list',
   standalone: true,
-  imports: [CommonModule, ButtonComponent, DataTableComponent, KpiCardComponent, FacturaFormComponent, KeywordConfirmModalComponent],
+  imports: [CommonModule, ButtonComponent, DataTableComponent, KpiCardComponent, FacturaFormComponent, KeywordConfirmModalComponent, ExportarComponent],
   templateUrl: './facturas-list.component.html',
   styleUrl: './facturas-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -24,10 +25,11 @@ export class FacturasListPageComponent implements OnInit {
   loading = this.facade.loading;
 
   // Modal controls
-  showFormModal    = signal(false);
-  showAnularModal  = signal(false);
-  facturaParaAnular = signal<Factura | null>(null);
-  searchQuery = signal('');
+  showFormModal      = signal(false);
+  showAnularModal    = signal(false);
+  showExportarModal  = signal(false);
+  facturaParaAnular  = signal<Factura | null>(null);
+  searchQuery        = signal('');
 
   ngOnInit(): void {
     this.facade.loadAll();
@@ -81,7 +83,17 @@ export class FacturasListPageComponent implements OnInit {
   }
 
   onExportar(): void {
-    // TODO: ruta de exportación pendiente
+    this.showExportarModal.set(true);
+  }
+
+  onConfirmarExportar(formato: string): void {
+    // TODO: integrar con servicio de descarga cuando backend confirme contrato
+    console.info('[FEL] Exportar en formato:', formato);
+    this.showExportarModal.set(false);
+  }
+
+  onCerrarExportar(): void {
+    this.showExportarModal.set(false);
   }
 
   getEstadoBadgeClass(estado: EstadoFactura): string {

--- a/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.html
+++ b/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.html
@@ -214,7 +214,7 @@
       </tr>
     </thead>
     <tbody>
-      @for (a of afectaciones(); track a.id) {
+      @for (a of afectacionesPaginadas(); track a.id) {
       <tr class="table-row">
         <td class="text-center">
           <span class="fecha-text">{{ a.fecha }}</span>
@@ -247,11 +247,36 @@
     </tbody>
     
     <div dtFooter class="pagination-footer">
-      <span class="results-count">Mostrando 1–{{ afectaciones().length }} de {{ afectaciones().length }} resultados</span>
+      <span class="results-count">
+        Mostrando {{ (paginaActual() - 1) * ITEMS_POR_PAGINA + 1 }}–{{ minOf(paginaActual() * ITEMS_POR_PAGINA, afectaciones().length) }}
+        de {{ afectaciones().length }} resultados
+      </span>
       <div class="page-numbers">
-        <button class="page-btn page-btn--active">1</button>
-        <button class="page-btn">2</button>
-        <button class="page-btn">3</button>
+        <button
+          class="page-btn page-btn--nav"
+          [disabled]="paginaActual() === 1"
+          (click)="anterior()"
+          aria-label="Página anterior"
+        >
+          <span class="material-symbols-outlined">chevron_left</span>
+        </button>
+
+        @for (p of paginas(); track p) {
+          <button
+            class="page-btn"
+            [class.page-btn--active]="paginaActual() === p"
+            (click)="irAPagina(p)"
+          >{{ p }}</button>
+        }
+
+        <button
+          class="page-btn page-btn--nav"
+          [disabled]="paginaActual() === totalPaginas()"
+          (click)="siguiente()"
+          aria-label="Página siguiente"
+        >
+          <span class="material-symbols-outlined">chevron_right</span>
+        </button>
       </div>
     </div>
   </restaurant-data-table>

--- a/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.scss
@@ -612,6 +612,19 @@
           color: var(--color-en-primario);
         }
       }
+
+      &--nav {
+        .material-symbols-outlined {
+          font-size: 18px;
+          line-height: 1;
+        }
+
+        &:disabled {
+          opacity: 0.35;
+          cursor: not-allowed;
+          pointer-events: none;
+        }
+      }
     }
   }
 }

--- a/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import {
@@ -52,8 +52,37 @@ export class PresupuestoDashboardComponent implements OnInit {
     'PRG-003': false,
   });
 
-  /** Historial de afectaciones */
+  /** Historial de afectaciones — fuente completa */
   afectaciones = this.facade.afectaciones;
+
+  // ── Paginación ─────────────────────────────────────────────────────────────
+  readonly ITEMS_POR_PAGINA = 5;
+  paginaActual = signal(1);
+
+  totalPaginas = computed(() =>
+    Math.max(1, Math.ceil(this.afectaciones().length / this.ITEMS_POR_PAGINA))
+  );
+
+  afectacionesPaginadas = computed(() => {
+    const inicio = (this.paginaActual() - 1) * this.ITEMS_POR_PAGINA;
+    return this.afectaciones().slice(inicio, inicio + this.ITEMS_POR_PAGINA);
+  });
+
+  paginas = computed(() =>
+    Array.from({ length: this.totalPaginas() }, (_, i) => i + 1)
+  );
+
+  irAPagina(n: number): void {
+    if (n >= 1 && n <= this.totalPaginas()) {
+      this.paginaActual.set(n);
+    }
+  }
+
+  anterior(): void { this.irAPagina(this.paginaActual() - 1); }
+  siguiente(): void { this.irAPagina(this.paginaActual() + 1); }
+
+  /** Template helper: evita pipe externo */
+  minOf(a: number, b: number): number { return Math.min(a, b); }
 
   /** Próximos vencimientos */
   vencimientos = this.facade.vencimientos;

--- a/libs/inventario/inventario/src/lib/pipes/formato-moneda.pipe.ts
+++ b/libs/inventario/inventario/src/lib/pipes/formato-moneda.pipe.ts
@@ -1,34 +1,39 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+const COP_FORMATTER = new Intl.NumberFormat('es-CO', {
+  style: 'currency',
+  currency: 'COP',
+  currencyDisplay: 'symbol',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
 @Pipe({
   name: 'formatoMoneda',
-  standalone: true
+  standalone: true,
 })
 export class FormatoMonedaPipe implements PipeTransform {
   transform(value: number | string | null | undefined, compact = true): string {
-    if (value == null || isNaN(Number(value))) return '$0';
+    if (value == null || value === '' || isNaN(Number(value))) {
+      return COP_FORMATTER.format(0);
+    }
     const num = Number(value);
 
     if (compact) {
       const abs = Math.abs(num);
       const sign = num < 0 ? '-' : '';
       if (abs >= 1_000_000_000) {
-        return `${sign}$${(abs / 1_000_000_000).toFixed(1).replace('.', ',')}B`;
+        return `${sign}$ ${(abs / 1_000_000_000).toFixed(1).replace('.', ',')}B`;
       }
       if (abs >= 1_000_000) {
-        return `${sign}$${(abs / 1_000_000).toFixed(0)}M`;
+        return `${sign}$ ${(abs / 1_000_000).toFixed(0)}M`;
       }
       if (abs >= 1_000) {
-        return `${sign}$${(abs / 1_000).toFixed(0)}K`;
+        return `${sign}$ ${(abs / 1_000).toFixed(0)}K`;
       }
-      return `${sign}$${abs}`;
+      return `${sign}$ ${abs.toLocaleString('es-CO')}`;
     }
 
-    return new Intl.NumberFormat('es-CO', {
-      style: 'currency',
-      currency: 'COP',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(num);
+    return COP_FORMATTER.format(num);
   }
 }


### PR DESCRIPTION
## Resumen

- **PRE-02**: Estandariza el pipe `FormatoMonedaPipe` con `Intl.NumberFormat` singleton y `currencyDisplay: symbol` para garantizar símbolo COP consistente en toda la tabla de afectaciones
- **PRE-03**: Implementa paginación reactiva con flechas prev/next en el historial de afectaciones — signals `paginaActual`, `afectacionesPaginadas`, `paginas`, botones deshabilitados en extremos
- **CON-TF-03**: Elimina el botón "Exportar Acta" del header del detalle de conciliación (funcionalidad bloqueada por backend)
- **FEL-01**: Conecta el botón "Exportar" de la lista de facturas con el componente `inventario-exportar` como modal de selección de formato
- **FEL-02**: Reemplaza la llamada directa a `facade.anularFactura()` en `factura-edit` por `KeywordConfirmModalComponent` con keyword `ANULAR` y accent `warning`

## Test plan

- [ ] `FormatoMonedaPipe`: verificar que valores en la tabla de afectaciones muestran formato `$ 1.234.567` con símbolo COP
- [ ] `FormatoMonedaPipe`: verificar fallback con valor `null` o vacío devuelve `$ 0`
- [ ] Paginación presupuesto: confirmar que flecha prev está deshabilitada en página 1, next en la última
- [ ] Paginación presupuesto: verificar que el contador "Mostrando X–Y de Z" actualiza correctamente al navegar
- [ ] Detalle conciliación: confirmar que el botón "Exportar Acta" ya no aparece en el header
- [ ] Lista facturas: clic en "Exportar" debe abrir modal de selección de formato (Excel / PDF)
- [ ] Editar factura: clic en "Anular Documento" debe abrir modal de confirmación con campo keyword
- [ ] Editar factura: confirmar con keyword `ANULAR` ejecuta la anulación y redirige a la lista
- [ ] Editar factura: cancelar en el modal no ejecuta ninguna acción

🤖 Generated with [Claude Code](https://claude.com/claude-code)