### PR TITLE
feat(inventario): FE-03 completar integración de movimientos

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
@@ -1,27 +1,54 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
-import { Movimiento, EntradaMovimientoData, SalidaMovimientoData } from '../models/movimiento.model';
+import { catchError, finalize, of } from 'rxjs';
+import {
+  Movimiento,
+  EntradaMovimientoData,
+  SalidaMovimientoData,
+  ReservaMovimientoData,
+  LiberacionMovimientoData,
+  AjusteMovimientoData,
+} from '../models/movimiento.model';
+import { ExistenciaProducto } from '../models/inventario.model';
 import { MovimientosService } from './services/movimientos.service';
-import { finalize, catchError, of } from 'rxjs';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable({ providedIn: 'root' })
 export class KardexFacade {
   private movimientosService = inject(MovimientosService);
 
-  private _movimientos = signal<Movimiento[]>([]);
+  // ── Estado ───────────────────────────────────────────────────────────────────
+  private _movimientos       = signal<Movimiento[]>([]);
   private _movimientoSeleccionado = signal<Movimiento | undefined>(undefined);
-  private _loading = signal<boolean>(false);
+  private _existencia        = signal<ExistenciaProducto | null>(null);
+  private _bajoMinimo        = signal<ExistenciaProducto[]>([]);
+  private _loading           = signal<boolean>(false);
+  private _error             = signal<string | null>(null);
 
-  public movimientos = computed(() => this._movimientos());
+  // ── Lectura pública ──────────────────────────────────────────────────────────
+  public movimientos          = computed(() => this._movimientos());
   public movimientoSeleccionado = computed(() => this._movimientoSeleccionado());
-  public loading = computed(() => this._loading());
+  public existencia           = computed(() => this._existencia());
+  public bajoMinimo           = computed(() => this._bajoMinimo());
+  public loading              = computed(() => this._loading());
+  public error                = computed(() => this._error());
 
+  // ── Kardex ───────────────────────────────────────────────────────────────────
+
+  /** El backend no expone un listado general de movimientos.
+   *  Llama cargarKardex(productoId) una vez se seleccione un producto. */
   loadAll(): void {
+    this._movimientos.set([]);
+    this._error.set(null);
+  }
+
+  cargarKardex(productoId: string): void {
     this._loading.set(true);
-    this.movimientosService.getMovimientos()
+    this._error.set(null);
+    this.movimientosService.getKardex(productoId)
       .pipe(
-        catchError(() => of([])),
+        catchError(() => {
+          this._error.set('Error al cargar el kardex');
+          return of([]);
+        }),
         finalize(() => this._loading.set(false))
       )
       .subscribe(data => this._movimientos.set(data));
@@ -37,27 +64,100 @@ export class KardexFacade {
       .subscribe(data => this._movimientoSeleccionado.set(data));
   }
 
+  // ── Existencias ──────────────────────────────────────────────────────────────
+
+  cargarExistencia(productoId: string): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.movimientosService.getExistencia(productoId)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar existencias');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(data => this._existencia.set(data));
+  }
+
+  cargarBajoMinimo(): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.movimientosService.getExistenciasBajoMinimo()
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar productos bajo mínimo');
+          return of([]);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(data => this._bajoMinimo.set(data));
+  }
+
+  // ── Registros ────────────────────────────────────────────────────────────────
+
   registrarEntrada(data: EntradaMovimientoData): void {
     this._loading.set(true);
     this.movimientosService.registrarEntrada(data)
       .pipe(
-        catchError(() => of(null)),
+        catchError(() => {
+          this._error.set('Error al registrar entrada');
+          return of(null);
+        }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe((res) => {
-        if (res) this.loadAll();
-      });
+      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
   }
 
   registrarSalida(data: SalidaMovimientoData): void {
     this._loading.set(true);
     this.movimientosService.registrarSalida(data)
       .pipe(
-        catchError(() => of(null)),
+        catchError(() => {
+          this._error.set('Error al registrar salida');
+          return of(null);
+        }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe((res) => {
-        if (res) this.loadAll();
-      });
+      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
+  }
+
+  registrarReserva(data: ReservaMovimientoData): void {
+    this._loading.set(true);
+    this.movimientosService.registrarReserva(data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al registrar reserva');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
+  }
+
+  registrarLiberacion(data: LiberacionMovimientoData): void {
+    this._loading.set(true);
+    this.movimientosService.registrarLiberacion(data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al registrar liberación');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
+  }
+
+  registrarAjuste(data: AjusteMovimientoData): void {
+    this._loading.set(true);
+    this.movimientosService.registrarAjuste(data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al registrar ajuste');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
   }
 }

--- a/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
@@ -1,6 +1,21 @@
-import { Movimiento, EntradaMovimientoData, SalidaMovimientoData } from '../../models/movimiento.model';
+import {
+  Movimiento,
+  EntradaMovimientoData,
+  SalidaMovimientoData,
+  ReservaMovimientoData,
+  LiberacionMovimientoData,
+  AjusteMovimientoData,
+} from '../../models/movimiento.model';
 import { ExistenciaProducto } from '../../models/inventario.model';
-import { MovimientoResponse, ExistenciaResponse, EntradaRequest, SalidaRequest } from '../api/inventory.api';
+import {
+  MovimientoResponse,
+  ExistenciaResponse,
+  EntradaRequest,
+  SalidaRequest,
+  ReservaRequest,
+  LiberacionRequest,
+  AjusteRequest,
+} from '../api/inventory.api';
 
 export function movimientoFromApi(dto: MovimientoResponse): Movimiento {
   return {
@@ -53,5 +68,32 @@ export function salidaToRequest(data: SalidaMovimientoData): SalidaRequest {
     categoria: data.categoria,
     proposito: data.proposito,
     observaciones: data.observaciones,
+  };
+}
+
+export function reservaToRequest(data: ReservaMovimientoData): ReservaRequest {
+  return {
+    productoId: data.producto,
+    cantidad: data.cantidad,
+    fichaId: data.fichaId,
+    instructorId: data.instructorId,
+    observaciones: data.observaciones,
+  };
+}
+
+export function liberacionToRequest(data: LiberacionMovimientoData): LiberacionRequest {
+  return {
+    productoId: data.producto,
+    cantidad: data.cantidad,
+    motivo: data.motivo,
+  };
+}
+
+export function ajusteToRequest(data: AjusteMovimientoData): AjusteRequest {
+  return {
+    productoId: data.producto,
+    cantidadNueva: data.cantidadNueva,
+    motivo: data.motivo,
+    responsableId: data.responsableId,
   };
 }

--- a/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
@@ -2,9 +2,25 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { Movimiento, EntradaMovimientoData, SalidaMovimientoData } from '../../models/movimiento.model';
-import { MovimientoResponse } from '../api/inventory.api';
-import { movimientoFromApi, entradaToRequest, salidaToRequest } from '../mappers/inventory.mapper';
+import {
+  Movimiento,
+  EntradaMovimientoData,
+  SalidaMovimientoData,
+  ReservaMovimientoData,
+  LiberacionMovimientoData,
+  AjusteMovimientoData,
+} from '../../models/movimiento.model';
+import { ExistenciaProducto } from '../../models/inventario.model';
+import { MovimientoResponse, ExistenciaResponse } from '../api/inventory.api';
+import {
+  movimientoFromApi,
+  existenciaFromApi,
+  entradaToRequest,
+  salidaToRequest,
+  reservaToRequest,
+  liberacionToRequest,
+  ajusteToRequest,
+} from '../mappers/inventory.mapper';
 
 const API = '/api/v1';
 
@@ -12,9 +28,12 @@ const API = '/api/v1';
 export class MovimientosService {
   private http = inject(HttpClient);
 
-  getMovimientos(): Observable<Movimiento[]> {
+  // ── Kardex ──────────────────────────────────────────────────────────────────
+
+  /** Historial de movimientos de un producto (GET /inventory/movimientos/{productoId}) */
+  getKardex(productoId: string): Observable<Movimiento[]> {
     return this.http
-      .get<MovimientoResponse[]>(`${API}/inventory/movimientos`)
+      .get<MovimientoResponse[]>(`${API}/inventory/movimientos/${productoId}`)
       .pipe(
         map(list => list.map(movimientoFromApi)),
         catchError(err => throwError(() => err))
@@ -30,6 +49,30 @@ export class MovimientosService {
       );
   }
 
+  // ── Existencias ─────────────────────────────────────────────────────────────
+
+  /** Stock de un producto (GET /inventory/existencias/{productoId}) */
+  getExistencia(productoId: string): Observable<ExistenciaProducto> {
+    return this.http
+      .get<ExistenciaResponse>(`${API}/inventory/existencias/${productoId}`)
+      .pipe(
+        map(existenciaFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** Productos bajo el mínimo de stock (GET /inventory/existencias/bajo-minimo) */
+  getExistenciasBajoMinimo(): Observable<ExistenciaProducto[]> {
+    return this.http
+      .get<ExistenciaResponse[]>(`${API}/inventory/existencias/bajo-minimo`)
+      .pipe(
+        map(list => list.map(existenciaFromApi)),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  // ── Movimientos de entrada / salida ─────────────────────────────────────────
+
   registrarEntrada(data: EntradaMovimientoData): Observable<{ success: boolean }> {
     return this.http
       .post<{ success: boolean }>(`${API}/inventory/movimientos/entrada`, entradaToRequest(data))
@@ -39,6 +82,26 @@ export class MovimientosService {
   registrarSalida(data: SalidaMovimientoData): Observable<{ success: boolean }> {
     return this.http
       .post<{ success: boolean }>(`${API}/inventory/movimientos/salida`, salidaToRequest(data))
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  // ── Reserva / Liberación / Ajuste ───────────────────────────────────────────
+
+  registrarReserva(data: ReservaMovimientoData): Observable<{ success: boolean }> {
+    return this.http
+      .post<{ success: boolean }>(`${API}/inventory/movimientos/reserva`, reservaToRequest(data))
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  registrarLiberacion(data: LiberacionMovimientoData): Observable<{ success: boolean }> {
+    return this.http
+      .post<{ success: boolean }>(`${API}/inventory/movimientos/liberacion`, liberacionToRequest(data))
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  registrarAjuste(data: AjusteMovimientoData): Observable<{ success: boolean }> {
+    return this.http
+      .post<{ success: boolean }>(`${API}/inventory/movimientos/ajuste`, ajusteToRequest(data))
       .pipe(catchError(err => throwError(() => err)));
   }
 }

--- a/libs/inventario/inventario/src/lib/models/movimiento.model.ts
+++ b/libs/inventario/inventario/src/lib/models/movimiento.model.ts
@@ -37,3 +37,27 @@ export interface SalidaMovimientoData {
   proposito: string;
   observaciones?: string;
 }
+
+/** Payload para reservar stock de un producto */
+export interface ReservaMovimientoData {
+  producto: string;
+  cantidad: number;
+  fichaId: string;
+  instructorId: string;
+  observaciones?: string;
+}
+
+/** Payload para liberar una reserva existente */
+export interface LiberacionMovimientoData {
+  producto: string;
+  cantidad: number;
+  motivo: string;
+}
+
+/** Payload para ajustar el inventario físico de un producto */
+export interface AjusteMovimientoData {
+  producto: string;
+  cantidadNueva: number;
+  motivo: string;
+  responsableId: string;
+}


### PR DESCRIPTION
## Resumen

Completa el service de movimientos con los 5 endpoints faltantes del backend y actualiza la `KardexFacade` para exponerlos como signals reactivos.

## Cambios

### `movimiento.model.ts`
Agrega los tipos de datos para los formularios nuevos:
- `ReservaMovimientoData` — fichaId + instructorId + cantidad
- `LiberacionMovimientoData` — producto + cantidad + motivo
- `AjusteMovimientoData` — cantidadNueva + motivo + responsableId

### `inventory.mapper.ts`
Agrega `reservaToRequest`, `liberacionToRequest` y `ajusteToRequest`.

### `movimientos.service.ts` — endpoints nuevos
| Método | Endpoint |
|---|---|
| `getKardex(productoId)` | `GET /inventory/movimientos/{productoId}` |
| `getExistencia(productoId)` | `GET /inventory/existencias/{productoId}` |
| `getExistenciasBajoMinimo()` | `GET /inventory/existencias/bajo-minimo` |
| `registrarReserva(data)` | `POST /inventory/movimientos/reserva` |
| `registrarLiberacion(data)` | `POST /inventory/movimientos/liberacion` |
| `registrarAjuste(data)` | `POST /inventory/movimientos/ajuste` |

### `kardex.facade.ts`
- Signals nuevos: `existencia`, `bajoMinimo`, `error`
- Métodos nuevos: `cargarKardex`, `cargarExistencia`, `cargarBajoMinimo`, `registrarReserva`, `registrarLiberacion`, `registrarAjuste`
- `loadAll()` se conserva como shim vacío (el backend no expone listado general de movimientos)

## Test plan
- [ ] `nx run inventario:lint` → 0 errores ✅
- [ ] Build monorepo limpio ✅
- [ ] Sin mocks en el service
- [ ] Los 5 tipos de movimiento tienen endpoint y mapper