### PR TITLE
feat(inventario): training/solicitudes session endpoints (G4)

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/training.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/training.api.ts
@@ -1,0 +1,49 @@
+// ─── DTOs de la API de Training /api/v1/training/solicitudes ────────────────
+
+export interface SolicitudSesionItemResponse {
+  productoId: string;
+  cantidad:   number;
+  unidadMedida: string;
+  justificacion: string;
+}
+
+/** GET /training/solicitudes/{id} — también como respuesta de POST y PATCH */
+export interface SolicitudSesionResponse {
+  id:                    string;
+  fichaId:               string;
+  programaId:            string;
+  instructorId:          string;
+  resultadoAprendizaje:  string;
+  actividades:           string;
+  voceroId:              string;
+  estado:                string;
+  items:                 SolicitudSesionItemResponse[];
+}
+
+/** POST /training/solicitudes */
+export interface CrearSolicitudSesionRequest {
+  fichaId:               string;
+  programaId:            string;
+  instructorId:          string;
+  resultadoAprendizaje:  string;
+  actividades:           string;
+  voceroId:              string;
+  items: {
+    productoId:    string;
+    cantidad:      number;
+    unidadMedida:  string;
+    justificacion: string;
+  }[];
+}
+
+/** PATCH /training/solicitudes/{id}/aprobar */
+export interface AprobarSolicitudSesionRequest {
+  aprobadorId:   string;
+  observaciones?: string;
+}
+
+/** PATCH /training/solicitudes/{id}/rechazar */
+export interface RechazarSolicitudSesionRequest {
+  aprobadorId: string;
+  motivo:      string;
+}

--- a/libs/inventario/inventario/src/lib/data-access/mappers/training.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/training.mapper.ts
@@ -1,0 +1,22 @@
+import { SolicitudSesionResponse } from '../api/training.api';
+import { SolicitudSesion } from '../../models/solicitud-sesion.model';
+
+/** Convierte el DTO de la API al modelo UI de SolicitudSesion */
+export function solicitudSesionFromApi(dto: SolicitudSesionResponse): SolicitudSesion {
+  return {
+    id:                   dto.id,
+    fichaId:              dto.fichaId,
+    programaId:           dto.programaId,
+    instructorId:         dto.instructorId,
+    resultadoAprendizaje: dto.resultadoAprendizaje,
+    actividades:          dto.actividades,
+    voceroId:             dto.voceroId,
+    estado:               dto.estado,
+    items: dto.items.map(i => ({
+      productoId:    i.productoId,
+      cantidad:      i.cantidad,
+      unidadMedida:  i.unidadMedida,
+      justificacion: i.justificacion,
+    })),
+  };
+}

--- a/libs/inventario/inventario/src/lib/data-access/services/solicitudes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/solicitudes.service.ts
@@ -9,8 +9,21 @@ import {
   CrearSolicitudData,
   ActualizarSolicitudData,
 } from '../../models/solicitudes-gil.model';
+import {
+  SolicitudSesion,
+  CrearSolicitudSesionData,
+  AprobarSesionData,
+  RechazarSesionData,
+} from '../../models/solicitud-sesion.model';
 import { GilResponse, EnviarProveedorRequest } from '../api/sourcing.api';
+import {
+  SolicitudSesionResponse,
+  CrearSolicitudSesionRequest,
+  AprobarSolicitudSesionRequest,
+  RechazarSolicitudSesionRequest,
+} from '../api/training.api';
 import { gilFromApi } from '../mappers/sourcing.mapper';
+import { solicitudSesionFromApi } from '../mappers/training.mapper';
 
 const API = '/api/v1';
 
