### PR TITLE
fix(inventario): correcciones de detalles UI — facturas, solicitudes, alertas, paquete

### DIFF
--- a/libs/inventario/inventario/src/lib/pages/actas-page/actas-create/actas-create.component.html
+++ b/libs/inventario/inventario/src/lib/pages/actas-page/actas-create/actas-create.component.html
@@ -1,4 +1,7 @@
 <div class="acta-create">
+  <!-- ── Volver ──────────────────────────────────────────────────────── -->
+  <inventario-back-button (clicked)="goBack()" />
+
   <!-- ── Título ──────────────────────────────────────────────────────── -->
   <h2 class="acta-create__title">Generación de Acta</h2>
 

--- a/libs/inventario/inventario/src/lib/pages/actas-page/actas-create/actas-create.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/actas-page/actas-create/actas-create.component.ts
@@ -11,6 +11,7 @@ import {
   StatusBadgeComponent,
   LucideIconComponent,
 } from '@restaurant/shared/ui';
+import { BackButtonComponent } from '../../../components/back-button/back-button.component';
 import { WizardStep } from '../../../models/acta.model';
 
 interface Firmante {
@@ -27,6 +28,7 @@ interface Firmante {
     CommonModule,
     StatusBadgeComponent,
     LucideIconComponent,
+    BackButtonComponent,
   ],
   templateUrl: './actas-create.component.html',
   styleUrl: './actas-create.component.scss',
@@ -74,6 +76,10 @@ export class ActasCreateComponent {
     if (this.currentStep() > 1) {
       this.currentStep.update(s => s - 1);
     }
+  }
+
+  goBack(): void {
+    this.router.navigate(['/app/inventario/actas']);
   }
 
   generarActa(): void {

--- a/libs/inventario/inventario/src/lib/pages/actas-page/actas-list/actas-list.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/actas-page/actas-list/actas-list.component.scss
@@ -153,7 +153,7 @@
 .actas-table__consecutivo {
   font-family: var(--font-family-headline);
   font-weight: 700;
-  color: var(--color-primario);
+  color: var(--color-en-superficie);
 }
 
 .actas-table__fecha {

--- a/libs/inventario/inventario/src/lib/pages/alertas-page/alertas-historial/alertas-historial.component.html
+++ b/libs/inventario/inventario/src/lib/pages/alertas-page/alertas-historial/alertas-historial.component.html
@@ -10,7 +10,7 @@
       </div>
     </div>
     <div class="header-right">
-      <restaurant-button variant="primary" (click)="exportarCSV()">
+      <restaurant-button variant="surface" (click)="openExportModal()">
         <div style="display: flex; align-items: center; gap: 0.5rem; font-weight: bold;">
           <lucide-icon name="download" [size]="18"></lucide-icon>
           Exportar
@@ -144,3 +144,11 @@
   </div>
 
 </div>
+
+<inventario-exportar
+  *ngIf="showExportModal()"
+  titulo="Exportar Historial de Alertas"
+  subtitulo="Seleccione el formato de salida para el historial de gestión de alertas"
+  (exportar)="onExport($event)"
+  (cerrar)="closeExportModal()"
+></inventario-exportar>

--- a/libs/inventario/inventario/src/lib/pages/alertas-page/alertas-historial/alertas-historial.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/alertas-page/alertas-historial/alertas-historial.component.ts
@@ -10,6 +10,7 @@ import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { LucideIconComponent, DataTableComponent, ButtonComponent } from '@restaurant/shared/ui';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
+import { ExportarComponent } from '../../../components/exportar/exportar.component';
 import { AlertaPrioridad } from '../../../models/alerta.model';
 import { AlertasFacade } from '../../../data-access/alertas.facade';
 
@@ -17,7 +18,7 @@ import { AlertasFacade } from '../../../data-access/alertas.facade';
   selector: 'restaurant-alertas-historial',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, LucideIconComponent, DataTableComponent, ButtonComponent, BackButtonComponent],
+  imports: [CommonModule, LucideIconComponent, DataTableComponent, ButtonComponent, BackButtonComponent, ExportarComponent],
   templateUrl: './alertas-historial.component.html',
   styleUrl: './alertas-historial.component.scss',
 })
@@ -93,7 +94,19 @@ export class AlertasHistorialComponent implements OnInit {
     this.filtroResponsable.set((event.target as HTMLSelectElement).value);
   }
 
-  exportarCSV(): void {
+  // ── Modal de exportación ─────────────────────────────────────────────────
+  showExportModal = signal(false);
+
+  openExportModal(): void {
+    this.showExportModal.set(true);
+  }
+
+  closeExportModal(): void {
+    this.showExportModal.set(false);
+  }
+
+  onExport(formato: string): void {
     this.facade.exportarHistorialCSV();
+    this.closeExportModal();
   }
 }

