### PR TITLE
feat(inventario): reporting endpoints G6a — ejecucion-presupuestal, kardex, alertas/resumen

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/alertas.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/alertas.facade.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { AlertasService } from './services/alertas.service';
 import { Alerta, RegistroHistorial, UmbralConfig } from '../models/alerta.model';
+import { ResumenAlertas } from '../models/reporting.model';
 import { finalize, catchError, of, firstValueFrom, forkJoin } from 'rxjs';
 
 @Injectable({
@@ -9,21 +10,23 @@ import { finalize, catchError, of, firstValueFrom, forkJoin } from 'rxjs';
 export class AlertasFacade {
   private alertasService = inject(AlertasService);
 
-  // Estados internos (Signals)
-  private _alertas = signal<Alerta[]>([]);
-  private _alertaSeleccionada = signal<Alerta | undefined>(undefined);
-  private _historial = signal<RegistroHistorial[]>([]);
-  private _umbrales  = signal<UmbralConfig[]>([]);
-  private _loading = signal<boolean>(false);
-  private _error = signal<string | null>(null);
+  // ── Estado interno ────────────────────────────────────────────────────────
+  private _alertas              = signal<Alerta[]>([]);
+  private _alertaSeleccionada   = signal<Alerta | undefined>(undefined);
+  private _historial            = signal<RegistroHistorial[]>([]); // legacy, mantenido por compat
+  private _resumenAlertas       = signal<ResumenAlertas | null>(null);
+  private _umbrales             = signal<UmbralConfig[]>([]);
+  private _loading              = signal<boolean>(false);
+  private _error                = signal<string | null>(null);
 
-  // Exposición pública (Solo lectura)
-  public alertas = computed(() => this._alertas());
+  // ── Exposición pública ────────────────────────────────────────────────────
+  public alertas            = computed(() => this._alertas());
   public alertaSeleccionada = computed(() => this._alertaSeleccionada());
-  public historial = computed(() => this._historial());
-  public umbrales  = computed(() => this._umbrales());
-  public loading = computed(() => this._loading());
-  public error = computed(() => this._error());
+  public historial          = computed(() => this._historial());
+  public resumenAlertas     = computed(() => this._resumenAlertas());
+  public umbrales           = computed(() => this._umbrales());
+  public loading            = computed(() => this._loading());
+  public error              = computed(() => this._error());
 
   /**
    * Carga inicial de datos.
@@ -58,18 +61,19 @@ export class AlertasFacade {
     }
   }
 
-  /** Carga el historial de resoluciones de alertas. */
-  cargarHistorial(): void {
+  /** GET /reporting/alertas/resumen — carga el resumen de alertas */
+  cargarHistorial(destinatarioId?: string): void {
     this._loading.set(true);
-    this.alertasService.getHistorial()
+    this._error.set(null);
+    this.alertasService.getResumenAlertas(destinatarioId)
       .pipe(
         catchError(() => {
-          this._error.set('Error al cargar el historial de alertas');
-          return of([]);
+          this._error.set('Error al cargar el resumen de alertas');
+          return of(null);
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(data => this._historial.set(data));
+      .subscribe(data => { if (data) this._resumenAlertas.set(data); });
   }
 
   /** Carga la configuración de umbrales. */

--- a/libs/inventario/inventario/src/lib/data-access/api/reporting.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/reporting.api.ts
@@ -1,0 +1,64 @@
+// ─── DTOs de la API de Reporting /api/v1/reporting ──────────────────────────
+
+/** GET /reporting/ejecucion-presupuestal?fichaId?&vigencia? */
+export interface EjecucionPresupuestalItemResponse {
+  fichaId:             string;
+  programaFormacion:   string;
+  vigencia:            number;
+  totalPresupuestado:  number;
+  totalComprometido:   number;
+  totalPagado:         number;
+  porcentajeEjecucion: number;
+  saldoDisponible:     number;
+}
+
+/** GET /reporting/kardex?productoId?&desde?&hasta? */
+export interface KardexValorizadoItemResponse {
+  fecha:            string;
+  tipo:             string;
+  productoId:       string;
+  productoNombre:   string;
+  cantidad:         number;
+  precioUnitario:   number;
+  valorTotal:       number;
+  saldoUnidades:    number;
+  saldoValorizado:  number;
+}
+
+/** GET /reporting/consumo?fichaId?&instructorId?&desde?&hasta? */
+export interface ConsumoItemResponse {
+  instructorId:      string;
+  instructorNombre:  string;
+  fichaId:           string;
+  programaFormacion: string;
+  productoId:        string;
+  productoNombre:    string;
+  cantidadConsumida: number;
+  valorTotal:        number;
+  fecha:             string;
+}
+
+/** GET /reporting/trazabilidad?fichaId?&desde?&hasta? */
+export interface TrazabilidadDocumentalItemResponse {
+  fichaId:           string;
+  programaFormacion: string;
+  instructorId:      string;
+  instructorNombre:  string;
+  requisicionId?:    string;
+  actaId?:           string;
+  paqueteId?:        string;
+  gilId?:            string;
+  facturaId?:        string;
+  estado:            string;
+  fecha:             string;
+}
+
+/** GET /reporting/alertas/resumen?destinatarioId? */
+export interface ResumenAlertasResponse {
+  totalAlertas:       number;
+  alertasPendientes:  number;
+  alertasResueltas:   number;
+  productosCriticos:  number;
+  alertasPorTipo:     { tipo: string; cantidad: number }[];
+  ultimaAlerta?:      string;
+}

--- a/libs/inventario/inventario/src/lib/data-access/consolidado.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/consolidado.facade.ts
@@ -2,6 +2,7 @@ import { Injectable, computed, inject, signal } from '@angular/core';
 import { catchError, finalize, of } from 'rxjs';
 import { ConsolidadoService } from './services/consolidado.service';
 import { Consolidado } from '../models/consolidado.model';
+import { EjecucionPresupuestal } from '../models/reporting.model';
 
 @Injectable({
   providedIn: 'root'
@@ -9,15 +10,17 @@ import { Consolidado } from '../models/consolidado.model';
 export class ConsolidadoFacade {
   private consolidadoService = inject(ConsolidadoService);
 
-  private _consolidados            = signal<Consolidado[]>([]);
-  private _consolidadoSeleccionado = signal<Consolidado | null>(null);
-  private _loading                 = signal<boolean>(false);
-  private _error                   = signal<string | null>(null);
+  private _consolidados              = signal<Consolidado[]>([]);
+  private _consolidadoSeleccionado   = signal<Consolidado | null>(null);
+  private _ejecucionPresupuestal     = signal<EjecucionPresupuestal[]>([]);
+  private _loading                   = signal<boolean>(false);
+  private _error                     = signal<string | null>(null);
 
-  consolidados            = computed(() => this._consolidados());
-  consolidadoSeleccionado = computed(() => this._consolidadoSeleccionado());
-  loading                 = computed(() => this._loading());
-  error                   = computed(() => this._error());
+  consolidados              = computed(() => this._consolidados());
+  consolidadoSeleccionado   = computed(() => this._consolidadoSeleccionado());
+  ejecucionPresupuestal     = computed(() => this._ejecucionPresupuestal());
+  loading                   = computed(() => this._loading());
+  error                     = computed(() => this._error());
 
   loadAll(): void {
     this._loading.set(true);
@@ -58,6 +61,21 @@ export class ConsolidadoFacade {
       .subscribe(data => {
         if (data) this._consolidados.update(list => [data, ...list]);
       });
+  }
+
+  /** GET /reporting/ejecucion-presupuestal */
+  cargarEjecucionPresupuestal(params?: { fichaId?: string; vigencia?: number }): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.consolidadoService.getEjecucionPresupuestal(params)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar la ejecución presupuestal');
+          return of([]);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(data => this._ejecucionPresupuestal.set(data));
   }
 
   reversarConsolidado(id: string): void {

--- a/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
@@ -9,6 +9,7 @@ import {
   AjusteMovimientoData,
 } from '../models/movimiento.model';
 import { ExistenciaProducto } from '../models/inventario.model';
+import { KardexValorizadoItem } from '../models/reporting.model';
 import { MovimientosService } from './services/movimientos.service';
 
 @Injectable({ providedIn: 'root' })
@@ -16,20 +17,22 @@ export class KardexFacade {
   private movimientosService = inject(MovimientosService);
 
   // ── Estado ───────────────────────────────────────────────────────────────────
-  private _movimientos       = signal<Movimiento[]>([]);
-  private _movimientoSeleccionado = signal<Movimiento | undefined>(undefined);
-  private _existencia        = signal<ExistenciaProducto | null>(null);
-  private _bajoMinimo        = signal<ExistenciaProducto[]>([]);
-  private _loading           = signal<boolean>(false);
-  private _error             = signal<string | null>(null);
+  private _movimientos              = signal<Movimiento[]>([]);
+  private _movimientoSeleccionado   = signal<Movimiento | undefined>(undefined);
+  private _existencia               = signal<ExistenciaProducto | null>(null);
+  private _bajoMinimo               = signal<ExistenciaProducto[]>([]);
+  private _kardexValorizado         = signal<KardexValorizadoItem[]>([]);
+  private _loading                  = signal<boolean>(false);
+  private _error                    = signal<string | null>(null);
 
   // ── Lectura pública ──────────────────────────────────────────────────────────
-  public movimientos          = computed(() => this._movimientos());
-  public movimientoSeleccionado = computed(() => this._movimientoSeleccionado());
-  public existencia           = computed(() => this._existencia());
-  public bajoMinimo           = computed(() => this._bajoMinimo());
-  public loading              = computed(() => this._loading());
-  public error                = computed(() => this._error());
+  public movimientos              = computed(() => this._movimientos());
+  public movimientoSeleccionado   = computed(() => this._movimientoSeleccionado());
+  public existencia               = computed(() => this._existencia());
+  public bajoMinimo               = computed(() => this._bajoMinimo());
+  public kardexValorizado         = computed(() => this._kardexValorizado());
+  public loading                  = computed(() => this._loading());
+  public error                    = computed(() => this._error());
 
   // ── Kardex ───────────────────────────────────────────────────────────────────
 
@@ -62,6 +65,25 @@ export class KardexFacade {
         finalize(() => this._loading.set(false))
       )
       .subscribe(data => this._movimientoSeleccionado.set(data));
+  }
+
+  /** GET /reporting/kardex?productoId?&desde?&hasta? */
+  cargarKardexValorizado(params?: {
+    productoId?: string;
+    desde?:      string;
+    hasta?:      string;
+  }): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.movimientosService.getKardexValorizado(params)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar el kardex valorizado');
+          return of([]);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(data => this._kardexValorizado.set(data));
   }
 
   // ── Existencias ──────────────────────────────────────────────────────────────

--- a/libs/inventario/inventario/src/lib/data-access/mappers/reporting.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/reporting.mapper.ts
@@ -1,0 +1,86 @@
+import {
+  EjecucionPresupuestalItemResponse,
+  KardexValorizadoItemResponse,
+  ConsumoItemResponse,
+  TrazabilidadDocumentalItemResponse,
+  ResumenAlertasResponse,
+} from '../api/reporting.api';
+import {
+  EjecucionPresupuestal,
+  KardexValorizadoItem,
+  ConsumoItem,
+  TrazabilidadDocumental,
+  ResumenAlertas,
+} from '../../models/reporting.model';
+
+export function ejecucionPresupuestalFromApi(
+  dto: EjecucionPresupuestalItemResponse,
+): EjecucionPresupuestal {
+  return {
+    fichaId:             dto.fichaId,
+    programaFormacion:   dto.programaFormacion,
+    vigencia:            dto.vigencia,
+    totalPresupuestado:  dto.totalPresupuestado,
+    totalComprometido:   dto.totalComprometido,
+    totalPagado:         dto.totalPagado,
+    porcentajeEjecucion: dto.porcentajeEjecucion,
+    saldoDisponible:     dto.saldoDisponible,
+  };
+}
+
+export function kardexValorizadoFromApi(dto: KardexValorizadoItemResponse): KardexValorizadoItem {
+  return {
+    fecha:           dto.fecha,
+    tipo:            dto.tipo,
+    productoId:      dto.productoId,
+    productoNombre:  dto.productoNombre,
+    cantidad:        dto.cantidad,
+    precioUnitario:  dto.precioUnitario,
+    valorTotal:      dto.valorTotal,
+    saldoUnidades:   dto.saldoUnidades,
+    saldoValorizado: dto.saldoValorizado,
+  };
+}
+
+export function consumoFromApi(dto: ConsumoItemResponse): ConsumoItem {
+  return {
+    instructorId:      dto.instructorId,
+    instructorNombre:  dto.instructorNombre,
+    fichaId:           dto.fichaId,
+    programaFormacion: dto.programaFormacion,
+    productoId:        dto.productoId,
+    productoNombre:    dto.productoNombre,
+    cantidadConsumida: dto.cantidadConsumida,
+    valorTotal:        dto.valorTotal,
+    fecha:             dto.fecha,
+  };
+}
+
+export function trazabilidadFromApi(
+  dto: TrazabilidadDocumentalItemResponse,
+): TrazabilidadDocumental {
+  return {
+    fichaId:           dto.fichaId,
+    programaFormacion: dto.programaFormacion,
+    instructorId:      dto.instructorId,
+    instructorNombre:  dto.instructorNombre,
+    requisicionId:     dto.requisicionId,
+    actaId:            dto.actaId,
+    paqueteId:         dto.paqueteId,
+    gilId:             dto.gilId,
+    facturaId:         dto.facturaId,
+    estado:            dto.estado,
+    fecha:             dto.fecha,
+  };
+}
+
+export function resumenAlertasFromApi(dto: ResumenAlertasResponse): ResumenAlertas {
+  return {
+    totalAlertas:      dto.totalAlertas,
+    alertasPendientes: dto.alertasPendientes,
+    alertasResueltas:  dto.alertasResueltas,
+    productosCriticos: dto.productosCriticos,
+    alertasPorTipo:    dto.alertasPorTipo.map(a => ({ tipo: a.tipo, cantidad: a.cantidad })),
+    ultimaAlerta:      dto.ultimaAlerta,
+  };
+}

--- a/libs/inventario/inventario/src/lib/data-access/services/alertas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/alertas.service.ts
@@ -1,10 +1,13 @@
 import { inject, Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { Alerta, UmbralConfig } from '../../models/alerta.model';
+import { ResumenAlertas } from '../../models/reporting.model';
 import { AlertaResponse, UmbralStockResponse, ActualizarUmbralRequest } from '../api/alerts.api';
+import { ResumenAlertasResponse } from '../api/reporting.api';
 import { alertaFromApi, umbralFromApi } from '../mappers/alerts.mapper';
+import { resumenAlertasFromApi } from '../mappers/reporting.mapper';
 
 const API = '/api/v1';
 
@@ -61,15 +64,22 @@ export class AlertasService {
       .pipe(catchError(err => throwError(() => err)));
   }
 
-  // ── Historial (Reporting) ─────────────────────────────────────────────────────
+  // ── Resumen Alertas (Reporting) ───────────────────────────────────────────────
 
-  /** TODO FE-05 — wired en reporting: GET /reporting/alertas/resumen */
-  getHistorial(): Observable<never> {
-    return throwError(() => new Error('getHistorial: usar /reporting/alertas/resumen — pendiente FE-05'));
+  /** GET /reporting/alertas/resumen?destinatarioId? */
+  getResumenAlertas(destinatarioId?: string): Observable<ResumenAlertas> {
+    let params = new HttpParams();
+    if (destinatarioId) params = params.set('destinatarioId', destinatarioId);
+    return this.http
+      .get<ResumenAlertasResponse>(`${API}/reporting/alertas/resumen`, { params })
+      .pipe(
+        map(resumenAlertasFromApi),
+        catchError(err => throwError(() => err))
+      );
   }
 
-  /** TODO FE-05 — sin endpoint de exportación CSV */
+  /** TODO FE-05 — sin endpoint de exportación CSV confirmado con backend */
   exportarHistorialCSV(): Observable<never> {
-    return throwError(() => new Error('exportarHistorialCSV: endpoint no disponible — pendiente FE-05'));
+    return throwError(() => new Error('exportarHistorialCSV: endpoint no disponible — pendiente confirmación backend'));
   }
 }

--- a/libs/inventario/inventario/src/lib/data-access/services/consolidado.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/consolidado.service.ts
@@ -1,10 +1,13 @@
 import { inject, Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { Consolidado } from '../../models/consolidado.model';
+import { EjecucionPresupuestal } from '../../models/reporting.model';
 import { ConsolidadoResponse } from '../api/budget.api';
+import { EjecucionPresupuestalItemResponse } from '../api/reporting.api';
 import { consolidadoFromApi } from '../mappers/budget.mapper';
+import { ejecucionPresupuestalFromApi } from '../mappers/reporting.mapper';
 
 const API = '/api/v1';
 
@@ -44,6 +47,24 @@ export class ConsolidadoService {
       .patch<void>(`${API}/budget/consolidados/${id}/reversar`, {})
       .pipe(
         map(() => true),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** GET /reporting/ejecucion-presupuestal?fichaId?&vigencia? */
+  getEjecucionPresupuestal(
+    params?: { fichaId?: string; vigencia?: number },
+  ): Observable<EjecucionPresupuestal[]> {
+    let httpParams = new HttpParams();
+    if (params?.fichaId)  httpParams = httpParams.set('fichaId',  params.fichaId);
+    if (params?.vigencia) httpParams = httpParams.set('vigencia', String(params.vigencia));
+    return this.http
+      .get<EjecucionPresupuestalItemResponse[]>(
+        `${API}/reporting/ejecucion-presupuestal`,
+        { params: httpParams },
+      )
+      .pipe(
+        map(list => list.map(ejecucionPresupuestalFromApi)),
         catchError(err => throwError(() => err))
       );
   }

--- a/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import {
@@ -12,6 +12,8 @@ import {
 } from '../../models/movimiento.model';
 import { ExistenciaProducto } from '../../models/inventario.model';
 import { MovimientoResponse, ExistenciaResponse } from '../api/inventory.api';
+import { KardexValorizadoItemResponse } from '../api/reporting.api';
+import { KardexValorizadoItem } from '../../models/reporting.model';
 import {
   movimientoFromApi,
   existenciaFromApi,
@@ -21,6 +23,7 @@ import {
   liberacionToRequest,
   ajusteToRequest,
 } from '../mappers/inventory.mapper';
+import { kardexValorizadoFromApi } from '../mappers/reporting.mapper';
 
 const API = '/api/v1';
 
@@ -103,5 +106,23 @@ export class MovimientosService {
     return this.http
       .post<{ success: boolean }>(`${API}/inventory/movimientos/ajuste`, ajusteToRequest(data))
       .pipe(catchError(err => throwError(() => err)));
+  }
+
+  /** GET /reporting/kardex?productoId?&desde?&hasta? (ISO_DATE_TIME) */
+  getKardexValorizado(params?: {
+    productoId?: string;
+    desde?:      string;
+    hasta?:      string;
+  }): Observable<KardexValorizadoItem[]> {
+    let httpParams = new HttpParams();
+    if (params?.productoId) httpParams = httpParams.set('productoId', params.productoId);
+    if (params?.desde)      httpParams = httpParams.set('desde',      params.desde);
+    if (params?.hasta)      httpParams = httpParams.set('hasta',      params.hasta);
+    return this.http
+      .get<KardexValorizadoItemResponse[]>(`${API}/reporting/kardex`, { params: httpParams })
+      .pipe(
+        map(list => list.map(kardexValorizadoFromApi)),
+        catchError(err => throwError(() => err))
+      );
   }
 }

--- a/libs/inventario/inventario/src/lib/models/reporting.model.ts
+++ b/libs/inventario/inventario/src/lib/models/reporting.model.ts
@@ -1,0 +1,70 @@
+// ─── Modelos UI del módulo Reporting ────────────────────────────────────────
+
+export interface EjecucionPresupuestal {
+  fichaId:             string;
+  programaFormacion:   string;
+  vigencia:            number;
+  totalPresupuestado:  number;
+  totalComprometido:   number;
+  totalPagado:         number;
+  porcentajeEjecucion: number;
+  saldoDisponible:     number;
+}
+
+export interface KardexValorizadoItem {
+  fecha:           string;
+  tipo:            string;
+  productoId:      string;
+  productoNombre:  string;
+  cantidad:        number;
+  precioUnitario:  number;
+  valorTotal:      number;
+  saldoUnidades:   number;
+  saldoValorizado: number;
+}
+
+export interface ConsumoItem {
+  instructorId:      string;
+  instructorNombre:  string;
+  fichaId:           string;
+  programaFormacion: string;
+  productoId:        string;
+  productoNombre:    string;
+  cantidadConsumida: number;
+  valorTotal:        number;
+  fecha:             string;
+}
+
+export interface TrazabilidadDocumental {
+  fichaId:           string;
+  programaFormacion: string;
+  instructorId:      string;
+  instructorNombre:  string;
+  requisicionId?:    string;
+  actaId?:           string;
+  paqueteId?:        string;
+  gilId?:            string;
+  facturaId?:        string;
+  estado:            string;
+  fecha:             string;
+}
+
+export interface ResumenAlertas {
+  totalAlertas:      number;
+  alertasPendientes: number;
+  alertasResueltas:  number;
+  productosCriticos: number;
+  alertasPorTipo:    { tipo: string; cantidad: number }[];
+  ultimaAlerta?:     string;
+}
+
+/** Filtros compartidos para los endpoints de reporting */
+export interface ReportingFiltros {
+  fichaId?:      string;
+  instructorId?: string;
+  vigencia?:     number;
+  productoId?:   string;
+  desde?:        string;
+  hasta?:        string;
+  destinatarioId?: string;
+}


### PR DESCRIPTION
## Resumen

Conecta 3 endpoints de `/api/v1/reporting` que estaban pendientes o con URL incorrecta, más los archivos base del contexto Reporting.

### Archivos nuevos (compartidos con G6b)
| Archivo | Contenido |
|---------|-----------|
| `api/reporting.api.ts` | DTOs de los 5 endpoints de Reporting |
| `models/reporting.model.ts` | Interfaces UI + `ReportingFiltros` |
| `mappers/reporting.mapper.ts` | 5 funciones mapper |

### Endpoints implementados
| Endpoint | Service → método | Facade → método |
|----------|-----------------|-----------------|
| `GET /reporting/ejecucion-presupuestal` | `ConsolidadoService.getEjecucionPresupuestal()` | `ConsolidadoFacade.cargarEjecucionPresupuestal()` |
| `GET /reporting/kardex` | `MovimientosService.getKardexValorizado()` | `KardexFacade.cargarKardexValorizado()` |
| `GET /reporting/alertas/resumen` | `AlertasService.getResumenAlertas()` | `AlertasFacade.cargarHistorial()` + signal `resumenAlertas` |

### Cambios en AlertasFacade
- `getHistorial()` (throwError) reemplazado por `getResumenAlertas()` real
- Nuevo signal `_resumenAlertas: signal<ResumenAlertas | null>` — no rompe `historial()` legacy

## Test plan
- [x] Lint pasa
- [x] Build pasa
- [ ] `cargarEjecucionPresupuestal()` llama a `/reporting/ejecucion-presupuestal` con params opcionales
- [ ] `cargarKardexValorizado()` llama a `/reporting/kardex` con `productoId`, `desde`, `hasta`
- [ ] `cargarHistorial()` llama a `/reporting/alertas/resumen` y popula `resumenAlertas` signal
- [ ] `historial()` sigue devolviendo `[]` sin errores (compat. backward)