### PR TITLE
feat(inventario): FE-02 DTOs de API y mappers por contexto

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/alerts.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/alerts.api.ts
@@ -1,0 +1,26 @@
+export interface AlertaResponse {
+  id: string;
+  tipo: string;
+  prioridad: 'ALTA' | 'MEDIA' | 'BAJA';
+  referenciaId: string;
+  referenciaTipo: string;
+  descripcion: string;
+  destinatarioId: string;
+  destinatarioRol: string;
+  fechaGeneracion: string;
+  estado: 'ACTIVA' | 'CRITICA' | 'RESUELTA';
+  fechaResolucion?: string;
+  accionResolucion?: string;
+  resueltoPorId?: string;
+  codigoSena?: string;
+  nombreBien?: string;
+  stockActual?: number;
+  stockMinimo?: number;
+  unidad?: string;
+}
+
+export interface ResolverAlertaRequest {
+  accionResolucion: string;
+  resueltoPorId: string;
+  observaciones?: string;
+}

--- a/libs/inventario/inventario/src/lib/data-access/api/budget.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/budget.api.ts
@@ -1,0 +1,71 @@
+export interface PresupuestoResponse {
+  id: string;
+  codigo: string;
+  descripcion: string;
+  fichaId: string;
+  programaFormacion: string;
+  montoAsignado: number;
+  saldoDisponible: number;
+  montoComprometido: number;
+  montoPagado: number;
+  retencionZese: number;
+  porcentajeEjecucion: number;
+}
+
+export interface RegistrarPresupuestoRequest {
+  programaId: string;
+  vigenciaFiscal: number;
+  nombreRubro: string;
+  codigoPresupuestal: string;
+  bolsaInicial: number;
+}
+
+export interface CompromisoResponse {
+  id: string;
+  gilId: string;
+  presupuestoId: string;
+  monto: number;
+  estado: 'ACTIVO' | 'ANULADO' | 'PAGADO';
+  fecha: string;
+}
+
+export interface ComprometerRequest {
+  gilId: string;
+  presupuestoId: string;
+  monto: number;
+}
+
+export interface PagoRequest {
+  monto: number;
+  fecha: string;
+  referencia: string;
+}
+
+export interface LineaConsolidadoResponse {
+  id: string;
+  tipo: string;
+  referencia: string;
+  descripcion: string;
+  cantidad: number;
+  valor: number;
+}
+
+export interface TotalesConsolidadoResponse {
+  totalBienes: number;
+  totalServicios: number;
+  totalGeneral: number;
+}
+
+export interface ConsolidadoResponse {
+  id: string;
+  numero: number;
+  fechaGeneracion: string;
+  generadoPor: string;
+  estado: 'GENERADO' | 'CONTABILIZADO' | 'REVERSADO';
+  lineas: LineaConsolidadoResponse[];
+  totales: TotalesConsolidadoResponse;
+}
+
+export interface GenerarConsolidadoRequest {
+  gilIds: string[];
+}

--- a/libs/inventario/inventario/src/lib/data-access/api/catalog.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/catalog.api.ts
@@ -1,0 +1,29 @@
+export interface PagedResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  page: number;
+  size: number;
+}
+
+export interface ProductoResponse {
+  id: string;
+  codigoSena: string;
+  codigoProveedor?: string;
+  nombre: string;
+  descripcion?: string;
+  categoria: string;
+  unidadMedida: string;
+  activo: boolean;
+}
+
+export interface CrearProductoRequest {
+  codigoSena?: string;
+  codigoProveedor?: string;
+  nombre: string;
+  descripcion?: string;
+  categoria: string;
+  unidadMedida: string;
+}
+
+export type ActualizarProductoRequest = Partial<CrearProductoRequest>;

