### PR TITLE
feat(inventario): registrarConteo y resolverDiferencia — Grupo 3

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/reconciliation.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/reconciliation.api.ts
@@ -32,16 +32,29 @@ export interface DiferenciaResponse {
   impacto: number;
 }
 
-export interface ConteoItemRequest {
-  productoId: string;
-  conteoFisico: number;
+/** POST /reconciliation/conciliaciones — inicia una nueva conciliación */
+export interface IniciarConciliacionRequest {
+  responsableId: string;
+  responsableNombre: string;
+  tipo: 'FISICA' | 'DOCUMENTAL';
+  fecha: string;
 }
 
-export interface IniciarConteoRequest {
+/** Ítem de conteo físico (POST /reconciliation/conciliaciones/{id}/conteo) */
+export interface ConteoItemRequest {
+  codigoSena: string;
+  descripcion: string;
+  cantidadSistema: number;
+  cantidadFisica: number;
+  valorUnitario: number;
+}
+
+/** Body de POST /reconciliation/conciliaciones/{id}/conteo */
+export interface RegistrarConteoRequest {
   items: ConteoItemRequest[];
 }
 
+/** PATCH /reconciliation/conciliaciones/{id}/diferencias/{diferenciaId}/resolver */
 export interface ResolverDiferenciaRequest {
-  ajuste: 'SISTEMA' | 'FISICO';
-  motivo: string;
+  justificacion: string;
 }

--- a/libs/inventario/inventario/src/lib/data-access/conciliacion.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/conciliacion.facade.ts
@@ -6,6 +6,7 @@ import {
   ConciliacionDetalle,
   DiferenciaItem,
   TomaFisicaItem,
+  ConteoItemData,
 } from '../models/conciliacion.model';
 
 @Injectable({
@@ -115,6 +116,46 @@ export class ConciliacionFacade {
       .subscribe(() => {
         // Refresca la lista tras iniciar la toma
         this.loadAll();
+      });
+  }
+
+  /**
+   * Registra el conteo físico de los ítems y recarga el detalle de la conciliación.
+   */
+  registrarConteo(id: string, items: ConteoItemData[]): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.conciliacionService
+      .registrarConteo(id, items)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al registrar el conteo físico');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res !== null) this.cargarConciliacion(id);
+      });
+  }
+
+  /**
+   * Resuelve una diferencia de inventario con su justificación y recarga el detalle.
+   */
+  resolverDiferencia(id: string, diferenciaId: string, justificacion: string): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.conciliacionService
+      .resolverDiferencia(id, diferenciaId, justificacion)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al resolver la diferencia');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res !== null) this.cargarConciliacion(id);
       });
   }
 

--- a/libs/inventario/inventario/src/lib/data-access/services/conciliacion.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/conciliacion.service.ts
@@ -8,7 +8,14 @@ import {
   DiferenciaItem,
   TomaFisicaItem,
 } from '../../models/conciliacion.model';
-import { ConciliacionListItemResponse, ConciliacionDetailResponse, DiferenciaResponse } from '../api/reconciliation.api';
+import {
+  ConciliacionListItemResponse,
+  ConciliacionDetailResponse,
+  DiferenciaResponse,
+  RegistrarConteoRequest,
+  ResolverDiferenciaRequest,
+} from '../api/reconciliation.api';
+import { ConteoItemData } from '../../models/conciliacion.model';
 import {
   conciliacionListItemFromApi,
   conciliacionDetailFromApi,
@@ -57,6 +64,36 @@ export class ConciliacionService {
   cerrarConciliacion(id: string): Observable<void> {
     return this.http
       .patch<void>(`${API}/reconciliation/conciliaciones/${id}/cerrar`, {})
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  /** POST /reconciliation/conciliaciones/{id}/conteo
+   *  Registra el conteo físico de todos los ítems de la sesión.
+   *  Respuesta: 204 No Content */
+  registrarConteo(id: string, items: ConteoItemData[]): Observable<void> {
+    const body: RegistrarConteoRequest = {
+      items: items.map(i => ({
+        codigoSena:      i.codigoSena,
+        descripcion:     i.descripcion,
+        cantidadSistema: i.cantidadSistema,
+        cantidadFisica:  i.cantidadFisica,
+        valorUnitario:   i.valorUnitario,
+      })),
+    };
+    return this.http
+      .post<void>(`${API}/reconciliation/conciliaciones/${id}/conteo`, body)
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  /** PATCH /reconciliation/conciliaciones/{id}/diferencias/{diferenciaId}/resolver
+   *  Respuesta: 204 No Content */
+  resolverDiferencia(id: string, diferenciaId: string, justificacion: string): Observable<void> {
+    const body: ResolverDiferenciaRequest = { justificacion };
+    return this.http
+      .patch<void>(
+        `${API}/reconciliation/conciliaciones/${id}/diferencias/${diferenciaId}/resolver`,
+        body,
+      )
       .pipe(catchError(err => throwError(() => err)));
   }
 

--- a/libs/inventario/inventario/src/lib/models/conciliacion.model.ts
+++ b/libs/inventario/inventario/src/lib/models/conciliacion.model.ts
@@ -55,3 +55,13 @@ export interface TopDiferencia {
   diferencia: string;
   icon: string;
 }
+
+/** Payload UI para registrar el conteo físico de un ítem
+ *  (POST /reconciliation/conciliaciones/{id}/conteo) */
+export interface ConteoItemData {
+  codigoSena: string;
+  descripcion: string;
+  cantidadSistema: number;
+  cantidadFisica: number;
+  valorUnitario: number;
+}


### PR DESCRIPTION
## Qué cambia

Completa los 2 métodos pendientes del módulo de conciliación de inventario.

### Correcciones en `reconciliation.api.ts`
Los DTOs estaban desactualizados respecto al contrato real:
- `ConteoItemRequest`: era `{productoId, conteoFisico}` → ahora `{codigoSena, descripcion, cantidadSistema, cantidadFisica, valorUnitario}`
- `ResolverDiferenciaRequest`: era `{ajuste: 'SISTEMA'|'FISICO', motivo}` → ahora `{justificacion}`
- Agrega `IniciarConciliacionRequest` con campos obligatorios del backend

### Nuevo en `conciliacion.model.ts`
- `ConteoItemData` — payload UI para el conteo físico

### `conciliacion.service.ts` — 2 métodos nuevos
| Método | Endpoint |
|--------|----------|
| `registrarConteo(id, items[])` | POST `/reconciliation/conciliaciones/{id}/conteo` |
| `resolverDiferencia(id, diferenciaId, justificacion)` | PATCH `.../diferencias/{diferenciaId}/resolver` |

### `conciliacion.facade.ts` — 2 métodos nuevos
Ambos recargan `cargarConciliacion(id)` al completarse.

## Test plan
- [ ] `registrarConteo()` con items válidos → 204, detalle se recarga con diferencias actualizadas
- [ ] `resolverDiferencia()` con justificación → 204, diferencia desaparece de la lista
- [ ] Error en `registrarConteo()` → `_error` se establece, `_loading` vuelve a false

🤖 Generated with [Claude Code](https://claude.com/claude-code)