@@ -94,5 +107,71 @@ export class SolicitudesService {
 
   generarGils(_ids: (string | number)[]): Observable<boolean> {
     return throwError(() => new Error('generarGils: endpoint no disponible — revisar con backend'));
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Training — /api/v1/training/solicitudes
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** POST /training/solicitudes — crea una solicitud de sesión — 201 Created */
+  crearSolicitudSesion(data: CrearSolicitudSesionData): Observable<SolicitudSesion> {
+    const body: CrearSolicitudSesionRequest = {
+      fichaId:              data.fichaId,
+      programaId:           data.programaId,
+      instructorId:         data.instructorId,
+      resultadoAprendizaje: data.resultadoAprendizaje,
+      actividades:          data.actividades,
+      voceroId:             data.voceroId,
+      items: data.items.map(i => ({
+        productoId:    i.productoId,
+        cantidad:      i.cantidad,
+        unidadMedida:  i.unidadMedida,
+        justificacion: i.justificacion,
+      })),
+    };
+    return this.http
+      .post<SolicitudSesionResponse>(`${API}/training/solicitudes`, body)
+      .pipe(
+        map(solicitudSesionFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** PATCH /training/solicitudes/{id}/aprobar */
+  aprobarSolicitudSesion(id: string, data: AprobarSesionData): Observable<SolicitudSesion> {
+    const body: AprobarSolicitudSesionRequest = {
+      aprobadorId:   data.aprobadorId,
+      observaciones: data.observaciones,
+    };
+    return this.http
+      .patch<SolicitudSesionResponse>(`${API}/training/solicitudes/${id}/aprobar`, body)
+      .pipe(
+        map(solicitudSesionFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** PATCH /training/solicitudes/{id}/rechazar */
+  rechazarSolicitudSesion(id: string, data: RechazarSesionData): Observable<SolicitudSesion> {
+    const body: RechazarSolicitudSesionRequest = {
+      aprobadorId: data.aprobadorId,
+      motivo:      data.motivo,
+    };
+    return this.http
+      .patch<SolicitudSesionResponse>(`${API}/training/solicitudes/${id}/rechazar`, body)
+      .pipe(
+        map(solicitudSesionFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** PATCH /training/solicitudes/{id}/comprometer — sin body — 204 No Content */
+  comprometerSolicitudSesion(id: string): Observable<SolicitudSesion> {
+    return this.http
+      .patch<SolicitudSesionResponse>(`${API}/training/solicitudes/${id}/comprometer`, {})
+      .pipe(
+        map(solicitudSesionFromApi),
+        catchError(err => throwError(() => err))
+      );
   }
 }

--- a/libs/inventario/inventario/src/lib/data-access/solicitudes.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/solicitudes.facade.ts
@@ -1,5 +1,11 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { SolicitudGil, SolicitudesGilFiltros, EstadoGil, CrearSolicitudData, ActualizarSolicitudData } from '../models/solicitudes-gil.model';
+import {
+  SolicitudSesion,
+  CrearSolicitudSesionData,
+  AprobarSesionData,
+  RechazarSesionData,
+} from '../models/solicitud-sesion.model';
 import { SolicitudesService } from './services/solicitudes.service';
 import { EnviarProveedorRequest } from './api/sourcing.api';
 import { finalize, catchError, of } from 'rxjs';
@@ -10,19 +16,23 @@ import { finalize, catchError, of } from 'rxjs';
 export class SolicitudesFacade {
   private solicitudesService = inject(SolicitudesService);
 
-  // Estados internos (Signals)
-  private _solicitudes = signal<SolicitudGil[]>([]);
-  private _loading = signal<boolean>(false);
-  private _filtros = signal<SolicitudesGilFiltros>({});
+  // ── Estado GIL (Procurement) ───────────────────────────────────────────────
+  private _solicitudes           = signal<SolicitudGil[]>([]);
+  private _loading               = signal<boolean>(false);
+  private _filtros               = signal<SolicitudesGilFiltros>({});
   private _solicitudSeleccionada = signal<SolicitudGil | undefined>(undefined);
-  private _error = signal<string | null>(null);
+  private _error                 = signal<string | null>(null);
 
-  // Exposición pública (Solo lectura)
-  public solicitudes = computed(() => this._solicitudes());
-  public loading = computed(() => this._loading());
-  public filtros = computed(() => this._filtros());
-  public solicitudSeleccionada = computed(() => this._solicitudSeleccionada());
-  public error = computed(() => this._error());
+  // ── Estado Training/Solicitudes ────────────────────────────────────────────
+  private _solicitudSesionSeleccionada = signal<SolicitudSesion | undefined>(undefined);
+
+  // ── Exposición pública ─────────────────────────────────────────────────────
+  public solicitudes                  = computed(() => this._solicitudes());
+  public loading                      = computed(() => this._loading());
+  public filtros                      = computed(() => this._filtros());
+  public solicitudSeleccionada        = computed(() => this._solicitudSeleccionada());
+  public error                        = computed(() => this._error());
+  public solicitudSesionSeleccionada  = computed(() => this._solicitudSesionSeleccionada());
 
   /**
    * Carga inicial de datos.
@@ -178,5 +188,75 @@ export class SolicitudesFacade {
       });
   }
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // Training — /api/v1/training/solicitudes
+  // ─────────────────────────────────────────────────────────────────────────
 
+  /** POST /training/solicitudes — crea la solicitud y la deja seleccionada */
+  crearSolicitudSesion(data: CrearSolicitudSesionData): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.solicitudesService.crearSolicitudSesion(data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al crear la solicitud de sesión');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res !== null) this._solicitudSesionSeleccionada.set(res);
+      });
+  }
+
+  /** PATCH /training/solicitudes/{id}/aprobar */
+  aprobarSolicitudSesion(id: string, data: AprobarSesionData): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.solicitudesService.aprobarSolicitudSesion(id, data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al aprobar la solicitud de sesión');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res !== null) this._solicitudSesionSeleccionada.set(res);
+      });
+  }
+
+  /** PATCH /training/solicitudes/{id}/rechazar */
+  rechazarSolicitudSesion(id: string, data: RechazarSesionData): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.solicitudesService.rechazarSolicitudSesion(id, data)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al rechazar la solicitud de sesión');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res !== null) this._solicitudSesionSeleccionada.set(res);
+      });
+  }
+
+  /** PATCH /training/solicitudes/{id}/comprometer */
+  comprometerSolicitudSesion(id: string): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.solicitudesService.comprometerSolicitudSesion(id)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al comprometer la solicitud de sesión');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res !== null) this._solicitudSesionSeleccionada.set(res);
+      });
+  }
 }

