### PR TITLE
fix(inventario): visual-pt1 — badges, botones y KpiCards estandarizados

### DIFF
--- a/libs/inventario/inventario/src/lib/pages/conciliacion-page/conciliacion-detalle/conciliacion-detalle.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/conciliacion-page/conciliacion-detalle/conciliacion-detalle.component.ts
@@ -12,7 +12,6 @@ import { ConciliacionFacade } from '../../../data-access/conciliacion.facade';
     CommonModule,
     RouterModule,
     LucideIconComponent,
-    ButtonComponent,
     KpiCardComponent,
     BackButtonComponent,
   ],
@@ -22,14 +21,14 @@ import { ConciliacionFacade } from '../../../data-access/conciliacion.facade';
 })
 export class ConciliacionDetalleComponent implements OnInit {
   private location = inject(Location);
-  private router   = inject(Router);
-  private route    = inject(ActivatedRoute);
-  private facade   = inject(ConciliacionFacade);
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
+  private facade = inject(ConciliacionFacade);
 
   // ── Estado reactivo desde facade ─────────────────────────────────────────
-  detalle         = this.facade.conciliacionSeleccionada;
+  detalle = this.facade.conciliacionSeleccionada;
   diferenciasList = this.facade.diferenciasList;
-  loading         = this.facade.loading;
+  loading = this.facade.loading;
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');

--- a/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-create/consolidado-create.component.html
+++ b/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-create/consolidado-create.component.html
@@ -149,9 +149,6 @@
           <restaurant-button variant="primary" (click)="confirmar()">
             Confirmar y Generar
           </restaurant-button>
-          <restaurant-button variant="surface" (click)="goBack()">
-            Volver al Paso 1
-          </restaurant-button>
         </div>
       </div>
     </aside>

--- a/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-detail/consolidado-detail.component.html
+++ b/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-detail/consolidado-detail.component.html
@@ -21,48 +21,35 @@
 
   <!-- Dashboard Stats Summary (Bento Grid) -->
   <div class="kpi-grid">
-    <restaurant-kpi-card variant="states">
-      <div class="bento-card kpi-content">
-        <p class="kpi-content__label">Total Consolidado</p>
-        <div>
-          <span class="kpi-content__value">$142,500,000</span>
-          <p class="kpi-content__trend kpi-content__trend--up">
-            <span class="material-symbols-outlined">trending_up</span>
-            +12.5% vs Mes Anterior
-          </p>
-        </div>
-      </div>
-    </restaurant-kpi-card>
+    <restaurant-kpi-card
+      label="Total Consolidado"
+      value="$142,500,000"
+      icon="landmark"
+      iconColor="green"
+      trend="+12.5% vs Mes Anterior"
+      [trendUp]="true"
+    />
 
-    <restaurant-kpi-card variant="states">
-      <div class="bento-card kpi-content">
-        <p class="kpi-content__label">Vouchers Incluidos</p>
-        <div>
-          <span class="kpi-content__value">28 Formatos</span>
-          <p class="kpi-content__subtitle">GIL-F014 v.2023</p>
-        </div>
-      </div>
-    </restaurant-kpi-card>
+    <restaurant-kpi-card
+      label="Vouchers Incluidos"
+      value="28 Formatos"
+      icon="file-text"
+      iconColor="blue"
+    />
 
-    <restaurant-kpi-card variant="states">
-      <div class="bento-card kpi-content">
-        <p class="kpi-content__label">Fecha de Cierre</p>
-        <div>
-          <span class="kpi-content__value">24 Oct, 2023</span>
-          <p class="kpi-content__subtitle">16:45 PM</p>
-        </div>
-      </div>
-    </restaurant-kpi-card>
+    <restaurant-kpi-card
+      label="Fecha de Cierre"
+      value="24 Oct, 2023"
+      icon="calendar"
+      iconColor="slate"
+    />
 
-    <restaurant-kpi-card variant="states">
-      <div class="bento-card kpi-content">
-        <p class="kpi-content__label">Centro de Operación</p>
-        <div>
-          <span class="kpi-content__value">Bogotá D.C.</span>
-          <p class="kpi-content__subtitle">Sede Administrativa</p>
-        </div>
-      </div>
-    </restaurant-kpi-card>
+    <restaurant-kpi-card
+      label="Centro de Operación"
+      value="Bogotá D.C."
+      icon="map-pin"
+      iconColor="blue"
+    />
   </div>
 
   <!-- Section 1: Subtotales Discriminados -->

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-detail/movimiento-detail.component.html
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-detail/movimiento-detail.component.html
@@ -18,7 +18,7 @@
           Imprimir Comprobante
         </div>
       </restaurant-button>
-      <restaurant-button variant="primary">
+      <restaurant-button variant="primary" (click)="openExportModal()">
         <div style="display: flex; align-items: center; gap: 0.5rem; font-weight: bold;">
           <lucide-icon name="file-text" [size]="18"></lucide-icon>
           Exportar PDF
@@ -137,3 +137,12 @@
 
   </div>
 </main>
+
+<!-- Modal de exportación -->
+<inventario-exportar
+  *ngIf="showExportModal()"
+  titulo="Exportar Movimiento"
+  subtitulo="Seleccione el formato de salida para este movimiento"
+  (exportar)="onExport($event)"
+  (cerrar)="closeExportModal()">
+</inventario-exportar>

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-detail/movimiento-detail.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-detail/movimiento-detail.component.ts
@@ -1,14 +1,15 @@
-import { Component, inject, ChangeDetectionStrategy, OnInit } from '@angular/core';
+import { Component, inject, ChangeDetectionStrategy, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { LucideIconComponent, ButtonComponent } from '@restaurant/shared/ui';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
+import { ExportarComponent } from '../../../components/exportar/exportar.component';
 import { KardexFacade } from '../../../data-access/kardex.facade';
 
 @Component({
   selector: 'restaurant-movimiento-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, LucideIconComponent, ButtonComponent, BackButtonComponent],
+  imports: [CommonModule, RouterModule, LucideIconComponent, ButtonComponent, BackButtonComponent, ExportarComponent],
   templateUrl: './movimiento-detail.component.html',
   styleUrl: './movimiento-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -22,6 +23,9 @@ export class MovimientoDetailComponent implements OnInit {
   movimiento = this.facade.movimientoSeleccionado;
   loading    = this.facade.loading;
 
+  // ── Modal de exportación ──────────────────────────────────────────────────
+  showExportModal = signal(false);
+
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
@@ -33,5 +37,18 @@ export class MovimientoDetailComponent implements OnInit {
 
   goBack(): void {
     this.router.navigate(['/app/inventario/movimientos']);
+  }
+
+  openExportModal(): void {
+    this.showExportModal.set(true);
+  }
+
+  closeExportModal(): void {
+    this.showExportModal.set(false);
+  }
+
+  onExport(formato: string): void {
+    console.log('Exportar movimiento:', formato);
+    this.closeExportModal();
   }
 }

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-consolidacion/solicitudes-insumos-consolidacion.component.html
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-consolidacion/solicitudes-insumos-consolidacion.component.html
@@ -45,10 +45,10 @@
             </div>
             <div class="item-info">
               <span class="item-name">{{ item.nombre }}</span>
-              <span class="item-status-badge">
-                <span class="material-symbols-outlined status-icon">merge</span>
-                Consolidado ×{{ item.origenes.length }}
-              </span>
+              <restaurant-status-badge
+                [label]="'Consolidado ×' + item.origenes.length"
+                variant="success">
+              </restaurant-status-badge>
             </div>
           </td>
           

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-consolidacion/solicitudes-insumos-consolidacion.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-consolidacion/solicitudes-insumos-consolidacion.component.scss
@@ -10,7 +10,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--color-text-secondary, #636E72);
+  color: var(--color-text-secondary);
   font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
@@ -22,7 +22,7 @@
   }
 
   &:hover {
-    color: var(--color-text-primary, #191c1d);
+    color: var(--color-en-superficie);
   }
 }
 
@@ -37,7 +37,7 @@
   font-family: 'Manrope', sans-serif;
   font-size: 2.25rem;
   font-weight: 800;
-  color: var(--color-text-primary, #191c1d);
+  color: var(--color-en-superficie);
   letter-spacing: -0.02em;
   margin: 0;
   line-height: 1.2;
@@ -48,7 +48,7 @@
 }
 
 .page-subtitle {
-  color: var(--color-text-secondary, #636E72);
+  color: var(--color-text-secondary);
   font-size: 0.9375rem;
   margin: 0;
   max-width: 800px;
@@ -65,7 +65,7 @@
 .origen-label {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--color-text-secondary, #636E72);
+  color: var(--color-text-secondary);
 }
 
 .origen-tags {
@@ -85,8 +85,8 @@
 
 /* Tarjeta Principal */
 .consolidacion-card {
-  background-color: var(--color-surface-container-lowest, #ffffff);
-  border: 1px solid var(--color-outline-variant, #e2e8f0);
+  background-color: var(--color-superficie-contenedor-mas-bajo);
+  border: 1px solid var(--color-superficie-contenedor-alto);
   border-radius: var(--radius-xl, 1rem);
   overflow: hidden;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
@@ -100,7 +100,7 @@
   align-items: flex-start;
   gap: 1rem;
   justify-content: space-between;
-  border-bottom: 1px solid var(--color-outline-variant, #e2e8f0);
+  border-bottom: 1px solid var(--color-superficie-contenedor-alto);
 
   @media (min-width: 768px) {
     flex-direction: row;
@@ -114,7 +114,7 @@
   font-size: 1.25rem;
   font-weight: 700;
   margin: 0;
-  color: var(--color-text-primary, #191c1d);
+  color: var(--color-en-superficie);
 }
 
 .items-badge {
@@ -142,13 +142,13 @@
     padding: 1rem 1.5rem;
     font-size: 0.8125rem;
     font-weight: 700;
-    color: var(--color-text-secondary, #636E72);
-    border-bottom: 1px solid var(--color-outline-variant, #e2e8f0);
+    color: var(--color-text-secondary);
+    border-bottom: 1px solid var(--color-superficie-contenedor-alto);
   }
 
   td {
     padding: 1.25rem 1.5rem;
-    border-bottom: 1px solid var(--color-outline-variant, #e2e8f0);
+    border-bottom: 1px solid var(--color-superficie-contenedor-alto);
     vertical-align: top;
   }
 
@@ -188,7 +188,7 @@
 .item-name {
   font-size: 0.9375rem;
   font-weight: 600;
-  color: var(--color-text-primary, #191c1d);
+  color: var(--color-en-superficie);
 }
 
 .item-status-badge {
@@ -210,7 +210,7 @@
 
 .col-unidad {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #636E72);
+  color: var(--color-text-secondary);
   padding-top: 1.5rem !important;
 }
 
@@ -240,7 +240,7 @@
 
 .desglose-qty {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #636E72);
+  color: var(--color-text-secondary);
 }
 
 .col-total {
@@ -250,7 +250,7 @@
 .total-value {
   font-size: 1.25rem;
   font-weight: 800;
-  color: var(--color-primario, #39a900);
+  color: var(--color-primario);
 }
 
 .text-right {
@@ -266,7 +266,7 @@
   justify-content: space-between;
   margin-top: 1rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--color-outline-variant, #e2e8f0);
+  border-top: 1px solid var(--color-superficie-contenedor-alto);
 
   @media (min-width: 768px) {
     flex-direction: row;

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-consolidacion/solicitudes-insumos-consolidacion.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-consolidacion/solicitudes-insumos-consolidacion.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
-import { ButtonComponent } from '@restaurant/shared/ui';
+import { ButtonComponent, StatusBadgeComponent } from '@restaurant/shared/ui';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
 
 interface ConsolidacionItem {
@@ -19,7 +19,7 @@ interface ConsolidacionItem {
 @Component({
   selector: 'restaurant-solicitudes-insumos-consolidacion',
   standalone: true,
-  imports: [CommonModule, RouterModule, ButtonComponent, BackButtonComponent],
+  imports: [CommonModule, RouterModule, ButtonComponent, BackButtonComponent, StatusBadgeComponent],
   templateUrl: './solicitudes-insumos-consolidacion.component.html',
   styleUrls: ['./solicitudes-insumos-consolidacion.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-list/solicitudes-insumos-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-list/solicitudes-insumos-list.component.html
@@ -58,39 +58,10 @@
 <!-- ══════════════════════════════════════════════════════════════════════════
      Tabla con filtros
 ══════════════════════════════════════════════════════════════════════════ -->
-<restaurant-data-table tableTitle="Solicitudes de Insumos" tableIcon="clipboard-list">
-
-  <!-- Barra de filtros -->
-  <div dtHeader class="table-controls">
-    <div class="filters-left">
-
-      <!-- Filtro Estado -->
-      <div class="select-box">
-        <select (change)="onFilterEstado($any($event.target).value)">
-          <option *ngFor="let opt of estadoOptions" [value]="opt.value">{{ opt.label }}</option>
-        </select>
-        <span class="material-symbols-outlined dropdown-icon">expand_more</span>
-      </div>
-
-      <!-- Filtro Fecha -->
-      <div class="select-box">
-        <select (change)="onFilterFecha($any($event.target).value)">
-          <option *ngFor="let opt of fechaOptions" [value]="opt.value">{{ opt.label }}</option>
-        </select>
-        <span class="material-symbols-outlined dropdown-icon">calendar_month</span>
-      </div>
-
-      <!-- Buscar por instructor -->
-      <div class="search-box">
-        <span class="material-symbols-outlined search-icon">search</span>
-        <input type="text"
-               placeholder="Buscar por Instructor..."
-               (input)="onSearch($any($event.target).value)" />
-      </div>
-    </div>
-
-    <p class="results-count">Mostrando 1–3 de 60 solicitudes</p>
-  </div>
+<restaurant-data-table
+  tableTitle="Solicitudes de Insumos"
+  tableIcon="clipboard-list"
+  searchPlaceholder="Buscar por instructor o código...">
 
   <!-- Cabecera de tabla -->
   <thead>
@@ -135,15 +106,10 @@
 
       <!-- Estado badge -->
       <td>
-        <span class="estado-badge"
-              [ngClass]="{
-                'estado-badge--pendiente': s.estado === 'ENVIADA',
-                'estado-badge--aprobado':  s.estado === 'APROBADA',
-                'estado-badge--procesado': s.estado === 'CERRADA'
-              }">
-          <span *ngIf="s.estado === 'CERRADA'" class="material-symbols-outlined" style="font-size: 14px; vertical-align: middle; margin-right: 2px;">lock</span>
-          {{ s.estado }}
-        </span>
+        <restaurant-status-badge
+          [label]="s.estado"
+          [variant]="getSolicitudVariant(s.estado)">
+        </restaurant-status-badge>
       </td>
 
       <!-- Acciones -->

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-list/solicitudes-insumos-list.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-list/solicitudes-insumos-list.component.ts
@@ -145,6 +145,15 @@ export class SolicitudesInsumosListComponent {
   onFilterFecha(v: string): void  { console.log('Fecha:', v);        }
   onClearFilters(): void          { console.log('Limpiar filtros');  }
 
+  getSolicitudVariant(estado: string): 'warning' | 'success' | 'neutral' {
+    const map: Record<string, 'warning' | 'success' | 'neutral'> = {
+      'ENVIADA':  'warning',
+      'APROBADA': 'success',
+      'CERRADA':  'neutral',
+    };
+    return map[estado] ?? 'neutral';
+  }
+
   onView(id: string | number): void {
     this.router.navigate(['/app/inventario/solicitudes-insumos-page', id, 'consolidacion']);
   }

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-page/solicitudes-generar/solicitudes-generar.component.html
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-page/solicitudes-generar/solicitudes-generar.component.html
@@ -145,12 +145,12 @@
       </div>
 
       <div class="modal-actions-col">
-        <button (click)="confirmarGeneracion()" class="btn-modal btn-modal--primary">
+        <restaurant-button variant="primary" (click)="confirmarGeneracion()">
           Confirmar y Generar GIL
-        </button>
-        <button (click)="cerrarModal()" class="btn-modal btn-modal--secondary">
+        </restaurant-button>
+        <restaurant-button variant="surface" (click)="cerrarModal()">
           Cancelar
-        </button>
+        </restaurant-button>
       </div>
     </div>
   </div>

--- a/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.html
+++ b/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.html
@@ -46,10 +46,10 @@
       <div class="asset-badges">
         <div class="asset-badge-item">
           <span class="badge-label">ESTADO</span>
-          <span class="estado-pill" [ngClass]="getEstadoPillClass(b.estado)">
-            <span class="estado-dot"></span>
-            {{ b.estado }}
-          </span>
+          <restaurant-status-badge
+            [label]="b.estado"
+            [variant]="getEstadoVariant(b.estado)">
+          </restaurant-status-badge>
         </div>
         <div class="asset-badge-item">
           <span class="badge-label">CATEGORÍA</span>
@@ -126,9 +126,10 @@
           <tr *ngFor="let m of movimientos()">
             <td class="mov-fecha">{{ m.fecha | date:'dd/MM/yyyy' }}</td>
             <td>
-              <span class="tipo-badge" [ngClass]="'tipo-badge--' + getTipoClass(m.tipo)">
-                {{ m.tipo }}
-              </span>
+              <restaurant-status-badge
+                [label]="m.tipo"
+                [variant]="getTipoVariant(m.tipo)">
+              </restaurant-status-badge>
             </td>
             <td class="mov-responsable">{{ m.responsable }}</td>
             <td class="mov-ubicacion">{{ m.ubicacion }}</td>
@@ -180,7 +181,10 @@
               <td>{{ f.fecha | date:'dd/MM/yyyy' }}</td>
               <td class="mov-valor">{{ f.monto | currency:'COP':'symbol-narrow':'1.0-0' }}</td>
               <td>
-                <span class="factura-estado" [ngClass]="getEstadoFacturaClass(f.estado)">{{ f.estado }}</span>
+                <restaurant-status-badge
+                  [label]="f.estado"
+                  [variant]="getFacturaEstadoVariant(f.estado)">
+                </restaurant-status-badge>
               </td>
             </tr>
           </tbody>

--- a/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { Bien, MovimientoBien } from '../../../models/inventario.model';
 import { InventarioFacade } from '../../../data-access/inventario.facade';
+import { StatusBadgeComponent } from '@restaurant/shared/ui';
 import { BienFormComponent } from '../../modals/bien-form/bien-form.component';
 import { BienFormDto, EstadoBien } from '../../../models/inventario.model';
 import { MOVIMIENTOS_MOCK } from '../../../models/inventario.mock';
@@ -11,7 +12,7 @@ import { BackButtonComponent } from '../../../components/back-button/back-button
 @Component({
   selector: 'restaurant-bien-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, BienFormComponent, BackButtonComponent],
+  imports: [CommonModule, RouterModule, BienFormComponent, BackButtonComponent, StatusBadgeComponent],
   templateUrl: './bien-detail.component.html',
   styleUrl: './bien-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -100,5 +101,34 @@ export class BienDetailPageComponent implements OnInit {
       'Inactivo': 'estado-pill--inactivo'
     };
     return map[estado] || '';
+  }
+
+  // ── StatusBadge helpers ─────────────────────────────────────────────────────
+  getEstadoVariant(estado: EstadoBien): 'success' | 'warning' | 'danger' | 'neutral' {
+    const map: Record<EstadoBien, 'success' | 'warning' | 'danger' | 'neutral'> = {
+      'Activo':    'success',
+      'Bajo Stock': 'warning',
+      'Agotado':   'danger',
+      'Inactivo':  'neutral',
+    };
+    return map[estado] ?? 'neutral';
+  }
+
+  getTipoVariant(tipo: string): 'success' | 'danger' | 'warning' | 'neutral' {
+    const map: Record<string, 'success' | 'danger' | 'warning' | 'neutral'> = {
+      'ENTRADA':  'success',
+      'SALIDA':   'danger',
+      'TRASLADO': 'warning',
+    };
+    return map[tipo] ?? 'neutral';
+  }
+
+  getFacturaEstadoVariant(estado: string): 'success' | 'warning' | 'neutral' {
+    const map: Record<string, 'success' | 'warning' | 'neutral'> = {
+      'PAGADA':    'success',
+      'CAUSADA':   'warning',
+      'PENDIENTE': 'neutral',
+    };
+    return map[estado] ?? 'neutral';
   }
 }


### PR DESCRIPTION
## Resumen

- **BIENES-01**: `bien-detail` reemplaza spans de estado/tipo/factura por `StatusBadgeComponent`
- **GIL-01/02**: `solicitudes-insumos-list` elimina filtros inline del `dtHeader` y usa `StatusBadge` para estados de solicitud
- **GIL-03/04**: `solicitudes-insumos-consolidacion` usa `StatusBadge` para el ítem consolidado y aplica design tokens (`var(--color-primario)`, `var(--color-superficie-contenedor-alto)`) en SCSS
- **GIL-05**: `solicitudes-generar` reemplaza `<button>` raw del modal de confirmación por `<restaurant-button>` con variantes `primary` y `surface`
- **CON-01**: `consolidado-create` elimina el botón "Volver al Paso 1" del panel lateral
- **CON-02**: `consolidado-detail` convierte los 4 KpiCards de `variant="states"` con contenido slotted a inputs estándar (`label`, `value`, `icon`, `iconColor`, `trend`, `trendUp`)
- **MOV-01**: `movimiento-detail` conecta el botón "Exportar PDF" al modal `inventario-exportar`; agrega `showExportModal`, `openExportModal()`, `closeExportModal()` y `onExport()` al componente
- **Limpieza**: `conciliacion-detalle` elimina import `ButtonComponent` sin uso

## Plan de prueba

- [ ] Verificar que `bien-detail` muestra correctamente los badges de estado Activo/Bajo Stock/Agotado/Inactivo
- [ ] Verificar que `solicitudes-insumos-list` muestra la tabla sin filtros duplicados y con badges de estado
- [ ] Verificar que `solicitudes-generar` abre el modal y los botones de confirmación/cancelar responden correctamente
- [ ] Verificar que `consolidado-create` no muestra el botón "Volver al Paso 1"
- [ ] Verificar que `consolidado-detail` muestra las 4 KpiCards con el layout estándar
- [ ] Verificar que `movimiento-detail` abre el modal de exportación al pulsar "Exportar PDF"
- [ ] `ng lint inventario` ✅ sin errores