--- a/libs/inventario/inventario/src/lib/data-access/api/inventory.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/inventory.api.ts
@@ -1,0 +1,68 @@
+export interface ExistenciaResponse {
+  productoId: string;
+  codigoSena: string;
+  nombre: string;
+  categoria: string;
+  unidadMedida: string;
+  stockDisponible: number;
+  stockMinimo?: number;
+}
+
+export interface MovimientoResponse {
+  id: string;
+  tipo: 'ENTRADA' | 'SALIDA' | 'RESERVA' | 'LIBERACION' | 'AJUSTE';
+  productoId: string;
+  productoNombre: string;
+  codigoSena: string;
+  cantidad: number;
+  unidadMedida: string;
+  fechaMovimiento: string;
+  responsableId: string;
+  responsableNombre: string;
+  valor: number;
+  estado: 'Completado' | 'Pendiente' | 'Cancelado';
+}
+
+export interface EntradaRequest {
+  productoId: string;
+  cantidad: number;
+  fecha: string;
+  proveedorId?: string;
+  facturaId?: string;
+  ubicacion: string;
+  valorUnitario: number;
+  observaciones?: string;
+}
+
+export interface SalidaRequest {
+  productoId: string;
+  cantidad: number;
+  fecha: string;
+  areaDestino: string;
+  instructorId?: string;
+  fichaId?: string;
+  categoria: string;
+  proposito: string;
+  observaciones?: string;
+}
+
+export interface ReservaRequest {
+  productoId: string;
+  cantidad: number;
+  fichaId: string;
+  instructorId: string;
+  observaciones?: string;
+}
+
+export interface LiberacionRequest {
+  productoId: string;
+  cantidad: number;
+  motivo: string;
+}
+
+export interface AjusteRequest {
+  productoId: string;
+  cantidadNueva: number;
+  motivo: string;
+  responsableId: string;
+}

--- a/libs/inventario/inventario/src/lib/data-access/api/legalization.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/legalization.api.ts
@@ -1,0 +1,87 @@
+export interface ActaResponse {
+  id: string;
+  numeroActa: string;
+  fecha: string;
+  programa: string;
+  fichaId: string;
+  instructorId: string;
+  requisicionId: string;
+  estado: 'BORRADOR' | 'PENDIENTE_FIRMAS' | 'FIRMADA' | 'REVISADA' | 'ARCHIVADA';
+  ciudad?: string;
+  lugar?: string;
+  agendaSesion?: string;
+  desarrolloSesion?: string;
+  resultadoAprendizaje?: string;
+  actividadesEjecutadas?: string;
+}
+
+export interface CrearActaRequest {
+  programa: string;
+  fichaId: string;
+  instructorId: string;
+  requisicionId: string;
+  ciudad?: string;
+  lugar?: string;
+  agendaSesion?: string;
+  desarrolloSesion?: string;
+  resultadoAprendizaje?: string;
+  actividadesEjecutadas?: string;
+}
+
+export interface PaqueteResponse {
+  id: string;
+  expediente: string;
+  titulo: string;
+  fichaId: string;
+  estado: 'INCOMPLETO' | 'COMPLETO' | 'ARCHIVADO';
+  gilId: string;
+  cufeFuenteId?: string;
+  actaId?: string;
+  requisicionId?: string;
+  registroAsistenciaAdjunto: boolean;
+  instructorId: string;
+  fecha: string;
+}
+
+export interface CrearPaqueteRequest {
+  fichaId: string;
+  gilId: string;
+  instructorId: string;
+  titulo?: string;
+}
+
+export interface TrazabilidadRequest {
+  actaId?: string;
+  requisicionId?: string;
+  cufeFuenteId?: string;
+}
+
+export interface RequisicionItemResponse {
+  codigo: string;
+  descripcion: string;
+  cantidad: number;
+  unidad: string;
+}
+
+export interface RequisicionResponse {
+  id: string;
+  numero: string;
+  programa: string;
+  fichaId: string;
+  instructorId: string;
+  instructorNombre: string;
+  diaSemana: string;
+  horaSesion: string;
+  fecha: string;
+  estado: 'BORRADOR' | 'ENVIADA' | 'DESPACHADA' | 'FIRMADA' | 'LEGALIZADA';
+  items: RequisicionItemResponse[];
+}
+
+export interface CrearRequisicionRequest {
+  programa: string;
+  fichaId: string;
+  instructorId: string;
+  diaSemana: string;
+  horaSesion: string;
+  items: RequisicionItemResponse[];
+}