--- a/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-detail/consolidado-detail.component.html
+++ b/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-detail/consolidado-detail.component.html
@@ -47,7 +47,7 @@
     <restaurant-kpi-card
       label="Centro de Operación"
       value="Bogotá D.C."
-      icon="map-pin"
+      icon="building-2"
       iconColor="blue"
     />
   </div>

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-edit/factura-edit.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-edit/factura-edit.component.html
@@ -67,7 +67,7 @@
       <div class="form-field">
         <label>Tipo de Documento</label>
         <div class="select-wrapper">
-          <select id="field-tipo-doc" [(ngModel)]="tipoDoc" [disabled]="isBlocked()">
+          <select id="field-tipo-doc" [ngModel]="tipoDoc()" (ngModelChange)="tipoDoc.set($event)" [disabled]="isBlocked()">
             <option>Factura Electrónica</option>
             <option>Nota Crédito</option>
             <option>Nota Débito</option>

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-edit/factura-edit.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-edit/factura-edit.component.ts
@@ -48,6 +48,7 @@ export class FacturaEditPageComponent implements OnInit {
       if (f) {
         this.nitCliente.set(f.nitEmisor);
         this.razonSocial.set(f.razonSocial);
+        this.tipoDoc.set(f.tipoDocumento);
         this.fechaEmision.set(f.fechaEmision);
         this.moneda.set(f.moneda);
         this.notasInternas.set(f.notasInternas ?? '');

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
@@ -156,6 +156,7 @@
 
     <!-- Pagination slot -->
     <div dtFooter class="table-pagination" *ngIf="!loading() && facturas().length > 0">
+      <span class="table-pagination__info">Mostrando {{ facturas().length }} de {{ kpis()?.totalFacturas | number }} facturas</span>
       <div class="pagination-btns">
         <button class="pagination-btn" disabled>
           <span class="material-symbols-outlined">chevron_left</span>
@@ -167,7 +168,6 @@
           <span class="material-symbols-outlined">chevron_right</span>
         </button>
       </div>
-      <span class="table-pagination__info">Mostrando {{ facturas().length }} de {{ kpis()?.totalFacturas | number }} facturas</span>
     </div>
 
   </restaurant-data-table>

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/facturas-list/facturas-list.component.html
@@ -7,7 +7,7 @@
       <p class="page-header__subtitle">Supervisión y control de documentos electrónicos en tiempo real.</p>
     </div>
     <div class="page-header__actions">
-      <restaurant-button variant="surface" (click)="onImportar()">
+      <restaurant-button variant="ghost" (click)="onImportar()">
         <span class="material-symbols-outlined">upload</span>
         Importar
       </restaurant-button>
@@ -156,7 +156,6 @@
 
     <!-- Pagination slot -->
     <div dtFooter class="table-pagination" *ngIf="!loading() && facturas().length > 0">
-      <span class="table-pagination__info">Mostrando {{ facturas().length }} de {{ kpis()?.totalFacturas | number }} facturas</span>
       <div class="pagination-btns">
         <button class="pagination-btn" disabled>
           <span class="material-symbols-outlined">chevron_left</span>
@@ -168,6 +167,7 @@
           <span class="material-symbols-outlined">chevron_right</span>
         </button>
       </div>
+      <span class="table-pagination__info">Mostrando {{ facturas().length }} de {{ kpis()?.totalFacturas | number }} facturas</span>
     </div>
 
   </restaurant-data-table>

--- a/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-list/paquete-list.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-list/paquete-list.component.scss
@@ -174,13 +174,13 @@
 .paquete-table__expediente {
   font-family: var(--font-family-mono);
   font-weight: 700;
-  color: var(--color-primario);
+  color: var(--color-en-superficie);
   cursor: pointer;
   text-decoration: none;
 
   &:hover {
     text-decoration: underline;
-    text-decoration-color: rgba(57, 169, 0, 0.3);
+    text-decoration-color: var(--color-superficie-contenedor-alto);
     text-underline-offset: 4px;
   }
 }

--- a/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.html
+++ b/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.html
@@ -43,7 +43,7 @@
     <restaurant-kpi-card label="DISPONIBLE" [value]="resumen()!.totalDisponible | formatoMoneda" icon="wallet"
       iconColor="blue" trend="Saldo sin comprometer" [trendUp]="null"></restaurant-kpi-card>
 
-    <restaurant-kpi-card label="TOTAL ZESE APLICADA" [value]="resumen()!.totalZese | formatoMoneda" icon="shield"
+    <restaurant-kpi-card label="TOTAL ZESE APLICADA" [value]="resumen()!.totalZese | formatoMoneda" icon="shield-check"
       iconColor="red" trend="Retención 0.625%" [trendUp]="null"></restaurant-kpi-card>
   </div>
   }

--- a/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.html
+++ b/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.html
@@ -43,7 +43,7 @@
     <restaurant-kpi-card label="DISPONIBLE" [value]="resumen()!.totalDisponible | formatoMoneda" icon="wallet"
       iconColor="blue" trend="Saldo sin comprometer" [trendUp]="null"></restaurant-kpi-card>
 
-    <restaurant-kpi-card label="TOTAL ZESE APLICADA" [value]="resumen()!.totalZese | formatoMoneda" icon="percent"
+    <restaurant-kpi-card label="TOTAL ZESE APLICADA" [value]="resumen()!.totalZese | formatoMoneda" icon="shield"
       iconColor="red" trend="Retención 0.625%" [trendUp]="null"></restaurant-kpi-card>
   </div>
   }

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-list/solicitudes-insumos-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-list/solicitudes-insumos-list.component.html
@@ -8,7 +8,7 @@
   </div>
   <restaurant-button variant="primary" routerLink="nueva">
     <span class="material-symbols-outlined">add</span>
