### PR TITLE
feat(inventario): métodos puntuales faltantes — Grupo 1

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/alertas.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/alertas.facade.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { AlertasService } from './services/alertas.service';
 import { Alerta, RegistroHistorial, UmbralConfig } from '../models/alerta.model';
-import { finalize, catchError, of, firstValueFrom } from 'rxjs';
+import { finalize, catchError, of, firstValueFrom, forkJoin } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -88,21 +88,24 @@ export class AlertasFacade {
 
   /**
    * Guarda los umbrales de configuración.
+   * Llama PUT /alerts/alertas/umbrales/{productoId} por cada umbral modificado.
    */
   guardarUmbrales(nuevosUmbrales: UmbralConfig[]): void {
+    if (!nuevosUmbrales.length) return;
     this._loading.set(true);
-    this.alertasService.updateUmbrales(nuevosUmbrales)
+    const requests$ = nuevosUmbrales.map(u =>
+      this.alertasService.updateUmbral(u.id, u.stockMinimo)
+    );
+    forkJoin(requests$)
       .pipe(
         catchError(() => {
           this._error.set('Error al guardar umbrales');
-          return of(false);
+          return of([]);
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe((res) => {
-        if (res) {
-          this._umbrales.set(nuevosUmbrales);
-        }
+      .subscribe(res => {
+        if (res.length) this._umbrales.set(nuevosUmbrales);
       });
   }
 

--- a/libs/inventario/inventario/src/lib/data-access/api/alerts.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/alerts.api.ts
@@ -24,3 +24,17 @@ export interface ResolverAlertaRequest {
   resueltoPorId: string;
   observaciones?: string;
 }
+
+/** GET /alerts/alertas/umbrales — existencia con flags de stock */
+export interface UmbralStockResponse {
+  productoId: string;
+  stockFisico: number;
+  stockDisponible: number;
+  stockMinimo: number;
+  bajoMinimo: boolean;
+}
+
+/** PUT /alerts/alertas/umbrales/{productoId} */
+export interface ActualizarUmbralRequest {
+  nuevoMinimo: number;
+}

--- a/libs/inventario/inventario/src/lib/data-access/api/sourcing.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/sourcing.api.ts
@@ -118,3 +118,9 @@ export type ActualizarGilRequest = Partial<CrearGilRequest>;
 export interface VincularInstructorRequest {
   instructorId: string;
 }
+
+/** PUT /procurement/giles/{id}/enviar-proveedor */
+export interface EnviarProveedorRequest {
+  proveedorDestinatarioId: string;
+  fechaEnvio: string;
+}

--- a/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
@@ -131,6 +131,55 @@ export class FacturasFacade {
       });
   }
 
+  /** Verifica la factura (dispara entrada automática de stock) */
+  verificarFactura(id: string | number): void {
+    this._loading.set(true);
+    this.svc.verificarFactura(id)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al verificar la factura');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res) { this._facturaSeleccionada.set(res); this.cargarFacturas(); }
+      });
+  }
+
+  /** Marca la factura como pagada (solo desde estado VERIFICADA) */
+  marcarPagada(id: string | number): void {
+    this._loading.set(true);
+    this.svc.marcarPagada(id)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al marcar la factura como pagada');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res) { this._facturaSeleccionada.set(res); this.cargarFacturas(); }
+      });
+  }
+
+  /** Actualiza los datos bancarios del proveedor (solo en REGISTRADA o VERIFICADA) */
+  actualizarInfoBancaria(
+    id: string | number,
+    data: { banco: string; tipoCuenta: string; numeroCuenta: string },
+  ): void {
+    this._loading.set(true);
+    this.svc.actualizarInfoBancaria(id, data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al actualizar la información bancaria');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res) this._facturaSeleccionada.set(res); });
+  }
+
   /** Carga una solicitud GIL */
   cargarSolicitudGIL(id: string): void {
     this.svc.getSolicitudGIL(id)

--- a/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
@@ -129,6 +129,23 @@ export class InventarioFacade {
   }
 
   /**
+   * Desactiva un bien (soft delete → activo: false).
+   * Usa PATCH /catalog/productos/{id}/desactivar.
+   */
+  desactivarBien(id: string | number): void {
+    this._loading.set(true);
+    this.bienesService.desactivarBien(id)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al desactivar el bien');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res !== null) this.cargarBienes(); });
+  }
+
+  /**
    * Actualiza un bien existente y refresca los datos.
    */
   actualizarBien(id: string | number, dto: BienFormDto): void {

--- a/libs/inventario/inventario/src/lib/data-access/mappers/alerts.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/alerts.mapper.ts
@@ -1,5 +1,5 @@
-import { Alerta } from '../../models/alerta.model';
-import { AlertaResponse, ResolverAlertaRequest } from '../api/alerts.api';
+import { Alerta, UmbralConfig } from '../../models/alerta.model';
+import { AlertaResponse, ResolverAlertaRequest, UmbralStockResponse } from '../api/alerts.api';
 
 export function alertaFromApi(dto: AlertaResponse): Alerta {
   return {
@@ -30,4 +30,20 @@ export function resolverAlertaToRequest(
   observaciones?: string
 ): ResolverAlertaRequest {
   return { accionResolucion: accion, resueltoPorId: usuarioId, observaciones };
+}
+
+/** GET /alerts/alertas/umbrales → UmbralConfig
+ *  Los campos de UI (bien, categoria, icono, emailActivo, correos) no existen
+ *  en el response del backend; se rellenan con defaults hasta que se enriquezcan. */
+export function umbralFromApi(dto: UmbralStockResponse): UmbralConfig {
+  return {
+    id:           dto.productoId,
+    bien:         dto.productoId, // TODO: enriquecer con nombre desde /catalog/productos/{id}
+    categoria:    '',
+    icono:        'inventory',
+    stockMinimo:  dto.stockMinimo,
+    emailActivo:  false,
+    correos:      '',
+    enAlerta:     dto.bajoMinimo,
+  };
 }

--- a/libs/inventario/inventario/src/lib/data-access/paquete.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/paquete.facade.ts
@@ -77,6 +77,20 @@ export class PaqueteFacade {
       });
   }
 
+  /** Archiva el paquete y recarga su detalle. */
+  archivarPaquete(id: string): void {
+    this._loading.set(true);
+    this.paqueteService.archivarPaquete(id)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al archivar el paquete');
+          return of(false);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(ok => { if (ok) this.cargarPaquete(id); });
+  }
+
   /** Incluye una requisición en el paquete y recarga su detalle. */
   incluirRequisicion(paqueteId: string, reqId: string): void {
     this.paqueteService.incluirRequisicion(paqueteId, reqId)

--- a/libs/inventario/inventario/src/lib/data-access/services/alertas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/alertas.service.ts
@@ -2,15 +2,17 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { Alerta } from '../../models/alerta.model';
-import { AlertaResponse, ResolverAlertaRequest } from '../api/alerts.api';
-import { alertaFromApi } from '../mappers/alerts.mapper';
+import { Alerta, UmbralConfig } from '../../models/alerta.model';
+import { AlertaResponse, UmbralStockResponse, ActualizarUmbralRequest } from '../api/alerts.api';
+import { alertaFromApi, umbralFromApi } from '../mappers/alerts.mapper';
 
 const API = '/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class AlertasService {
   private http = inject(HttpClient);
+
+  // ── Alertas ──────────────────────────────────────────────────────────────────
 
   getAlertas(): Observable<Alerta[]> {
     return this.http
@@ -39,24 +41,34 @@ export class AlertasService {
       );
   }
 
-  // ── FE-05: los métodos de umbrales e historial no tienen endpoint en backend aún ──
+  // ── Umbrales ─────────────────────────────────────────────────────────────────
 
-  /** TODO FE-05 — endpoint pendiente de confirmación con backend */
-  getUmbrales(): Observable<never> {
-    return throwError(() => new Error('getUmbrales: endpoint no disponible — pendiente FE-05'));
+  /** GET /alerts/alertas/umbrales — lista todos los productos con existencia registrada */
+  getUmbrales(): Observable<UmbralConfig[]> {
+    return this.http
+      .get<UmbralStockResponse[]>(`${API}/alerts/alertas/umbrales`)
+      .pipe(
+        map(list => list.map(umbralFromApi)),
+        catchError(err => throwError(() => err))
+      );
   }
 
-  /** TODO FE-05 — endpoint pendiente de confirmación con backend */
-  updateUmbrales(_umbrales: unknown): Observable<never> {
-    return throwError(() => new Error('updateUmbrales: endpoint no disponible — pendiente FE-05'));
+  /** PUT /alerts/alertas/umbrales/{productoId} — actualiza el mínimo de un producto */
+  updateUmbral(productoId: string, nuevoMinimo: number): Observable<UmbralStockResponse> {
+    const body: ActualizarUmbralRequest = { nuevoMinimo };
+    return this.http
+      .put<UmbralStockResponse>(`${API}/alerts/alertas/umbrales/${productoId}`, body)
+      .pipe(catchError(err => throwError(() => err)));
   }
 
-  /** TODO FE-05 — endpoint pendiente de confirmación con backend */
+  // ── Historial (Reporting) ─────────────────────────────────────────────────────
+
+  /** TODO FE-05 — wired en reporting: GET /reporting/alertas/resumen */
   getHistorial(): Observable<never> {
-    return throwError(() => new Error('getHistorial: endpoint no disponible — pendiente FE-05'));
+    return throwError(() => new Error('getHistorial: usar /reporting/alertas/resumen — pendiente FE-05'));
   }
 
-  /** TODO FE-05 — endpoint pendiente de confirmación con backend */
+  /** TODO FE-05 — sin endpoint de exportación CSV */
   exportarHistorialCSV(): Observable<never> {
     return throwError(() => new Error('exportarHistorialCSV: endpoint no disponible — pendiente FE-05'));
   }

--- a/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
@@ -89,4 +89,14 @@ export class BienesService {
       .delete<void>(`${API}/catalog/productos/${id}`)
       .pipe(catchError(err => throwError(() => err)));
   }
+
+  /** PATCH /catalog/productos/{id}/desactivar — soft delete: marca activo=false */
+  desactivarBien(id: string | number): Observable<Bien> {
+    return this.http
+      .patch<ProductoResponse>(`${API}/catalog/productos/${id}/desactivar`, {})
+      .pipe(
+        map(bienFromCatalogo),
+        catchError(err => throwError(() => err))
+      );
+  }
 }

--- a/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
@@ -81,6 +81,39 @@ export class FacturasService {
       .pipe(catchError(err => throwError(() => err)));
   }
 
+  /** PATCH /sourcing/facturas/{id}/verificar — dispara entrada automática de stock */
+  verificarFactura(id: string | number): Observable<Factura> {
+    return this.http
+      .patch<FacturaResponse>(`${API}/sourcing/facturas/${id}/verificar`, {})
+      .pipe(
+        map(facturaFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** PATCH /sourcing/facturas/{id}/pagar — solo válido desde estado VERIFICADA */
+  marcarPagada(id: string | number): Observable<Factura> {
+    return this.http
+      .patch<FacturaResponse>(`${API}/sourcing/facturas/${id}/pagar`, {})
+      .pipe(
+        map(facturaFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** PATCH /sourcing/facturas/{id}/info-bancaria — solo en estados REGISTRADA o VERIFICADA */
+  actualizarInfoBancaria(
+    id: string | number,
+    data: { banco: string; tipoCuenta: string; numeroCuenta: string },
+  ): Observable<Factura> {
+    return this.http
+      .patch<FacturaResponse>(`${API}/sourcing/facturas/${id}/info-bancaria`, data)
+      .pipe(
+        map(facturaFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
   /** Mapea GilResponse al tipo SolicitudGIL que usa la FacturasFacade.
    *  SolicitudGIL (facturas.model) y SolicitudGil (solicitudes-gil.model) son dos
    *  tipos distintos — unificarlos es trabajo de un refactor posterior. */

--- a/libs/inventario/inventario/src/lib/data-access/services/paquete.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/paquete.service.ts
@@ -73,4 +73,14 @@ export class PaqueteService {
   incluirRequisicion(paqueteId: string, reqId: string): Observable<boolean> {
     return this.vincularTrazabilidad(paqueteId, { requisicionId: reqId });
   }
+
+  /** PATCH /legalization/paquetes/{id}/archivar */
+  archivarPaquete(id: string): Observable<boolean> {
+    return this.http
+      .patch<void>(`${API}/legalization/paquetes/${id}/archivar`, {})
+      .pipe(
+        map(() => true),
+        catchError(err => throwError(() => err))
+      );
+  }
 }

--- a/libs/inventario/inventario/src/lib/data-access/services/solicitudes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/solicitudes.service.ts
@@ -9,7 +9,7 @@ import {
   CrearSolicitudData,
   ActualizarSolicitudData,
 } from '../../models/solicitudes-gil.model';
-import { GilResponse } from '../api/sourcing.api';
+import { GilResponse, EnviarProveedorRequest } from '../api/sourcing.api';
 import { gilFromApi } from '../mappers/sourcing.mapper';
 
 const API = '/api/v1';
@@ -62,16 +62,26 @@ export class SolicitudesService {
 
   cambiarEstado(id: string, estado: EstadoGil): Observable<boolean> {
     const accionMap: Record<EstadoGil, string> = {
-      BORRADOR:         '',
-      EMITIDO:          'emitir',
-      ENVIADO_PROVEEDOR: 'enviar-proveedor',
-      CERRADO:          'cerrar',
+      BORRADOR:          '',
+      EMITIDO:           'emitir',
+      ENVIADO_PROVEEDOR: '', // usa enviarAProveedor() — requiere PUT con body
+      CERRADO:           'cerrar',
     };
     const accion = accionMap[estado];
-    if (!accion) return throwError(() => new Error(`Estado ${estado} sin endpoint de transición`));
+    if (!accion) return throwError(() => new Error(`Estado ${estado} sin endpoint de transición PATCH`));
 
     return this.http
       .patch<void>(`${API}/procurement/giles/${id}/${accion}`, {})
+      .pipe(
+        map(() => true),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** PUT /procurement/giles/{id}/enviar-proveedor — requiere body con proveedorDestinatarioId y fechaEnvio */
+  enviarAProveedor(id: string, data: EnviarProveedorRequest): Observable<boolean> {
+    return this.http
+      .put<GilResponse>(`${API}/procurement/giles/${id}/enviar-proveedor`, data)
       .pipe(
         map(() => true),
         catchError(err => throwError(() => err))

--- a/libs/inventario/inventario/src/lib/data-access/solicitudes.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/solicitudes.facade.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { SolicitudGil, SolicitudesGilFiltros, EstadoGil, CrearSolicitudData, ActualizarSolicitudData } from '../models/solicitudes-gil.model';
 import { SolicitudesService } from './services/solicitudes.service';
+import { EnviarProveedorRequest } from './api/sourcing.api';
 import { finalize, catchError, of } from 'rxjs';
 
 @Injectable({
@@ -144,6 +145,20 @@ export class SolicitudesFacade {
           this.cargarSolicitudes();
         }
       });
+  }
+
+  /** PUT /procurement/giles/{id}/enviar-proveedor con proveedorDestinatarioId y fechaEnvio */
+  enviarAProveedor(id: string, data: EnviarProveedorRequest): void {
+    this._loading.set(true);
+    this.solicitudesService.enviarAProveedor(id, data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al enviar el GIL al proveedor');
+          return of(false);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(ok => { if (ok) this.cargarSolicitudById(id); });
   }
 
   generarGils(ids: (string | number)[]): void {


### PR DESCRIPTION
## Qué cambia

7 endpoints que faltaban en services y facades existentes, sin tocar modelos ni routing.

### Services
| Service | Método nuevo | Endpoint |
|---------|-------------|----------|
| `facturas.service` | `verificarFactura(id)` | PATCH `/sourcing/facturas/{id}/verificar` |
| `facturas.service` | `marcarPagada(id)` | PATCH `/sourcing/facturas/{id}/pagar` |
| `facturas.service` | `actualizarInfoBancaria(id, data)` | PATCH `/sourcing/facturas/{id}/info-bancaria` |
| `solicitudes.service` | `enviarAProveedor(id, data)` | **PUT** `/procurement/giles/{id}/enviar-proveedor` (con body) |
| `bienes.service` | `desactivarBien(id)` | PATCH `/catalog/productos/{id}/desactivar` |
| `paquete.service` | `archivarPaquete(id)` | PATCH `/legalization/paquetes/{id}/archivar` |
| `alertas.service` | `getUmbrales()` + `updateUmbral(productoId, nuevoMinimo)` | GET/PUT `/alerts/alertas/umbrales` |

### Facades
Cada método de service queda expuesto en su facade correspondiente (`FacturasFacade`, `SolicitudesFacade`, `InventarioFacade`, `PaqueteFacade`, `AlertasFacade`).

### APIs + Mappers
- `alerts.api`: `UmbralStockResponse`, `ActualizarUmbralRequest`
- `sourcing.api`: `EnviarProveedorRequest`
- `alerts.mapper`: `umbralFromApi()` — mapea `productoId → id`, `bajoMinimo → enAlerta`

## Notas
- `enviarAProveedor` usa **PUT** (no PATCH), separado de `cambiarEstado` que usaba PATCH sin body
- `guardarUmbrales` en `AlertasFacade` usa `forkJoin` para llamar un PUT por cada umbral modificado
- `umbralFromApi` rellena con defaults los campos UI sin equivalente en backend (`bien`, `categoria`, `icono`, `emailActivo`, `correos`)

## Test plan
- [ ] Verificar factura → estado cambia a VERIFICADA, lista se recarga
- [ ] Marcar pagada → solo funciona desde VERIFICADA (409 en otro estado)
- [ ] Actualizar info bancaria → sólo en REGISTRADA o VERIFICADA
- [ ] Enviar GIL a proveedor con proveedorDestinatarioId y fechaEnvio → estado ENVIADO_PROVEEDOR
- [ ] Desactivar bien → bien aparece con activo: false en listado
- [ ] Archivar paquete → estado del paquete cambia
- [ ] Cargar umbrales → lista de productos con stockMinimo real del backend
- [ ] Guardar umbral modificado → PUT por cada fila editada

🤖 Generated with [Claude Code](https://claude.com/claude-code)