--- a/libs/inventario/inventario/src/lib/data-access/api/reconciliation.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/reconciliation.api.ts
@@ -1,0 +1,47 @@
+export interface ConciliacionListItemResponse {
+  id: string;
+  fecha: string;
+  ubicacion: string;
+  itemsTotal: number;
+  itemsDif: number;
+  precision: number;
+  estado: string;
+}
+
+export interface ConciliacionDetailResponse {
+  id: string;
+  fecha: string;
+  responsable: string;
+  estado: string;
+  totalItemsContados: number;
+  diferencias: number;
+  precision: number;
+  valorTotalDiferencias: number;
+}
+
+export interface DiferenciaResponse {
+  id: string;
+  producto: string;
+  codigo: string;
+  categoria: string;
+  stockSistema: number;
+  stockFisico: number;
+  diferencia: number;
+  unidad: string;
+  valorUnit: number;
+  impacto: number;
+}
+
+export interface ConteoItemRequest {
+  productoId: string;
+  conteoFisico: number;
+}
+
+export interface IniciarConteoRequest {
+  items: ConteoItemRequest[];
+}
+
+export interface ResolverDiferenciaRequest {
+  ajuste: 'SISTEMA' | 'FISICO';
+  motivo: string;
+}

--- a/libs/inventario/inventario/src/lib/data-access/api/sourcing.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/sourcing.api.ts
@@ -1,0 +1,120 @@
+export interface FacturaLineaResponse {
+  descripcion: string;
+  cantidad: number;
+  precioUnitario: number;
+  iva: number;
+  total: number;
+}
+
+export interface FacturaResponse {
+  id: string;
+  numeroFactura: string;
+  cufe: string;
+  proveedorNit: string;
+  nitReceptor: string;
+  proveedorNombre: string;
+  razonSocial: string;
+  tipoDocumento: string;
+  fechaEmision: string;
+  fechaVencimiento?: string;
+  fechaRecepcion?: string;
+  estado: 'REGISTRADA' | 'VERIFICADA' | 'PAGADA' | 'ANULADA';
+  lineas: FacturaLineaResponse[];
+  subtotal: number;
+  totalIva: number;
+  total: number;
+  ordenCompra?: string;
+  gilVinculado?: string;
+  instructorId?: string;
+  valorRetencionZese?: number;
+  motivoAnulacion?: string;
+}
+
+export interface FacturaResumenResponse {
+  totalFacturas: number;
+  tendenciaTotalFacturas: number;
+  montoMensual: number;
+  tendenciaMonto: number;
+  registradas: number;
+  verificadas: number;
+  pagadas: number;
+  anuladas: number;
+}
+
+export interface RegistrarFacturaRequest {
+  numeroFactura: string;
+  cufe: string;
+  proveedorNit: string;
+  nitReceptor: string;
+  fechaEmision: string;
+  fechaVencimiento?: string;
+  fechaRecepcion?: string;
+  lineas: Pick<FacturaLineaResponse, 'descripcion' | 'cantidad' | 'precioUnitario' | 'iva'>[];
+  ordenCompra?: string;
+  gilVinculado?: string;
+  instructorId?: string;
+  valorRetencionZese?: number;
+}
+
+export type ActualizarFacturaRequest = Partial<RegistrarFacturaRequest>;
+
+export interface AnularFacturaRequest {
+  motivoAnulacion: string;
+}
+
+export interface InfoBancariaRequest {
+  numeroCuenta: string;
+  banco: string;
+  tipoCuenta: string;
+}
+
+export interface CuentadanteGilResponse {
+  id: string;
+  nombre: string;
+  documento?: string;
+}
+
+export interface BienGilResponse {
+  codigo: string;
+  descripcion: string;
+  um: string;
+  cantidad: number;
+  valorUnitario: number;
+  subtotal: number;
+}
+
+export interface GilResponse {
+  id: string;
+  numeroGil: string;
+  fecha: string;
+  centroFormacionId: string;
+  area: string;
+  cuentadantes: CuentadanteGilResponse[];
+  destino: string;
+  fichaId: string;
+  estado: 'BORRADOR' | 'EMITIDO' | 'ENVIADO_PROVEEDOR' | 'CERRADO';
+  programaId?: string;
+  emitidoPor?: string;
+  resultadoAprendizaje?: string;
+  actividades?: string;
+  voceroNombre?: string;
+  voceroDocumento?: string;
+  solicitudesOrigenIds?: string[];
+  observaciones?: string;
+  bienes?: BienGilResponse[];
+}
+
+export interface CrearGilRequest {
+  fecha: string;
+  centroFormacionId?: string;
+  area?: string;
+  cuentadantes?: CuentadanteGilResponse[];
+  destino?: string;
+  fichaId?: string;
+}
+
+export type ActualizarGilRequest = Partial<CrearGilRequest>;
+
+export interface VincularInstructorRequest {
+  instructorId: string;
+}