-    Nueva Solicitud
+    Nueva GIL
   </restaurant-button>
 </div>
 

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-page/solicitudes-list/solicitudes-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-page/solicitudes-list/solicitudes-list.component.html
@@ -87,7 +87,6 @@
       </div>
     </div>
 
-    <p class="results-count">Mostrando 1–{{ solicitudes().length }} de {{ totalSolicitudes() }} resultados</p>
   </div>
 
   <!-- Cabecera de tabla -->
@@ -175,6 +174,7 @@
 
   <!-- Paginación -->
   <div dtFooter class="pagination-footer">
+    <p class="results-count">Mostrando 1–{{ solicitudes().length }} de {{ totalSolicitudes() }} resultados</p>
     <div class="page-numbers">
       <button class="page-btn page-btn--active">1</button>
       <button class="page-btn">2</button>

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-page/solicitudes-list/solicitudes-list.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-page/solicitudes-list/solicitudes-list.component.scss
@@ -257,7 +257,7 @@
   background: var(--color-surface-secondary);
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
 }
 
 .page-numbers {


### PR DESCRIPTION
## Resumen

- **T-UI-01** `facturas-list`: botón Importar cambia `variant="surface"` → `variant="ghost"` (gris por defecto, consistente con el hover anterior)
- **T-UI-02** `solicitudes-insumos-list`: renombra botón "Nueva Solicitud" → "Nueva GIL"
- **T-UI-03** `facturas-list` paginación: mueve el texto "Mostrando X de Y" al lado derecho de los botones de paginación
- **T-UI-04** `factura-edit`: pre-selecciona `tipoDocumento` desde la factura cargada; corrige binding de signal con `[ngModel]/(ngModelChange)` en lugar de `[(ngModel)]`
- **T-UI-05** `consolidado-detail` KPI: icono `map-pin` → `building-2` en "Centro de Operación"
- **T-UI-06** `alertas-historial`: reemplaza botón Exportar directo por modal `inventario-exportar` compartido
- **T-UI-07** `presupuesto-dashboard` KPI: icono `percent` → `shield` en "TOTAL ZESE APLICADA"
- **T-UI-08** `actas-list`: color de `.actas-table__consecutivo` de `var(--color-primario)` → `var(--color-en-superficie)` (negro normal)
- **T-UI-09** `paquete-list`: color de `.paquete-table__expediente` de `var(--color-primario)` → `var(--color-en-superficie)`; hover underline color neutralizado

## Plan de prueba

- [ ] Facturas — botón Importar se ve gris sin hacer hover
- [ ] Solicitudes GIL — header muestra "Nueva GIL"
- [ ] Facturas — tabla paginación: botones primero, "Mostrando X" a la derecha
- [ ] Factura editar — select Tipo Documento pre-cargado con el valor de la factura seleccionada
- [ ] Consolidado detalle — KPI "Centro de Operación" muestra icono edificio
- [ ] Historial alertas — botón Exportar abre modal `inventario-exportar`
- [ ] Presupuesto — KPI "TOTAL ZESE APLICADA" muestra icono escudo
- [ ] Actas listado — columna "Consecutivo" en negro (no verde)
- [ ] Paquete probatorio listado — columna "ID Expediente" en negro (no verde)