### PR TITLE
feat(inventario): sourcing conciliacion-gil + instructor-vinculos (G5)

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/sourcing.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/sourcing.api.ts
@@ -124,3 +124,37 @@ export interface EnviarProveedorRequest {
   proveedorDestinatarioId: string;
   fechaEnvio: string;
 }
+
+// ─── Sourcing — Conciliación Factura-GIL (/api/v1/sourcing/conciliaciones-gil) ─
+
+export interface GilDiferenciaItemResponse {
+  gilItemId:            string;
+  descripcion:          string;
+  cantidadGil:          number;
+  cantidadFactura:      number;
+  precioUnitarioGil:    number;
+  precioUnitarioFactura: number;
+  diferencia:           number;
+  observacion?:         string;
+  resuelta:             boolean;
+}
+
+/** Respuesta de POST, GET y PATCH /sourcing/conciliaciones-gil */
+export interface ConciliacionGilResponse {
+  id:          string;
+  facturaId:   string;
+  gilId:       string;
+  estado:      string;
+  diferencias: GilDiferenciaItemResponse[];
+}
+
+/** POST /sourcing/conciliaciones-gil */
+export interface ConciliarRequest {
+  facturaId: string;
+  gilId:     string;
+}
+
+/** PATCH /sourcing/conciliaciones-gil/{id}/diferencias/{gilItemId}/resolver */
+export interface ResolverDiferenciaGilRequest {
+  observacion: string;
+}

--- a/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { finalize, catchError, of } from 'rxjs';
-import { Factura, FacturaFiltros, FacturaKpis, SolicitudGIL } from '../models/facturas.model';
+import { Factura, FacturaFiltros, FacturaKpis, SolicitudGIL, ConciliacionGil } from '../models/facturas.model';
 import { FacturasService } from './services/facturas.service';
 
 @Injectable({
@@ -9,23 +9,25 @@ import { FacturasService } from './services/facturas.service';
 export class FacturasFacade {
   private svc = inject(FacturasService);
 
-  // Internal state
-  private _facturas = signal<Factura[]>([]);
-  private _kpis = signal<FacturaKpis | null>(null);
-  private _facturaSeleccionada = signal<Factura | null>(null);
-  private _solicitudGIL = signal<SolicitudGIL | null>(null);
-  private _loading = signal<boolean>(false);
-  private _filtros = signal<FacturaFiltros>({});
-  private _error = signal<string | null>(null);
+  // ── Estado interno ────────────────────────────────────────────────────────
+  private _facturas             = signal<Factura[]>([]);
+  private _kpis                 = signal<FacturaKpis | null>(null);
+  private _facturaSeleccionada  = signal<Factura | null>(null);
+  private _solicitudGIL         = signal<SolicitudGIL | null>(null);
+  private _conciliacionGil      = signal<ConciliacionGil | null>(null);
+  private _loading              = signal<boolean>(false);
+  private _filtros              = signal<FacturaFiltros>({});
+  private _error                = signal<string | null>(null);
 
-  // Public readonly
-  public facturas = computed(() => this._facturas());
-  public kpis = computed(() => this._kpis());
+  // ── Exposición pública ────────────────────────────────────────────────────
+  public facturas            = computed(() => this._facturas());
+  public kpis                = computed(() => this._kpis());
   public facturaSeleccionada = computed(() => this._facturaSeleccionada());
-  public solicitudGIL = computed(() => this._solicitudGIL());
-  public loading = computed(() => this._loading());
-  public filtros = computed(() => this._filtros());
-  public error = computed(() => this._error());
+  public solicitudGIL        = computed(() => this._solicitudGIL());
+  public conciliacionGil     = computed(() => this._conciliacionGil());
+  public loading             = computed(() => this._loading());
+  public filtros             = computed(() => this._filtros());
+  public error               = computed(() => this._error());
 
   /** Carga inicial del panel */
   loadAll(): void {
@@ -190,5 +192,73 @@ export class FacturasFacade {
         })
       )
       .subscribe(s => this._solicitudGIL.set(s ?? null));
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Sourcing — Conciliación Factura-GIL
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** POST /sourcing/conciliaciones-gil — vincula factura con GIL y guarda el resultado */
+  conciliarFacturaGil(facturaId: string, gilId: string): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.svc.conciliarFacturaGil(facturaId, gilId)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al conciliar la factura con el GIL');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res !== null) this._conciliacionGil.set(res); });
+  }
+
+  /** GET /sourcing/conciliaciones-gil?facturaId=X ó ?gilId=Y */
+  cargarConciliacionGil(params: { facturaId?: string; gilId?: string }): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.svc.getConciliacionGil(params)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar la conciliación GIL');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res !== null) this._conciliacionGil.set(res); });
+  }
+
+  /** PATCH /sourcing/conciliaciones-gil/{id}/diferencias/{gilItemId}/resolver */
+  resolverDiferenciaGil(id: string, gilItemId: string, observacion: string): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.svc.resolverDiferenciaGil(id, gilItemId, observacion)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al resolver la diferencia GIL');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res !== null) this._conciliacionGil.set(res); });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Sourcing — Vinculación Instructor
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** PUT /sourcing/instructor-vinculos/{ordenCompra} */
+  vincularInstructorOrden(ordenCompra: string, instructorId: string): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.svc.vincularInstructorOrden(ordenCompra, instructorId)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al vincular el instructor a la orden de compra');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(() => { /* 204 No Content — sin payload que actualizar */ });
   }
 }