--- a/libs/inventario/inventario/src/lib/data-access/mappers/alerts.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/alerts.mapper.ts
@@ -1,0 +1,33 @@
+import { Alerta } from '../../models/alerta.model';
+import { AlertaResponse, ResolverAlertaRequest } from '../api/alerts.api';
+
+export function alertaFromApi(dto: AlertaResponse): Alerta {
+  return {
+    id: dto.id,
+    tipo: dto.tipo,
+    prioridad: dto.prioridad,
+    referenciaId: dto.referenciaId,
+    referenciaTipo: dto.referenciaTipo,
+    descripcion: dto.descripcion,
+    destinatarioId: dto.destinatarioId,
+    destinatarioRol: dto.destinatarioRol,
+    fechaGeneracion: dto.fechaGeneracion,
+    estado: dto.estado,
+    fechaResolucion: dto.fechaResolucion,
+    accionResolucion: dto.accionResolucion,
+    resueltoPorId: dto.resueltoPorId,
+    codigoSena: dto.codigoSena,
+    nombreBien: dto.nombreBien,
+    stockActual: dto.stockActual,
+    stockMinimo: dto.stockMinimo,
+    unidad: dto.unidad,
+  };
+}
+
+export function resolverAlertaToRequest(
+  accion: string,
+  usuarioId: string,
+  observaciones?: string
+): ResolverAlertaRequest {
+  return { accionResolucion: accion, resueltoPorId: usuarioId, observaciones };
+}

--- a/libs/inventario/inventario/src/lib/data-access/mappers/budget.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/budget.mapper.ts
@@ -1,0 +1,42 @@
+import { Rubro } from '../../models/presupuesto.model';
+import { Consolidado } from '../../models/consolidado.model';
+import { PresupuestoResponse, ConsolidadoResponse } from '../api/budget.api';
+
+export function rubroFromApi(dto: PresupuestoResponse): Rubro {
+  return {
+    id: dto.id,
+    codigo: dto.codigo,
+    descripcion: dto.descripcion,
+    fichaId: dto.fichaId,
+    programaFormacion: dto.programaFormacion,
+    montoAsignado: dto.montoAsignado,
+    saldoDisponible: dto.saldoDisponible,
+    montoComprometido: dto.montoComprometido,
+    montoPagado: dto.montoPagado,
+    retencionZese: dto.retencionZese,
+    porcentajeEjecucion: dto.porcentajeEjecucion,
+  };
+}
+
+export function consolidadoFromApi(dto: ConsolidadoResponse): Consolidado {
+  return {
+    id: dto.id,
+    numero: dto.numero,
+    fechaGeneracion: dto.fechaGeneracion,
+    generadoPor: dto.generadoPor,
+    estado: dto.estado,
+    lineas: dto.lineas.map((l) => ({
+      id: l.id,
+      tipo: l.tipo,
+      referencia: l.referencia,
+      descripcion: l.descripcion,
+      cantidad: l.cantidad,
+      valor: l.valor,
+    })),
+    totales: {
+      totalBienes: dto.totales.totalBienes,
+      totalServicios: dto.totales.totalServicios,
+      totalGeneral: dto.totales.totalGeneral,
+    },
+  };
+}