--- a/libs/inventario/inventario/src/lib/models/solicitud-sesion.model.ts
+++ b/libs/inventario/inventario/src/lib/models/solicitud-sesion.model.ts
@@ -1,0 +1,49 @@
+// ─── Modelo UI del módulo Training — Solicitudes de Sesión (RF-5.x) ─────────
+
+export type EstadoSolicitudSesion =
+  | 'PENDIENTE'
+  | 'APROBADA'
+  | 'RECHAZADA'
+  | 'COMPROMETIDA';
+
+export interface SolicitudSesionItem {
+  productoId:    string;
+  cantidad:      number;
+  unidadMedida:  string;
+  justificacion: string;
+}
+
+export interface SolicitudSesion {
+  id:                   string;
+  fichaId:              string;
+  programaId:           string;
+  instructorId:         string;
+  resultadoAprendizaje: string;
+  actividades:          string;
+  voceroId:             string;
+  estado:               string;
+  items:                SolicitudSesionItem[];
+}
+
+/** Payload para crear una solicitud de sesión (POST /training/solicitudes) */
+export interface CrearSolicitudSesionData {
+  fichaId:              string;
+  programaId:           string;
+  instructorId:         string;
+  resultadoAprendizaje: string;
+  actividades:          string;
+  voceroId:             string;
+  items: SolicitudSesionItem[];
+}
+
+/** Payload para aprobar (PATCH /training/solicitudes/{id}/aprobar) */
+export interface AprobarSesionData {
+  aprobadorId:    string;
+  observaciones?: string;
+}
+
+/** Payload para rechazar (PATCH /training/solicitudes/{id}/rechazar) */
+export interface RechazarSesionData {
+  aprobadorId: string;
+  motivo:      string;
+}


### PR DESCRIPTION
## Resumen

- `POST /training/solicitudes` → `crearSolicitudSesion()` — crea solicitud de sesión y la deja en `solicitudSesionSeleccionada`
- `PATCH /training/solicitudes/{id}/aprobar` → `aprobarSolicitudSesion()` — envía `{aprobadorId, observaciones?}` y actualiza el estado seleccionado
- `PATCH /training/solicitudes/{id}/rechazar` → `rechazarSolicitudSesion()` — envía `{aprobadorId, motivo}` y actualiza el estado seleccionado
- `PATCH /training/solicitudes/{id}/comprometer` → `comprometerSolicitudSesion()` — sin body, 204 No Content (ya no registra salida de stock — Sprint 12)

## Archivos nuevos

| Archivo | Propósito |
|---------|-----------|
| `data-access/api/training.api.ts` | DTOs del contrato backend |
| `data-access/mappers/training.mapper.ts` | `solicitudSesionFromApi()` |
| `models/solicitud-sesion.model.ts` | Interfaces UI + payloads |

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `services/solicitudes.service.ts` | +4 métodos training |
| `solicitudes.facade.ts` | +signal `solicitudSesionSeleccionada` + 4 facade methods |

## Test plan

- [ ] Lint pasa (`nx run inventario:lint`)
- [ ] Build pasa (`nx run restaurant-app:build`)
- [ ] Los nuevos métodos del service llaman al endpoint correcto con el DTO exacto del contrato
- [ ] El facade actualiza `solicitudSesionSeleccionada` tras cada operación exitosa
- [ ] `loading` y `error` se gestionan correctamente en los 4 flujos