--- a/libs/inventario/inventario/src/lib/data-access/mappers/sourcing.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/sourcing.mapper.ts
@@ -1,6 +1,6 @@
-import { Factura, FacturaFormDto } from '../../models/facturas.model';
+import { Factura, FacturaFormDto, ConciliacionGil } from '../../models/facturas.model';
 import { SolicitudGil, BienSolicitud, CuentadanteGil } from '../../models/solicitudes-gil.model';
-import { FacturaResponse, GilResponse, RegistrarFacturaRequest } from '../api/sourcing.api';
+import { FacturaResponse, GilResponse, RegistrarFacturaRequest, ConciliacionGilResponse } from '../api/sourcing.api';
 
 export function facturaFromApi(dto: FacturaResponse): Factura {
   return {
@@ -42,6 +42,26 @@ export function facturaFormToRequest(form: FacturaFormDto): RegistrarFacturaRequ
     gilVinculado: form.gilVinculado,
     instructorId: form.instructorId,
     valorRetencionZese: form.valorRetencionZese,
+  };
+}
+
+export function conciliacionGilFromApi(dto: ConciliacionGilResponse): ConciliacionGil {
+  return {
+    id:        dto.id,
+    facturaId: dto.facturaId,
+    gilId:     dto.gilId,
+    estado:    dto.estado,
+    diferencias: dto.diferencias.map(d => ({
+      gilItemId:             d.gilItemId,
+      descripcion:           d.descripcion,
+      cantidadGil:           d.cantidadGil,
+      cantidadFactura:       d.cantidadFactura,
+      precioUnitarioGil:     d.precioUnitarioGil,
+      precioUnitarioFactura: d.precioUnitarioFactura,
+      diferencia:            d.diferencia,
+      observacion:           d.observacion,
+      resuelta:              d.resuelta,
+    })),
   };
 }
 

--- a/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
@@ -2,9 +2,17 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { Factura, FacturaFiltros, FacturaKpis, SolicitudGIL, EstadoGIL } from '../../models/facturas.model';
-import { FacturaResponse, FacturaResumenResponse, GilResponse } from '../api/sourcing.api';
-import { facturaFromApi } from '../mappers/sourcing.mapper';
+import { Factura, FacturaFiltros, FacturaKpis, SolicitudGIL, EstadoGIL, ConciliacionGil } from '../../models/facturas.model';
+import {
+  FacturaResponse,
+  FacturaResumenResponse,
+  GilResponse,
+  ConciliacionGilResponse,
+  ConciliarRequest,
+  ResolverDiferenciaGilRequest,
+  VincularInstructorRequest,
+} from '../api/sourcing.api';
+import { facturaFromApi, conciliacionGilFromApi } from '../mappers/sourcing.mapper';
 
 const API = '/api/v1';
 