--- a/libs/inventario/inventario/src/lib/data-access/mappers/catalog.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/catalog.mapper.ts
@@ -1,0 +1,25 @@
+import { ProductoCatalogo, BienFormDto } from '../../models/inventario.model';
+import { ProductoResponse, CrearProductoRequest } from '../api/catalog.api';
+
+export function productoFromApi(dto: ProductoResponse): ProductoCatalogo {
+  return {
+    id: dto.id,
+    codigoSena: dto.codigoSena,
+    codigoProveedor: dto.codigoProveedor,
+    nombre: dto.nombre,
+    descripcion: dto.descripcion,
+    categoria: dto.categoria,
+    unidadMedida: dto.unidadMedida,
+  };
+}
+
+export function bienFormToRequest(form: BienFormDto): CrearProductoRequest {
+  return {
+    nombre: form.nombre,
+    codigoSena: form.codigoSena,
+    codigoProveedor: form.codigoProveedor,
+    descripcion: form.descripcion,
+    categoria: form.categoria,
+    unidadMedida: form.unidadMedida,
+  };
+}

--- a/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
@@ -1,0 +1,56 @@
+import { Movimiento, ExistenciaProducto, EntradaMovimientoData, SalidaMovimientoData } from '../../models/movimiento.model';
+import { MovimientoResponse, ExistenciaResponse, EntradaRequest, SalidaRequest } from '../api/inventory.api';
+
+export function movimientoFromApi(dto: MovimientoResponse): Movimiento {
+  return {
+    id: dto.id,
+    tipo: dto.tipo,
+    productoNombre: dto.productoNombre,
+    codigoSena: dto.codigoSena,
+    cantidad: dto.cantidad,
+    unidadMedida: dto.unidadMedida,
+    fechaMovimiento: dto.fechaMovimiento,
+    responsableNombre: dto.responsableNombre,
+    valor: dto.valor,
+    estado: dto.estado,
+  };
+}
+
+export function existenciaFromApi(dto: ExistenciaResponse): ExistenciaProducto {
+  return {
+    productoId: dto.productoId,
+    codigoSena: dto.codigoSena,
+    nombre: dto.nombre,
+    categoria: dto.categoria,
+    unidadMedida: dto.unidadMedida,
+    stockDisponible: dto.stockDisponible,
+    stockMinimo: dto.stockMinimo,
+  };
+}
+
+export function entradaToRequest(data: EntradaMovimientoData): EntradaRequest {
+  return {
+    productoId: data.producto,
+    cantidad: data.cantidad,
+    fecha: data.fecha,
+    proveedorId: data.proveedor,
+    facturaId: data.factura,
+    ubicacion: data.ubicacion,
+    valorUnitario: data.valorUnitario,
+    observaciones: data.observaciones,
+  };
+}
+
+export function salidaToRequest(data: SalidaMovimientoData): SalidaRequest {
+  return {
+    productoId: data.producto,
+    cantidad: data.cantidad,
+    fecha: data.fecha,
+    areaDestino: data.areaDestino,
+    instructorId: data.instructor,
+    fichaId: data.ficha,
+    categoria: data.categoria,
+    proposito: data.proposito,
+    observaciones: data.observaciones,
+  };
+}

--- a/libs/inventario/inventario/src/lib/data-access/mappers/legalization.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/legalization.mapper.ts
@@ -1,0 +1,61 @@
+import { ActaLegalizacion } from '../../models/acta.model';
+import { PaqueteProbatorio } from '../../models/paquete.model';
+import { Requisicion, RequisicionItem } from '../../models/requisicion.model';
+import { ActaResponse, PaqueteResponse, RequisicionResponse } from '../api/legalization.api';
+
+export function actaFromApi(dto: ActaResponse): ActaLegalizacion {
+  return {
+    id: dto.id,
+    numeroActa: dto.numeroActa,
+    fecha: dto.fecha,
+    programa: dto.programa,
+    fichaId: dto.fichaId,
+    instructorId: dto.instructorId,
+    requisicionId: dto.requisicionId,
+    estado: dto.estado,
+    ciudad: dto.ciudad,
+    lugar: dto.lugar,
+    agendaSesion: dto.agendaSesion,
+    desarrolloSesion: dto.desarrolloSesion,
+    resultadoAprendizaje: dto.resultadoAprendizaje,
+    actividadesEjecutadas: dto.actividadesEjecutadas,
+  };
+}
+
+export function paqueteFromApi(dto: PaqueteResponse): PaqueteProbatorio {
+  return {
+    id: dto.id,
+    expediente: dto.expediente,
+    titulo: dto.titulo,
+    fichaId: dto.fichaId,
+    estado: dto.estado,
+    gilId: dto.gilId,
+    cufeFuenteId: dto.cufeFuenteId,
+    actaId: dto.actaId,
+    requisicionId: dto.requisicionId,
+    registroAsistenciaAdjunto: dto.registroAsistenciaAdjunto,
+    instructorId: dto.instructorId,
+    fecha: dto.fecha,
+  };
+}
+
+export function requisicionFromApi(dto: RequisicionResponse): Requisicion {
+  return {
+    id: dto.id,
+    numero: dto.numero,
+    programa: dto.programa,
+    fichaId: dto.fichaId,
+    instructorId: dto.instructorId,
+    instructorNombre: dto.instructorNombre,
+    diaSemana: dto.diaSemana,
+    horaSesion: dto.horaSesion,
+    fecha: dto.fecha,
+    estado: dto.estado,
+    items: dto.items.map((i): RequisicionItem => ({
+      codigo: i.codigo,
+      descripcion: i.descripcion,
+      cantidad: i.cantidad,
+      unidad: i.unidad,
+    })),
+  };
+}

