### PR TITLE
feat(inventario): remaining endpoints G7 — masivo, presupuesto detalle, paquete fix

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/budget.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/budget.api.ts
@@ -82,3 +82,37 @@ export interface ConsolidadoResponse {
 export interface GenerarConsolidadoRequest {
   gilIds: string[];
 }
+
+/** GET /budget/presupuestos/{id} — rubro dentro del detalle */
+export interface RubroResponse {
+  id: string;
+  codigo: string;
+  descripcion: string;
+  montoAsignado: number;
+  saldoDisponible: number;
+  montoComprometido: number;
+  montoPagado: number;
+  retencionZese: number;
+  porcentajeEjecucion: number;
+}
+
+/** GET /budget/presupuestos/{id} — detalle completo de un presupuesto */
+export interface PresupuestoDetalleResponse {
+  id: string;
+  fichaId: string;
+  programaFormacion: string;
+  vigencia: number;
+  fechaAprobacion: string;
+  rubros: RubroResponse[];
+}
+
+/** GET /budget/presupuestos/resumen?vigencia? */
+export interface ResumenPresupuestosResponse {
+  totalPresupuestos: number;
+  vigencia?: number;
+  totalAsignado: number;
+  totalComprometido: number;
+  totalPagado: number;
+  saldoGlobal: number;
+  porcentajeEjecucion: number;
+}

--- a/libs/inventario/inventario/src/lib/data-access/api/catalog.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/catalog.api.ts
@@ -27,3 +27,30 @@ export interface CrearProductoRequest {
 }
 
 export type ActualizarProductoRequest = Partial<CrearProductoRequest>;
+
+/** POST /catalog/productos/eliminacion-masiva */
+export interface EliminarProductosMasivaRequest {
+  ids: string[];
+  confirmacion: string;
+}
+
+export interface EliminacionMasivaResponse {
+  idsEliminados: string[];
+}
+
+/** POST /catalog/productos/importar */
+export interface ImportarProductosRequest {
+  productos: CrearProductoRequest[];
+}
+
+/** POST /catalog/productos/exportaciones (202 Accepted — async) */
+export interface SolicitarExportacionRequest {
+  formato: 'CSV' | 'EXCEL';
+}
+
+export interface ExportacionProductosResponse {
+  exportId: string;
+  estado: string;
+  formato: 'CSV' | 'EXCEL';
+  totalProductos: number;
+}

--- a/libs/inventario/inventario/src/lib/data-access/api/legalization.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/legalization.api.ts
@@ -44,8 +44,9 @@ export interface PaqueteResponse {
 }
 
 export interface CrearPaqueteRequest {
+  actaId: string;
+  requisicionId: string;
   fichaId: string;
-  gilId: string;
   instructorId: string;
   titulo?: string;
 }

--- a/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { Bien, BienFiltros, BienKpis, BienFormDto } from '../models/inventario.model';
+import { ExportacionProductosResponse } from './api/catalog.api';
 import { BienesService } from './services/bienes.service';
 import { finalize, catchError, of } from 'rxjs';
 
@@ -10,20 +11,22 @@ export class InventarioFacade {
   private bienesService = inject(BienesService);
 
   // Estados internos (Signals)
-  private _bienes = signal<Bien[]>([]);
-  private _kpis = signal<BienKpis | null>(null);
-  private _loading = signal<boolean>(false);
-  private _filtros = signal<BienFiltros>({});
-  private _bienSeleccionado = signal<Bien | undefined>(undefined);
-  private _error = signal<string | null>(null);
+  private _bienes              = signal<Bien[]>([]);
+  private _kpis                = signal<BienKpis | null>(null);
+  private _loading             = signal<boolean>(false);
+  private _filtros             = signal<BienFiltros>({});
+  private _bienSeleccionado    = signal<Bien | undefined>(undefined);
+  private _exportacionPendiente = signal<ExportacionProductosResponse | null>(null);
+  private _error               = signal<string | null>(null);
 
   // Exposición pública (Solo lectura)
-  public bienes = computed(() => this._bienes());
-  public kpis = computed(() => this._kpis());
-  public loading = computed(() => this._loading());
-  public filtros = computed(() => this._filtros());
-  public bienSeleccionado = computed(() => this._bienSeleccionado());
-  public error = computed(() => this._error());
+  public bienes               = computed(() => this._bienes());
+  public kpis                 = computed(() => this._kpis());
+  public loading              = computed(() => this._loading());
+  public filtros              = computed(() => this._filtros());
+  public bienSeleccionado     = computed(() => this._bienSeleccionado());
+  public exportacionPendiente = computed(() => this._exportacionPendiente());
+  public error                = computed(() => this._error());
 
   /**
    * Carga inicial de datos.
@@ -161,5 +164,49 @@ export class InventarioFacade {
       .subscribe((res) => {
         if (res !== null) this.loadAll();
       });
+  }
+
+  // ── Operaciones masivas ────────────────────────────────────────────────────
+
+  /** POST /catalog/productos/eliminacion-masiva */
+  eliminarBienesMasivo(ids: string[], confirmacion: string): void {
+    this._loading.set(true);
+    this.bienesService.eliminarBienesMasivo(ids, confirmacion)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al eliminar los bienes en masa');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res !== null) this.cargarBienes(); });
+  }
+
+  /** POST /catalog/productos/importar */
+  importarBienes(productos: BienFormDto[]): void {
+    this._loading.set(true);
+    this.bienesService.importarBienes(productos)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al importar los bienes');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res !== null) this.loadAll(); });
+  }
+
+  /** POST /catalog/productos/exportaciones (202 Accepted — async) */
+  solicitarExportacion(formato: 'CSV' | 'EXCEL'): void {
+    this._loading.set(true);
+    this.bienesService.solicitarExportacion(formato)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al solicitar la exportación');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => { if (res !== null) this._exportacionPendiente.set(res); });
   }
 }

--- a/libs/inventario/inventario/src/lib/data-access/mappers/budget.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/budget.mapper.ts
@@ -1,6 +1,12 @@
-import { Rubro, Compromiso } from '../../models/presupuesto.model';
+import { Rubro, Compromiso, PresupuestoDetalle, ResumenPresupuestosGlobal } from '../../models/presupuesto.model';
 import { Consolidado } from '../../models/consolidado.model';
-import { PresupuestoResponse, ConsolidadoResponse, CompromisoResponse } from '../api/budget.api';
+import {
+  PresupuestoResponse,
+  ConsolidadoResponse,
+  CompromisoResponse,
+  PresupuestoDetalleResponse,
+  ResumenPresupuestosResponse,
+} from '../api/budget.api';
 
 export function rubroFromApi(dto: PresupuestoResponse): Rubro {
   return {
@@ -29,6 +35,41 @@ export function compromisoFromApi(dto: CompromisoResponse): Compromiso {
     montoRetencionZese: dto.montoRetencionZese,
     fecha:              dto.fecha,
     estado:             dto.estado,
+  };
+}
+
+export function presupuestoDetalleFromApi(dto: PresupuestoDetalleResponse): PresupuestoDetalle {
+  return {
+    id:                dto.id,
+    fichaId:           dto.fichaId,
+    programaFormacion: dto.programaFormacion,
+    vigencia:          dto.vigencia,
+    fechaAprobacion:   dto.fechaAprobacion,
+    rubros: dto.rubros.map(r => ({
+      id:                 r.id,
+      codigo:             r.codigo,
+      descripcion:        r.descripcion,
+      fichaId:            dto.fichaId,
+      programaFormacion:  dto.programaFormacion,
+      montoAsignado:      r.montoAsignado,
+      saldoDisponible:    r.saldoDisponible,
+      montoComprometido:  r.montoComprometido,
+      montoPagado:        r.montoPagado,
+      retencionZese:      r.retencionZese,
+      porcentajeEjecucion: r.porcentajeEjecucion,
+    })),
+  };
+}
+
+export function resumenPresupuestosFromApi(dto: ResumenPresupuestosResponse): ResumenPresupuestosGlobal {
+  return {
+    totalPresupuestos: dto.totalPresupuestos,
+    vigencia:          dto.vigencia,
+    totalAsignado:     dto.totalAsignado,
+    totalComprometido: dto.totalComprometido,
+    totalPagado:       dto.totalPagado,
+    saldoGlobal:       dto.saldoGlobal,
+    porcentajeEjecucion: dto.porcentajeEjecucion,
   };
 }
 

--- a/libs/inventario/inventario/src/lib/data-access/presupuesto.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/presupuesto.facade.ts
@@ -3,6 +3,7 @@ import { catchError, finalize, of } from 'rxjs';
 import { PresupuestoService } from './services/presupuesto.service';
 import {
   PresupuestoResumen,
+  PresupuestoDetalle,
   Rubro,
   GrupoPresupuestal,
   AfectacionPresupuestal,
@@ -20,24 +21,26 @@ export class PresupuestoFacade {
   private presupuestoService = inject(PresupuestoService);
 
   // Estados internos (Signals)
-  private _resumen          = signal<PresupuestoResumen | null>(null);
-  private _rubros           = signal<Rubro[]>([]);
-  private _compromisos      = signal<Compromiso[]>([]);
-  private _afectaciones     = signal<AfectacionPresupuestal[]>([]);
-  private _vencimientos     = signal<VencimientoProximo[]>([]);
-  private _ejecucionMensual = signal<EjecucionMensual[]>([]);
-  private _loading          = signal<boolean>(false);
-  private _error            = signal<string | null>(null);
+  private _resumen               = signal<PresupuestoResumen | null>(null);
+  private _rubros                = signal<Rubro[]>([]);
+  private _compromisos           = signal<Compromiso[]>([]);
+  private _afectaciones          = signal<AfectacionPresupuestal[]>([]);
+  private _vencimientos          = signal<VencimientoProximo[]>([]);
+  private _ejecucionMensual      = signal<EjecucionMensual[]>([]);
+  private _presupuestoSeleccionado = signal<PresupuestoDetalle | undefined>(undefined);
+  private _loading               = signal<boolean>(false);
+  private _error                 = signal<string | null>(null);
 
   // Exposición pública (solo lectura)
-  public resumen          = computed(() => this._resumen());
-  public rubros           = computed(() => this._rubros());
-  public compromisos      = computed(() => this._compromisos());
-  public afectaciones     = computed(() => this._afectaciones());
-  public vencimientos     = computed(() => this._vencimientos());
-  public ejecucionMensual = computed(() => this._ejecucionMensual());
-  public loading          = computed(() => this._loading());
-  public error            = computed(() => this._error());
+  public resumen                = computed(() => this._resumen());
+  public rubros                 = computed(() => this._rubros());
+  public compromisos            = computed(() => this._compromisos());
+  public afectaciones           = computed(() => this._afectaciones());
+  public vencimientos           = computed(() => this._vencimientos());
+  public ejecucionMensual       = computed(() => this._ejecucionMensual());
+  public presupuestoSeleccionado = computed(() => this._presupuestoSeleccionado());
+  public loading                = computed(() => this._loading());
+  public error                  = computed(() => this._error());
 
   /** Vista agrupada de rubros por ficha — derivada en cliente */
   public grupos = computed<GrupoPresupuestal[]>(() => {
@@ -80,36 +83,37 @@ export class PresupuestoFacade {
    */
   loadAll(): void {
     this._loading.set(true);
-    let loadedCount = 0;
-    const totalRequests = 5;
+    this._error.set(null);
 
-    const checkLoading = () => {
-      loadedCount++;
-      if (loadedCount === totalRequests) {
+    this.presupuestoService.getResumen()
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar el resumen presupuestal');
+          return of(null);
+        })
+      )
+      .subscribe(data => {
+        if (data) {
+          this._resumen.set({
+            vigenciaFiscal:    data.vigencia ?? new Date().getFullYear(),
+            corte:             new Date().toLocaleDateString('es-CO'),
+            totalApropiacion:  data.totalAsignado,
+            totalComprometido: data.totalComprometido,
+            totalPagado:       data.totalPagado,
+            totalDisponible:   data.saldoGlobal,
+            totalZese:         0,
+            porcentajeEjecucion: data.porcentajeEjecucion,
+            variacionAnual:    0,
+          });
+        }
+      });
+
+    this.presupuestoService.getRubros()
+      .pipe(catchError(() => of([])))
+      .subscribe(data => {
+        this._rubros.set(data);
         this._loading.set(false);
-      }
-    };
-
-    this.presupuestoService.getResumen().subscribe(data => {
-      this._resumen.set(data);
-      checkLoading();
-    });
-    this.presupuestoService.getRubros().subscribe(data => {
-      this._rubros.set(data);
-      checkLoading();
-    });
-    this.presupuestoService.getAfectaciones().subscribe(data => {
-      this._afectaciones.set(data);
-      checkLoading();
-    });
-    this.presupuestoService.getVencimientos().subscribe(data => {
-      this._vencimientos.set(data);
-      checkLoading();
-    });
-    this.presupuestoService.getEjecucionMensual().subscribe(data => {
-      this._ejecucionMensual.set(data);
-      checkLoading();
-    });
+      });
   }
 
   // ── Compromisos ────────────────────────────────────────────────────────────
@@ -191,6 +195,20 @@ export class PresupuestoFacade {
       .subscribe(res => {
         if (res) this.loadAll();
       });
+  }
+
+  /** GET /budget/presupuestos/{id} — carga el detalle de un presupuesto */
+  cargarPresupuestoById(id: string): void {
+    this._loading.set(true);
+    this.presupuestoService.getPresupuestoById(id)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar el detalle del presupuesto');
+          return of(undefined);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(data => this._presupuestoSeleccionado.set(data));
   }
 
   trasladarRubro(data: TrasladarRubroData): void {

--- a/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
@@ -3,7 +3,15 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, of, throwError, forkJoin } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { Bien, BienFiltros, BienKpis, BienFormDto } from '../../models/inventario.model';
-import { PagedResponse, ProductoResponse } from '../api/catalog.api';
+import {
+  PagedResponse,
+  ProductoResponse,
+  EliminarProductosMasivaRequest,
+  EliminacionMasivaResponse,
+  ImportarProductosRequest,
+  SolicitarExportacionRequest,
+  ExportacionProductosResponse,
+} from '../api/catalog.api';
 import { ExistenciaResponse } from '../api/inventory.api';
 import {
   bienFromCatalogo,
@@ -98,5 +106,31 @@ export class BienesService {
         map(bienFromCatalogo),
         catchError(err => throwError(() => err))
       );
+  }
+
+  // ── Operaciones masivas ──────────────────────────────────────────────────────
+
+  /** POST /catalog/productos/eliminacion-masiva */
+  eliminarBienesMasivo(ids: string[], confirmacion: string): Observable<EliminacionMasivaResponse> {
+    const body: EliminarProductosMasivaRequest = { ids, confirmacion };
+    return this.http
+      .post<EliminacionMasivaResponse>(`${API}/catalog/productos/eliminacion-masiva`, body)
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  /** POST /catalog/productos/importar */
+  importarBienes(productos: BienFormDto[]): Observable<{ success: boolean }> {
+    const body: ImportarProductosRequest = { productos: productos.map(bienFormToRequest) };
+    return this.http
+      .post<{ success: boolean }>(`${API}/catalog/productos/importar`, body)
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  /** POST /catalog/productos/exportaciones (202 Accepted — async) */
+  solicitarExportacion(formato: 'CSV' | 'EXCEL'): Observable<ExportacionProductosResponse> {
+    const body: SolicitarExportacionRequest = { formato };
+    return this.http
+      .post<ExportacionProductosResponse>(`${API}/catalog/productos/exportaciones`, body)
+      .pipe(catchError(err => throwError(() => err)));
   }
 }

--- a/libs/inventario/inventario/src/lib/data-access/services/paquete.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/paquete.service.ts
@@ -33,8 +33,9 @@ export class PaqueteService {
   /** La facade pasa Partial<PaqueteProbatorio> — el service construye el request tipado. */
   crearPaquete(data: Partial<PaqueteProbatorio>): Observable<PaqueteProbatorio> {
     const request: CrearPaqueteRequest = {
-      fichaId:      data.fichaId ?? '',
-      gilId:        data.gilId ?? '',
+      actaId:       data.actaId       ?? '',
+      requisicionId: data.requisicionId ?? '',
+      fichaId:      data.fichaId      ?? '',
       instructorId: data.instructorId ?? '',
       titulo:       data.titulo,
     };

--- a/libs/inventario/inventario/src/lib/data-access/services/presupuesto.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/presupuesto.service.ts
@@ -4,6 +4,8 @@ import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import {
   PresupuestoResumen,
+  PresupuestoDetalle,
+  ResumenPresupuestosGlobal,
   Rubro,
   AfectacionPresupuestal,
   VencimientoProximo,
@@ -14,8 +16,15 @@ import {
   ComprometerData,
   PagoData,
 } from '../../models/presupuesto.model';
-import { PresupuestoResponse, CompromisoResponse, ComprometerRequest, PagoRequest } from '../api/budget.api';
-import { rubroFromApi, compromisoFromApi } from '../mappers/budget.mapper';
+import {
+  PresupuestoResponse,
+  PresupuestoDetalleResponse,
+  ResumenPresupuestosResponse,
+  CompromisoResponse,
+  ComprometerRequest,
+  PagoRequest,
+} from '../api/budget.api';
+import { rubroFromApi, compromisoFromApi, presupuestoDetalleFromApi, resumenPresupuestosFromApi } from '../mappers/budget.mapper';
 
 const API = '/api/v1';
 
@@ -32,23 +41,26 @@ export class PresupuestoService {
       );
   }
 
-  /** Resumen derivado de los rubros — FE-06 alineará con el contrato oficial */
-  getResumen(): Observable<PresupuestoResumen> {
-    return this.getRubros().pipe(
-      map(rubros => ({
-        vigenciaFiscal: new Date().getFullYear(),
-        corte: new Date().toLocaleDateString('es-CO'),
-        totalApropiacion:   rubros.reduce((s, r) => s + r.montoAsignado, 0),
-        totalComprometido:  rubros.reduce((s, r) => s + r.montoComprometido, 0),
-        totalPagado:        rubros.reduce((s, r) => s + r.montoPagado, 0),
-        totalDisponible:    rubros.reduce((s, r) => s + r.saldoDisponible, 0),
-        totalZese:          rubros.reduce((s, r) => s + r.retencionZese, 0),
-        porcentajeEjecucion: rubros.length
-          ? rubros.reduce((s, r) => s + r.porcentajeEjecucion, 0) / rubros.length
-          : 0,
-        variacionAnual: 0, // TODO FE-06: sin endpoint disponible aún
-      }))
-    );
+  /** GET /budget/presupuestos/resumen?vigencia? */
+  getResumen(vigencia?: number): Observable<ResumenPresupuestosGlobal> {
+    let params = new HttpParams();
+    if (vigencia) params = params.set('vigencia', String(vigencia));
+    return this.http
+      .get<ResumenPresupuestosResponse>(`${API}/budget/presupuestos/resumen`, { params })
+      .pipe(
+        map(resumenPresupuestosFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** GET /budget/presupuestos/{id} */
+  getPresupuestoById(id: string): Observable<PresupuestoDetalle> {
+    return this.http
+      .get<PresupuestoDetalleResponse>(`${API}/budget/presupuestos/${id}`)
+      .pipe(
+        map(presupuestoDetalleFromApi),
+        catchError(err => throwError(() => err))
+      );
   }
 
   registrarPresupuesto(data: RegistrarPresupuestoData): Observable<{ success: boolean }> {

--- a/libs/inventario/inventario/src/lib/models/presupuesto.model.ts
+++ b/libs/inventario/inventario/src/lib/models/presupuesto.model.ts
@@ -73,6 +73,27 @@ export interface EjecucionMensual {
   esMesActual: boolean;
 }
 
+/** Detalle de un presupuesto (GET /budget/presupuestos/{id}) */
+export interface PresupuestoDetalle {
+  id: string;
+  fichaId: string;
+  programaFormacion: string;
+  vigencia: number;
+  fechaAprobacion: string;
+  rubros: Rubro[];
+}
+
+/** Resumen global de presupuestos (GET /budget/presupuestos/resumen) */
+export interface ResumenPresupuestosGlobal {
+  totalPresupuestos: number;
+  vigencia?: number;
+  totalAsignado: number;
+  totalComprometido: number;
+  totalPagado: number;
+  saldoGlobal: number;
+  porcentajeEjecucion: number;
+}
+
 /** Payload para registrar un nuevo rubro presupuestal */
 export interface RegistrarPresupuestoData {
   programaId: string;


### PR DESCRIPTION
## Cambios

### Catalog — Operaciones masivas
- `catalog.api.ts`: 5 nuevos DTOs: `EliminarProductosMasivaRequest`, `EliminacionMasivaResponse`, `ImportarProductosRequest`, `SolicitarExportacionRequest`, `ExportacionProductosResponse`
- `bienes.service.ts`: `eliminarBienesMasivo()`, `importarBienes()`, `solicitarExportacion()`
- `inventario.facade.ts`: signal `exportacionPendiente` + 3 métodos masivos

### Legalization — Fix DTO paquete
- `legalization.api.ts`: `CrearPaqueteRequest.gilId` → `actaId + requisicionId`
- `paquete.service.ts`: `crearPaquete()` usa `data.actaId` y `data.requisicionId`

### Budget — Presupuesto por ID y resumen global
- `budget.api.ts`: `RubroResponse`, `PresupuestoDetalleResponse`, `ResumenPresupuestosResponse`
- `presupuesto.model.ts`: `PresupuestoDetalle`, `ResumenPresupuestosGlobal`
- `budget.mapper.ts`: `presupuestoDetalleFromApi()`, `resumenPresupuestosFromApi()`
- `presupuesto.service.ts`: reemplaza `getResumen()` client-side con `GET /budget/presupuestos/resumen`; agrega `getPresupuestoById(id)`
- `presupuesto.facade.ts`: signal `presupuestoSeleccionado` + `cargarPresupuestoById()`; `loadAll()` usa endpoint real

## Verificación
- `nx run inventario:lint` ✅
- `nx run restaurant-app:build` ✅ (317 inserciones, sin errores)