@@ -112,6 +120,60 @@ export class FacturasService {
         map(facturaFromApi),
         catchError(err => throwError(() => err))
       );
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Sourcing — Conciliación Factura-GIL /api/v1/sourcing/conciliaciones-gil
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** POST /sourcing/conciliaciones-gil — vincula una factura con su GIL — 201 Created */
+  conciliarFacturaGil(facturaId: string, gilId: string): Observable<ConciliacionGil> {
+    const body: ConciliarRequest = { facturaId, gilId };
+    return this.http
+      .post<ConciliacionGilResponse>(`${API}/sourcing/conciliaciones-gil`, body)
+      .pipe(
+        map(conciliacionGilFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** GET /sourcing/conciliaciones-gil?facturaId=X  ó  ?gilId=Y */
+  getConciliacionGil(params: { facturaId?: string; gilId?: string }): Observable<ConciliacionGil> {
+    let httpParams = new HttpParams();
+    if (params.facturaId) httpParams = httpParams.set('facturaId', params.facturaId);
+    if (params.gilId)     httpParams = httpParams.set('gilId',     params.gilId);
+    return this.http
+      .get<ConciliacionGilResponse>(`${API}/sourcing/conciliaciones-gil`, { params: httpParams })
+      .pipe(
+        map(conciliacionGilFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** PATCH /sourcing/conciliaciones-gil/{id}/diferencias/{gilItemId}/resolver */
+  resolverDiferenciaGil(id: string, gilItemId: string, observacion: string): Observable<ConciliacionGil> {
+    const body: ResolverDiferenciaGilRequest = { observacion };
+    return this.http
+      .patch<ConciliacionGilResponse>(
+        `${API}/sourcing/conciliaciones-gil/${id}/diferencias/${gilItemId}/resolver`,
+        body,
+      )
+      .pipe(
+        map(conciliacionGilFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Sourcing — Vinculación Instructor /api/v1/sourcing/instructor-vinculos
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** PUT /sourcing/instructor-vinculos/{ordenCompra} — 204 No Content */
+  vincularInstructorOrden(ordenCompra: string, instructorId: string): Observable<void> {
+    const body: VincularInstructorRequest = { instructorId };
+    return this.http
+      .put<void>(`${API}/sourcing/instructor-vinculos/${ordenCompra}`, body)
+      .pipe(catchError(err => throwError(() => err)));
   }
 
   /** Mapea GilResponse al tipo SolicitudGIL que usa la FacturasFacade.

--- a/libs/inventario/inventario/src/lib/models/facturas.model.ts
+++ b/libs/inventario/inventario/src/lib/models/facturas.model.ts
@@ -108,6 +108,30 @@ export interface FacturaFormDto {
   motivoAnulacion?: string;
 }
 
+// ─── Conciliación Factura-GIL ───────────────────────────────────────────────
+
+export interface ConciliacionGilDiferencia {
+  gilItemId:             string;
+  descripcion:           string;
+  cantidadGil:           number;
+  cantidadFactura:       number;
+  precioUnitarioGil:     number;
+  precioUnitarioFactura: number;
+  diferencia:            number;
+  observacion?:          string;
+  resuelta:              boolean;
+}
+
+export interface ConciliacionGil {
+  id:          string;
+  facturaId:   string;
+  gilId:       string;
+  estado:      string;
+  diferencias: ConciliacionGilDiferencia[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
  * Estado de la solicitud GIL F-014.
  */


### PR DESCRIPTION
## Resumen

4 endpoints nuevos del contexto Sourcing:

### Conciliación Factura-GIL (`/sourcing/conciliaciones-gil`)
| Método | Endpoint | Facade |
|--------|----------|--------|
| POST | `/sourcing/conciliaciones-gil` | `conciliarFacturaGil(facturaId, gilId)` |
| GET | `/sourcing/conciliaciones-gil?facturaId=X\|?gilId=Y` | `cargarConciliacionGil(params)` |
| PATCH | `/sourcing/conciliaciones-gil/{id}/diferencias/{gilItemId}/resolver` | `resolverDiferenciaGil(id, gilItemId, observacion)` |

### Vinculación Instructor (`/sourcing/instructor-vinculos`)
| Método | Endpoint | Facade |
|--------|----------|--------|
| PUT | `/sourcing/instructor-vinculos/{ordenCompra}` | `vincularInstructorOrden(ordenCompra, instructorId)` |

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `api/sourcing.api.ts` | +`ConciliacionGilResponse`, `GilDiferenciaItemResponse`, `ConciliarRequest`, `ResolverDiferenciaGilRequest` |
| `models/facturas.model.ts` | +`ConciliacionGil`, `ConciliacionGilDiferencia` |
| `mappers/sourcing.mapper.ts` | +`conciliacionGilFromApi()` |
| `services/facturas.service.ts` | +4 métodos |
| `facturas.facade.ts` | +signal `conciliacionGil` + 4 métodos facade |

## Nota
`VincularInstructorRequest` ya existía en `sourcing.api.ts` — se reutilizó directamente.

## Test plan

- [ ] Lint pasa (`nx run inventario:lint`)
- [ ] Build pasa (`nx run restaurant-app:build`)
- [ ] `conciliarFacturaGil` envía `{facturaId, gilId}` y actualiza `conciliacionGil` signal
- [ ] `cargarConciliacionGil` envía el query param correcto (facturaId o gilId)
- [ ] `resolverDiferenciaGil` construye la URL correcta con ambos IDs
- [ ] `vincularInstructorOrden` hace PUT con `{instructorId}` en la ruta correcta