--- a/libs/inventario/inventario/src/lib/data-access/mappers/reconciliation.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/reconciliation.mapper.ts
@@ -1,0 +1,52 @@
+import { ConciliacionRegistro, ConciliacionDetalle, DiferenciaItem } from '../../models/conciliacion.model';
+import {
+  ConciliacionListItemResponse,
+  ConciliacionDetailResponse,
+  DiferenciaResponse,
+} from '../api/reconciliation.api';
+
+export function conciliacionListItemFromApi(dto: ConciliacionListItemResponse): ConciliacionRegistro {
+  const estadoColorMap: Record<string, ConciliacionRegistro['estadoColor']> = {
+    CERRADA: 'success',
+    EN_PROCESO: 'info',
+    PENDIENTE: 'warning',
+    CON_DIFERENCIAS: 'error',
+  };
+  return {
+    id: dto.id,
+    fecha: dto.fecha,
+    ubicacion: dto.ubicacion,
+    itemsTotal: dto.itemsTotal,
+    itemsDif: dto.itemsDif,
+    precision: dto.precision,
+    estado: dto.estado,
+    estadoColor: estadoColorMap[dto.estado] ?? 'info',
+  };
+}
+
+export function conciliacionDetailFromApi(dto: ConciliacionDetailResponse): ConciliacionDetalle {
+  return {
+    id: dto.id,
+    fecha: dto.fecha,
+    responsable: dto.responsable,
+    estado: dto.estado,
+    totalItemsContados: dto.totalItemsContados,
+    diferencias: dto.diferencias,
+    precision: dto.precision,
+    valorTotalDiferencias: dto.valorTotalDiferencias,
+  };
+}
+
+export function diferenciaFromApi(dto: DiferenciaResponse): DiferenciaItem {
+  return {
+    producto: dto.producto,
+    codigo: dto.codigo,
+    categoria: dto.categoria,
+    stockSistema: dto.stockSistema,
+    stockFisico: dto.stockFisico,
+    diferencia: dto.diferencia,
+    unidad: dto.unidad,
+    valorUnit: dto.valorUnit,
+    impacto: dto.impacto,
+  };
+}

