### PR TITLE
feat(inventario): compromisos presupuestales — Grupo 2

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/budget.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/budget.api.ts
@@ -20,25 +20,38 @@ export interface RegistrarPresupuestoRequest {
   bolsaInicial: number;
 }
 
+/** GET /budget/compromisos — item de la lista */
 export interface CompromisoResponse {
   id: string;
-  gilId: string;
   presupuestoId: string;
+  rubroId: string;
+  gilId?: string;
+  concepto: string;
   monto: number;
-  estado: 'ACTIVO' | 'ANULADO' | 'PAGADO';
+  montoRetencionZese: number;
   fecha: string;
+  estado: 'VIGENTE' | 'ANULADO';
 }
 
+/** POST /budget/compromisos */
 export interface ComprometerRequest {
-  gilId: string;
   presupuestoId: string;
+  rubroId: string;
+  gilId?: string;
+  facturaId?: string;
+  fichaId: string;
+  programaId: string;
+  concepto: string;
   monto: number;
+  aplicarZESE: boolean;
+  fecha: string;
 }
 
+/** POST /budget/compromisos/{id}/pagos */
 export interface PagoRequest {
+  cufeFuenteId: string;
   monto: number;
   fecha: string;
-  referencia: string;
 }
 
 export interface LineaConsolidadoResponse {

--- a/libs/inventario/inventario/src/lib/data-access/mappers/budget.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/budget.mapper.ts
@@ -1,6 +1,6 @@
-import { Rubro } from '../../models/presupuesto.model';
+import { Rubro, Compromiso } from '../../models/presupuesto.model';
 import { Consolidado } from '../../models/consolidado.model';
-import { PresupuestoResponse, ConsolidadoResponse } from '../api/budget.api';
+import { PresupuestoResponse, ConsolidadoResponse, CompromisoResponse } from '../api/budget.api';
 
 export function rubroFromApi(dto: PresupuestoResponse): Rubro {
   return {
@@ -15,6 +15,20 @@ export function rubroFromApi(dto: PresupuestoResponse): Rubro {
     montoPagado: dto.montoPagado,
     retencionZese: dto.retencionZese,
     porcentajeEjecucion: dto.porcentajeEjecucion,
+  };
+}
+
+export function compromisoFromApi(dto: CompromisoResponse): Compromiso {
+  return {
+    id:                 dto.id,
+    presupuestoId:      dto.presupuestoId,
+    rubroId:            dto.rubroId,
+    gilId:              dto.gilId,
+    concepto:           dto.concepto,
+    monto:              dto.monto,
+    montoRetencionZese: dto.montoRetencionZese,
+    fecha:              dto.fecha,
+    estado:             dto.estado,
   };
 }
 

--- a/libs/inventario/inventario/src/lib/data-access/presupuesto.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/presupuesto.facade.ts
@@ -10,6 +10,9 @@ import {
   EjecucionMensual,
   RegistrarPresupuestoData,
   TrasladarRubroData,
+  Compromiso,
+  ComprometerData,
+  PagoData,
 } from '../models/presupuesto.model';
 
 @Injectable({ providedIn: 'root' })
@@ -19,6 +22,7 @@ export class PresupuestoFacade {
   // Estados internos (Signals)
   private _resumen          = signal<PresupuestoResumen | null>(null);
   private _rubros           = signal<Rubro[]>([]);
+  private _compromisos      = signal<Compromiso[]>([]);
   private _afectaciones     = signal<AfectacionPresupuestal[]>([]);
   private _vencimientos     = signal<VencimientoProximo[]>([]);
   private _ejecucionMensual = signal<EjecucionMensual[]>([]);
@@ -28,6 +32,7 @@ export class PresupuestoFacade {
   // Exposición pública (solo lectura)
   public resumen          = computed(() => this._resumen());
   public rubros           = computed(() => this._rubros());
+  public compromisos      = computed(() => this._compromisos());
   public afectaciones     = computed(() => this._afectaciones());
   public vencimientos     = computed(() => this._vencimientos());
   public ejecucionMensual = computed(() => this._ejecucionMensual());
@@ -106,6 +111,72 @@ export class PresupuestoFacade {
       checkLoading();
     });
   }
+
+  // ── Compromisos ────────────────────────────────────────────────────────────
+
+  /** Carga compromisos con filtros opcionales de presupuesto y estado */
+  cargarCompromisos(presupuestoId?: string, estado?: 'VIGENTE' | 'ANULADO'): void {
+    this._loading.set(true);
+    this.presupuestoService.getCompromisos(presupuestoId, estado)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar los compromisos');
+          return of([]);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(data => this._compromisos.set(data));
+  }
+
+  /** Crea un compromiso presupuestal y recarga la lista */
+  comprometer(data: ComprometerData): void {
+    this._loading.set(true);
+    this.presupuestoService.comprometer(data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al comprometer el presupuesto');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res) this.cargarCompromisos(data.presupuestoId);
+      });
+  }
+
+  /** Anula un compromiso y recarga la lista */
+  anularCompromiso(id: string, presupuestoId?: string): void {
+    this._loading.set(true);
+    this.presupuestoService.anularCompromiso(id)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al anular el compromiso');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res !== null) this.cargarCompromisos(presupuestoId);
+      });
+  }
+
+  /** Registra un pago contra un compromiso y recarga la lista */
+  registrarPago(compromisoId: string, data: PagoData, presupuestoId?: string): void {
+    this._loading.set(true);
+    this.presupuestoService.registrarPago(compromisoId, data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al registrar el pago');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res) this.cargarCompromisos(presupuestoId);
+      });
+  }
+
+  // ── Presupuestos ────────────────────────────────────────────────────────────
 
   registrarPresupuesto(data: RegistrarPresupuestoData): void {
     this._loading.set(true);

--- a/libs/inventario/inventario/src/lib/data-access/services/presupuesto.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/presupuesto.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import {
@@ -10,9 +10,12 @@ import {
   EjecucionMensual,
   RegistrarPresupuestoData,
   TrasladarRubroData,
+  Compromiso,
+  ComprometerData,
+  PagoData,
 } from '../../models/presupuesto.model';
-import { PresupuestoResponse } from '../api/budget.api';
-import { rubroFromApi } from '../mappers/budget.mapper';
+import { PresupuestoResponse, CompromisoResponse, ComprometerRequest, PagoRequest } from '../api/budget.api';
+import { rubroFromApi, compromisoFromApi } from '../mappers/budget.mapper';
 
 const API = '/api/v1';
 
@@ -55,6 +58,60 @@ export class PresupuestoService {
         map(() => ({ success: true })),
         catchError(err => throwError(() => err))
       );
+  }
+
+  // ── Compromisos ──────────────────────────────────────────────────────────────
+
+  /** GET /budget/compromisos — lista filtrada por presupuesto y/o estado */
+  getCompromisos(presupuestoId?: string, estado?: 'VIGENTE' | 'ANULADO'): Observable<Compromiso[]> {
+    let params = new HttpParams();
+    if (presupuestoId) params = params.set('presupuestoId', presupuestoId);
+    if (estado)        params = params.set('estado', estado);
+
+    return this.http
+      .get<CompromisoResponse[]>(`${API}/budget/compromisos`, { params })
+      .pipe(
+        map(list => list.map(compromisoFromApi)),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** POST /budget/compromisos — aplica retención ZESE si aplicarZESE=true */
+  comprometer(data: ComprometerData): Observable<{ id: string }> {
+    const body: ComprometerRequest = {
+      presupuestoId: data.presupuestoId,
+      rubroId:       data.rubroId,
+      gilId:         data.gilId,
+      facturaId:     data.facturaId,
+      fichaId:       data.fichaId,
+      programaId:    data.programaId,
+      concepto:      data.concepto,
+      monto:         data.monto,
+      aplicarZESE:   data.aplicarZESE,
+      fecha:         data.fecha,
+    };
+    return this.http
+      .post<{ id: string }>(`${API}/budget/compromisos`, body)
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  /** PATCH /budget/compromisos/{id}/anular — 422 si ya anulado */
+  anularCompromiso(id: string): Observable<void> {
+    return this.http
+      .patch<void>(`${API}/budget/compromisos/${id}/anular`, {})
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  /** POST /budget/compromisos/{id}/pagos */
+  registrarPago(compromisoId: string, data: PagoData): Observable<{ id: string }> {
+    const body: PagoRequest = {
+      cufeFuenteId: data.cufeFuenteId,
+      monto:        data.monto,
+      fecha:        data.fecha,
+    };
+    return this.http
+      .post<{ id: string }>(`${API}/budget/compromisos/${compromisoId}/pagos`, body)
+      .pipe(catchError(err => throwError(() => err)));
   }
 
   // ── FE-06: los métodos siguientes requieren alineación con backend ──

--- a/libs/inventario/inventario/src/lib/models/presupuesto.model.ts
+++ b/libs/inventario/inventario/src/lib/models/presupuesto.model.ts
@@ -90,6 +90,42 @@ export interface TrasladarRubroData {
   motivo?: string;
 }
 
+// ── Compromisos presupuestales ────────────────────────────────────────────────
+
+/** Compromiso presupuestal (GET /budget/compromisos) */
+export interface Compromiso {
+  id: string;
+  presupuestoId: string;
+  rubroId: string;
+  gilId?: string;
+  concepto: string;
+  monto: number;
+  montoRetencionZese: number;
+  fecha: string;
+  estado: 'VIGENTE' | 'ANULADO';
+}
+
+/** Payload UI para comprometer presupuesto (POST /budget/compromisos) */
+export interface ComprometerData {
+  presupuestoId: string;
+  rubroId: string;
+  gilId?: string;
+  facturaId?: string;
+  fichaId: string;
+  programaId: string;
+  concepto: string;
+  monto: number;
+  aplicarZESE: boolean;
+  fecha: string;
+}
+
+/** Payload UI para registrar pago (POST /budget/compromisos/{id}/pagos) */
+export interface PagoData {
+  cufeFuenteId: string;
+  monto: number;
+  fecha: string;
+}
+
 // ============================================================
 // MOCKS
 // ============================================================


### PR DESCRIPTION
## Qué cambia

Implementa el bloque de compromisos presupuestales, que faltaba completamente.

### Correcciones en `budget.api.ts`
Los DTOs existentes no coincidían con el contrato del backend:
- `CompromisoResponse`: agrega `rubroId`, `concepto`, `montoRetencionZese`; estado cambia de `ACTIVO|ANULADO|PAGADO` → `VIGENTE|ANULADO`
- `ComprometerRequest`: agrega `rubroId`, `fichaId`, `programaId`, `concepto`, `aplicarZESE`, `fecha`
- `PagoRequest`: cambia `referencia` → `cufeFuenteId` (contrato real del backend)

### Nuevos en `presupuesto.model.ts`
- `Compromiso` — modelo UI del compromiso
- `ComprometerData` — payload de entrada para comprometer
- `PagoData` — payload de entrada para registrar pago

### `budget.mapper.ts`
- `compromisoFromApi()` — mapea `CompromisoResponse → Compromiso`

### `presupuesto.service.ts` — 4 métodos nuevos
| Método | Endpoint |
|--------|----------|
| `getCompromisos(presupuestoId?, estado?)` | GET `/budget/compromisos` |
| `comprometer(data)` | POST `/budget/compromisos` |
| `anularCompromiso(id)` | PATCH `/budget/compromisos/{id}/anular` |
| `registrarPago(id, data)` | POST `/budget/compromisos/{id}/pagos` |

### `presupuesto.facade.ts`
- Signal `_compromisos` + computed `compromisos`
- `cargarCompromisos()`, `comprometer()`, `anularCompromiso()`, `registrarPago()`

## Test plan
- [ ] `cargarCompromisos()` → lista compromisos del backend
- [ ] `comprometer()` con `aplicarZESE=true` → `montoRetencionZese > 0` en response
- [ ] `anularCompromiso()` → estado pasa a ANULADO; 422 si ya anulado
- [ ] `registrarPago()` con `cufeFuenteId` válido → 201 con id de pago

🤖 Generated with [Claude Code](https://claude.com/claude-code)