--- a/libs/inventario/inventario/src/lib/data-access/mappers/sourcing.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/sourcing.mapper.ts
@@ -1,0 +1,80 @@
+import { Factura, FacturaFormDto } from '../../models/facturas.model';
+import { SolicitudGil, BienSolicitud, CuentadanteGil } from '../../models/solicitudes-gil.model';
+import { FacturaResponse, GilResponse, RegistrarFacturaRequest } from '../api/sourcing.api';
+
+export function facturaFromApi(dto: FacturaResponse): Factura {
+  return {
+    id: dto.id,
+    numeroFactura: dto.numeroFactura,
+    cufe: dto.cufe,
+    proveedorNit: dto.proveedorNit,
+    nitReceptor: dto.nitReceptor,
+    proveedorNombre: dto.proveedorNombre,
+    razonSocial: dto.razonSocial,
+    tipoDocumento: dto.tipoDocumento,
+    fechaEmision: dto.fechaEmision,
+    fechaVencimiento: dto.fechaVencimiento,
+    fechaRecepcion: dto.fechaRecepcion,
+    estado: dto.estado,
+    lineas: dto.lineas,
+    subtotal: dto.subtotal,
+    totalIva: dto.totalIva,
+    total: dto.total,
+    ordenCompra: dto.ordenCompra,
+    gilVinculado: dto.gilVinculado,
+    instructorId: dto.instructorId,
+    valorRetencionZese: dto.valorRetencionZese,
+    motivoAnulacion: dto.motivoAnulacion,
+  };
+}
+
+export function facturaFormToRequest(form: FacturaFormDto): RegistrarFacturaRequest {
+  return {
+    numeroFactura: form.numeroFactura,
+    cufe: '',
+    proveedorNit: form.proveedorNit,
+    nitReceptor: form.nitReceptor,
+    fechaEmision: form.fechaEmision,
+    fechaVencimiento: form.fechaVencimiento,
+    fechaRecepcion: form.fechaRecepcion,
+    lineas: [],
+    ordenCompra: form.ordenCompra,
+    gilVinculado: form.gilVinculado,
+    instructorId: form.instructorId,
+    valorRetencionZese: form.valorRetencionZese,
+  };
+}
+
+export function gilFromApi(dto: GilResponse): SolicitudGil {
+  return {
+    id: dto.id,
+    numeroGil: dto.numeroGil,
+    fecha: dto.fecha,
+    centroFormacionId: dto.centroFormacionId,
+    area: dto.area,
+    cuentadantes: dto.cuentadantes.map((c): CuentadanteGil => ({
+      id: c.id,
+      nombre: c.nombre,
+      documento: c.documento,
+    })),
+    destino: dto.destino,
+    fichaId: dto.fichaId,
+    estado: dto.estado,
+    programaId: dto.programaId,
+    emitidoPor: dto.emitidoPor,
+    resultadoAprendizaje: dto.resultadoAprendizaje,
+    actividades: dto.actividades,
+    voceroNombre: dto.voceroNombre,
+    voceroDocumento: dto.voceroDocumento,
+    solicitudesOrigenIds: dto.solicitudesOrigenIds,
+    observaciones: dto.observaciones,
+    bienes: dto.bienes?.map((b): BienSolicitud => ({
+      codigo: b.codigo,
+      descripcion: b.descripcion,
+      um: b.um,
+      cantidad: b.cantidad,
+      valorUnitario: b.valorUnitario,
+      subtotal: b.subtotal,
+    })),
+  };
+}


### PR DESCRIPTION
## Resumen

- Crea la carpeta `data-access/api/` con DTOs tipados que reflejan el contrato exacto de cada endpoint del backend (`/api/v1`)
- Crea la carpeta `data-access/mappers/` con funciones puras `fromApi` / `toRequest` por contexto
- Separa el shape del backend del modelo de UI — los components no dependen directamente del contrato backend

## Contextos cubiertos

| Archivo API | Mapper | Endpoints cubiertos |
|---|---|---|
| `catalog.api.ts` | `catalog.mapper.ts` | `/catalog/productos` |
| `inventory.api.ts` | `inventory.mapper.ts` | `/inventory/movimientos` + `/existencias` |
| `alerts.api.ts` | `alerts.mapper.ts` | `/alerts/alertas` |
| `budget.api.ts` | `budget.mapper.ts` | `/budget/presupuestos` + compromisos + consolidados |
| `sourcing.api.ts` | `sourcing.mapper.ts` | `/sourcing/facturas` + `/procurement/giles` |
| `legalization.api.ts` | `legalization.mapper.ts` | `/legalization/actas` + paquetes + requisiciones |
| `reconciliation.api.ts` | `reconciliation.mapper.ts` | `/reconciliation/conciliaciones` |

## Test plan

- [ ] `nx run inventario:lint` → 0 errores (verificado en CI local)
- [ ] Sin `any` en los nuevos archivos
- [ ] Cada mapper retorna el tipo de UI correcto (verificado por TypeScript)
- [ ] No se modificó ningún archivo existente — cambio puramente aditivo

## Nota sobre tamaño

797 líneas en 14 archivos nuevos. Son interfaces TypeScript + funciones puras de mapeo sin lógica de negocio. Acordado con el dev para mantener un único PR por coherencia del ticket FE-02.