### PR TITLE
feat(inventario): replace hardcoded mock data with reactive computed signals

### DIFF
--- a/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-detail/consolidado-detail.component.html
+++ b/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-detail/consolidado-detail.component.html
@@ -4,8 +4,8 @@
     <div class="page-header__left">
       <inventario-back-button (clicked)="goBack()"></inventario-back-button>
       <div class="page-header__title-row">
-        <h1 class="page-header__title">Detalle: <span class="text-primary">#CON-2023-0842</span></h1>
-        <span class="badge badge--success-soft">CONTABILIZADO</span>
+        <h1 class="page-header__title">Detalle: <span class="text-primary">#{{ consolidado()?.id ?? '...' }}</span></h1>
+        <span class="badge badge--success-soft">{{ consolidado()?.estado ?? '' }}</span>
       </div>
     </div>
 
@@ -23,206 +23,124 @@
   <div class="kpi-grid">
     <restaurant-kpi-card
       label="Total Consolidado"
-      value="$142,500,000"
+      [value]="(consolidado()?.totales?.totalGeneral ?? 0) | currency:'COP':'symbol-narrow':'1.0-0'"
       icon="landmark"
-      iconColor="green"
-      trend="+12.5% vs Mes Anterior"
-      [trendUp]="true"
-    />
+      iconColor="green">
+    </restaurant-kpi-card>
 
     <restaurant-kpi-card
-      label="Vouchers Incluidos"
-      value="28 Formatos"
+      label="Líneas incluidas"
+      [value]="(consolidado()?.lineas?.length ?? 0)"
       icon="file-text"
-      iconColor="blue"
-    />
+      iconColor="blue">
+    </restaurant-kpi-card>
 
     <restaurant-kpi-card
-      label="Fecha de Cierre"
-      value="24 Oct, 2023"
+      label="Fecha de Generación"
+      [value]="consolidado()?.fechaGeneracion ?? '--'"
       icon="calendar"
-      iconColor="slate"
-    />
+      iconColor="slate">
+    </restaurant-kpi-card>
 
     <restaurant-kpi-card
-      label="Centro de Operación"
-      value="Bogotá D.C."
-      icon="building-2"
-      iconColor="blue"
-    />
+      label="Generado por"
+      [value]="consolidado()?.generadoPor ?? '--'"
+      icon="user"
+      iconColor="blue">
+    </restaurant-kpi-card>
   </div>
 
-  <!-- Section 1: Subtotales Discriminados -->
+  <!-- Section 1: Subtotales por tipo de línea -->
   <section class="bento-card p-0">
     <div class="section-header">
       <div class="section-header__title-container">
         <div class="section-header__icon">
           <span class="material-symbols-outlined">pie_chart</span>
         </div>
-        <h3 class="section-header__title">Subtotales Discriminados</h3>
+        <h3 class="section-header__title">Subtotales por Tipo</h3>
       </div>
-      <span class="section-header__subtitle">Agrupado por categoría contable</span>
+      <span class="section-header__subtitle">Agrupado por tipo de línea</span>
     </div>
 
     <restaurant-data-table>
       <thead>
         <tr>
-          <th class="th-left">Centro de Costo</th>
-          <th class="th-left">Categoría de Inventario</th>
-          <th class="th-right">Subtotal</th>
+          <th class="th-left">Tipo</th>
+          <th class="th-right">Cantidad total</th>
+          <th class="th-right">Valor total</th>
         </tr>
       </thead>
       <tbody>
-        @for (item of subtotales; track item.cc) {
+        @for (item of subtotalesPorTipo(); track item.tipo) {
           <tr>
-            <td>
-              <div class="td-flex-col">
-                <span class="td-bold">{{ item.cc }}</span>
-                <span class="td-muted">{{ item.area }}</span>
-              </div>
-            </td>
-            <td>
-              <span class="td-medium">{{ item.categoria }}</span>
-            </td>
+            <td><span class="td-bold">{{ item.tipo }}</span></td>
+            <td class="text-right"><span class="td-medium">{{ item.cantidad }}</span></td>
             <td class="text-right">
-              <span class="td-value-primary">{{ item.subtotal }}</span>
+              <span class="td-value-primary">{{ item.valor | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
             </td>
           </tr>
+        }
+        @if (subtotalesPorTipo().length === 0) {
+          <tr><td colspan="3" class="td-muted text-center">Sin líneas registradas</td></tr>
         }
       </tbody>
     </restaurant-data-table>
   </section>
 
-  <!-- Section 1.5: Tabla de Ejecución Detallada -->
+  <!-- Section 2: Líneas de ejecución -->
   <section class="bento-card p-0 table-overflow">
     <div class="section-header">
       <div class="section-header__title-container">
         <div class="section-header__icon">
           <span class="material-symbols-outlined">table_view</span>
         </div>
-        <h3 class="section-header__title">Tabla de Ejecución Detallada</h3>
+        <h3 class="section-header__title">Líneas del Consolidado</h3>
       </div>
     </div>
 
     <restaurant-data-table>
       <thead>
         <tr>
-          <th class="th-left">Fecha</th>
-          <th class="th-left">Nº Factura</th>
-          <th class="th-left">CUFE</th>
-          <th class="th-left">Programa</th>
-          <th class="th-left">Ficha</th>
-          <th class="th-left">Cód. SENA</th>
+          <th class="th-left">Referencia</th>
           <th class="th-left">Descripción</th>
-          <th class="th-right">Cant.</th>
-          <th class="th-right">Valor Unit.</th>
-          <th class="th-right">IVA%</th>
-          <th class="th-right">Subtotal</th>
-          <th class="th-right">ZESE</th>
+          <th class="th-left">Tipo</th>
+          <th class="th-right">Cantidad</th>
+          <th class="th-right">Valor</th>
         </tr>
       </thead>
       <tbody>
-        @for (item of ejecucion; track item.factura) {
+        @for (linea of (consolidado()?.lineas ?? []); track linea.id) {
           <tr>
-            <td class="td-muted whitespace-nowrap">{{ item.fecha }}</td>
-            <td class="td-medium whitespace-nowrap">{{ item.factura }}</td>
-            <td class="td-mono td-muted cursor-help" [title]="item.cufeFull">{{ item.cufe }}</td>
-            <td class="td-normal">{{ item.programa }}</td>
-            <td class="td-muted">{{ item.ficha }}</td>
-            <td class="td-muted whitespace-nowrap">{{ item.codigo }}</td>
-            <td class="td-normal">{{ item.desc }}</td>
-            <td class="text-right td-normal">{{ item.cant }}</td>
-            <td class="text-right td-normal whitespace-nowrap">{{ item.valorUnit }}</td>
-            <td class="text-right td-muted">{{ item.iva }}</td>
-            <td class="text-right td-medium whitespace-nowrap">{{ item.subtotal }}</td>
-            <td class="text-right td-normal">{{ item.zese }}</td>
+            <td class="td-mono td-muted">{{ linea.referencia }}</td>
+            <td class="td-normal">{{ linea.descripcion }}</td>
+            <td><span class="td-muted">{{ linea.tipo }}</span></td>
+            <td class="text-right td-normal">{{ linea.cantidad }}</td>
+            <td class="text-right td-medium">{{ linea.valor | currency:'COP':'symbol-narrow':'1.0-0' }}</td>
           </tr>
+        }
+        @if ((consolidado()?.lineas ?? []).length === 0) {
+          <tr><td colspan="5" class="td-muted text-center">Sin líneas registradas</td></tr>
         }
       </tbody>
       <tfoot dtFooter class="tfoot-totals">
         <tr>
-          <td class="tfoot-totals__label" colspan="10">Totales</td>
+          <td class="tfoot-totals__label" colspan="3">Totales</td>
           <td class="text-right">
             <div class="td-flex-col text-right">
-              <span class="tfoot-totals__sublabel">Σ Valor Neto</span>
-              <span class="tfoot-totals__value">$13,050,000</span>
+              <span class="tfoot-totals__sublabel">Σ Bienes</span>
+              <span class="tfoot-totals__value">{{ (consolidado()?.totales?.totalBienes ?? 0) | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
             </div>
           </td>
           <td class="text-right">
             <div class="td-flex-col text-right">
-              <span class="tfoot-totals__sublabel">Σ IVA</span>
-              <span class="tfoot-totals__value">$2,479,500</span>
+              <span class="tfoot-totals__sublabel">Σ Servicios</span>
+              <span class="tfoot-totals__value">{{ (consolidado()?.totales?.totalServicios ?? 0) | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
             </div>
           </td>
         </tr>
       </tfoot>
     </restaurant-data-table>
   </section>
-
-  <!-- Section 2: Listado de Formatos GIL-F014 -->
-  <restaurant-data-table
-    tableTitle="Listado de Formatos GIL-F014"
-    tableIcon="description"
-    searchPlaceholder="Buscar por código GIL o solicitante...">
-    
-    <thead>
-      <tr>
-        <th class="th-center">Código GIL</th>
-        <th class="th-center">Solicitante</th>
-        <th class="th-center">Programa</th>
-        <th class="th-center">CUFE</th>
-        <th class="th-center">Fecha</th>
-        <th class="th-center">Valor</th>
-        <th class="th-center">Acciones</th>
-      </tr>
-    </thead>
-    <tbody class="text-black text-center">
-      @for (item of gils; track item.codigo) {
-          <tr>
-            <td>
-              <span class="badge badge--surface font-mono">{{ item.codigo }}</span>
-            </td>
-            <td>
-              <div class="td-flex-row">
-                <div class="avatar">{{ item.iniciales }}</div>
-                <span class="td-medium">{{ item.solicitante }}</span>
-              </div>
-            </td>
-            <td>
-              <span class="td-muted">{{ item.programa }}</span>
-            </td>
-            <td>
-              <span class="td-mono-dashed cursor-help" [title]="item.cufeFull">{{ item.cufe }}</span>
-            </td>
-            <td>
-              <span class="td-muted">{{ item.fecha }}</span>
-            </td>
-            <td class="text-center">
-              <span class="td-bold">{{ item.valor }}</span>
-            </td>
-            <td class="text-center">
-              <button class="action-btn" title="Ver Detalle" (click)="goToGilDetail(item.codigo)">
-                <span class="material-symbols-outlined">visibility</span>
-              </button>
-            </td>
-          </tr>
-        }
-      </tbody>
-      <div dtFooter class="dt-footer">
-        <span class="table-pagination__info">Mostrando 4 de 28 registros</span>
-        <div class="pagination-btns">
-          <button class="pagination-btn" disabled>
-            <span class="material-symbols-outlined">chevron_left</span>
-          </button>
-          <button class="pagination-btn pagination-btn--active">1</button>
-          <button class="pagination-btn">2</button>
-          <button class="pagination-btn">3</button>
-          <button class="pagination-btn">
-            <span class="material-symbols-outlined">chevron_right</span>
-          </button>
-        </div>
-      </div>
-    </restaurant-data-table>
   @if (showExportModal()) {
 <restaurant-exportar-consolidado-modal
    
@@ -231,16 +149,15 @@
   </restaurant-exportar-consolidado-modal>
 }
 
-  @if (showReversarModal()) {
-<restaurant-reversar-consolidado-modal
-   
-    [consolidadoId]="'#CON-2023-0842'"
-    [periodo]="'Octubre 2024'"
-    [total]="'$ 1.452.300.000'"
-    [comprobantes]="12" 
-    [isBlocked]="isReversarBlocked()"
-    (close)="closeReversarModal()"
-    (confirm)="confirmReversar()">
-  </restaurant-reversar-consolidado-modal>
-}
+  @if (showReversarModal() && consolidado()) {
+    <restaurant-reversar-consolidado-modal
+      [consolidadoId]="consolidado()!.id"
+      [periodo]="consolidado()!.fechaGeneracion"
+      [total]="(consolidado()!.totales.totalGeneral | currency:'COP':'symbol-narrow':'1.0-0') ?? ''"
+      [comprobantes]="consolidado()!.lineas.length"
+      [isBlocked]="isReversarBlocked()"
+      (close)="closeReversarModal()"
+      (confirm)="confirmReversar()">
+    </restaurant-reversar-consolidado-modal>
+  }
 </div>

--- a/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-detail/consolidado-detail.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-detail/consolidado-detail.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
-import { Location } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject, signal, OnInit } from '@angular/core';
+import { CurrencyPipe } from '@angular/common';
 import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { ButtonComponent, DataTableComponent, KpiCardComponent } from '@restaurant/shared/ui';
 import { ExportarConsolidadoModalComponent } from '../components/exportar-consolidado-modal/exportar-consolidado-modal.component';
@@ -10,20 +10,31 @@ import { ConsolidadoFacade } from '../../../data-access/consolidado.facade';
 @Component({
   selector: 'restaurant-consolidado-detail',
   standalone: true,
-  imports: [RouterModule, ButtonComponent, DataTableComponent, KpiCardComponent, ExportarConsolidadoModalComponent, ReversarConsolidadoModalComponent, BackButtonComponent],
+  imports: [RouterModule, CurrencyPipe, ButtonComponent, DataTableComponent, KpiCardComponent, ExportarConsolidadoModalComponent, ReversarConsolidadoModalComponent, BackButtonComponent],
   templateUrl: './consolidado-detail.component.html',
   styleUrl: './consolidado-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ConsolidadoDetailComponent implements OnInit {
-  private router   = inject(Router);
-  private location = inject(Location);
-  private route    = inject(ActivatedRoute);
-  private facade   = inject(ConsolidadoFacade);
+  private router = inject(Router);
+  private route  = inject(ActivatedRoute);
+  private facade = inject(ConsolidadoFacade);
 
   // ── Estado reactivo desde facade ─────────────────────────────────────────
   consolidado = this.facade.consolidadoSeleccionado;
   loading     = this.facade.loading;
+
+  // ── Subtotales agrupados por tipo de línea ────────────────────────────────
+  subtotalesPorTipo = computed(() => {
+    const lineas = this.consolidado()?.lineas ?? [];
+    const grupos: Record<string, { tipo: string; cantidad: number; valor: number }> = {};
+    for (const l of lineas) {
+      if (!grupos[l.tipo]) grupos[l.tipo] = { tipo: l.tipo, cantidad: 0, valor: 0 };
+      grupos[l.tipo].cantidad += l.cantidad;
+      grupos[l.tipo].valor    += l.valor;
+    }
+    return Object.values(grupos);
+  });
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -34,30 +45,9 @@ export class ConsolidadoDetailComponent implements OnInit {
     this.facade.cargarConsolidado(id);
   }
 
-  showExportModal = signal(false);
+  showExportModal   = signal(false);
   showReversarModal = signal(false);
   isReversarBlocked = signal(false);
-
-  // Mocks para la tabla de subtotales
-  subtotales = [
-    { cc: 'CC-001', area: 'Mantenimiento y Planta', categoria: 'Suministros de Oficina', subtotal: '$45,230,000' },
-    { cc: 'CC-045', area: 'Formación Técnica', categoria: 'Material Didáctico', subtotal: '$82,100,500' },
-    { cc: 'CC-012', area: 'Gestión Humana', categoria: 'Elementos de Seguridad', subtotal: '$15,169,500' }
-  ];
-
-  // Mocks para la tabla de ejecución detallada
-  ejecucion = [
-    { fecha: '12 Oct, 2023', factura: 'FAC-8902', cufe: 'A1B2C3...', cufeFull: 'A1B2C3D4E5F6', programa: 'Cocina', ficha: '2541010', codigo: 'CS-091', desc: 'Insumos Cárnicos', cant: 15, valorUnit: '$450,000', iva: '19%', subtotal: '$6,750,000', zese: '$0' },
-    { fecha: '14 Oct, 2023', factura: 'FAC-8915', cufe: '9F8E7D...', cufeFull: '9F8E7D6C5B4A', programa: 'Sistemas', ficha: '2541022', codigo: 'IT-105', desc: 'Equipos de Cómputo', cant: 3, valorUnit: '$2,100,000', iva: '19%', subtotal: '$6,300,000', zese: '$0' }
-  ];
-
-  // Mocks para la tabla de formatos GIL
-  gils = [
-    { codigo: 'GIL-2023-F014-001', iniciales: 'RM', solicitante: 'Ricardo Martínez', programa: 'Cocina', cufe: 'A1B2C3...', cufeFull: 'A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6', fecha: '12 Oct, 2023', valor: '$12,450,000' },
-    { codigo: 'GIL-2023-F014-002', iniciales: 'AL', solicitante: 'Ana Lucia Gómez', programa: 'Repostería', cufe: 'Z9Y8X7...', cufeFull: 'Z9Y8X7W6V5U4T3S2R1Q0P9O8N7M6L5K4', fecha: '14 Oct, 2023', valor: '$8,900,000' },
-    { codigo: 'GIL-2023-F014-003', iniciales: 'JP', solicitante: 'Julián Prada', programa: 'Sistemas', cufe: '1A2B3C...', cufeFull: '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P', fecha: '18 Oct, 2023', valor: '$23,750,000' },
-    { codigo: 'GIL-2023-F014-004', iniciales: 'SC', solicitante: 'Sofía Cárdenas', programa: 'Mantenimiento', cufe: '9F8E7D...', cufeFull: '9F8E7D6C5B4A39281706A5B4C3D2E1F0', fecha: '20 Oct, 2023', valor: '$11,200,000' }
-  ];
 
   goBack(): void {
     this.router.navigate(['/app/inventario/consolidado']);

--- a/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-list/consolidado-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-list/consolidado-list.component.html
@@ -15,40 +15,34 @@
     </div>
   </div>
 
-  <!-- Bento-Style KPI Grid (Using standard KpiCardComponent) -->
+  <!-- KPI Grid derivado de la lista real -->
   <div class="kpi-grid">
-    <restaurant-kpi-card 
-      label="Retención ZESE Acumulada" 
-      [value]="kpis().retencionZese | currency:'COP':'symbol-narrow':'1.0-0'" 
-      icon="landmark" 
-      iconColor="blue"
-      trend="+4.2%" 
-      [trendUp]="true">
+    <restaurant-kpi-card
+      label="Total Ejecutado"
+      [value]="kpiTotalEjecutado() | currency:'COP':'symbol-narrow':'1.0-0'"
+      icon="bar-chart-2"
+      iconColor="blue">
     </restaurant-kpi-card>
 
-    <restaurant-kpi-card 
-      label="Total IVA Acumulado" 
-      [value]="kpis().ivaAcumulado | currency:'COP':'symbol-narrow':'1.0-0'" 
-      icon="banknote" 
-      iconColor="green"
-      trend="Estable" 
-      [trendUp]="null">
+    <restaurant-kpi-card
+      label="Contabilizados"
+      [value]="kpiContabilizados()"
+      icon="check-circle"
+      iconColor="green">
     </restaurant-kpi-card>
 
-    <restaurant-kpi-card 
-      label="Total Ejecutado Neto" 
-      [value]="kpis().totalEjecutado | currency:'COP':'symbol-narrow':'1.0-0'" 
-      icon="bar-chart-2" 
-      iconColor="red"
-      trend="Alerta" 
-      [trendUp]="false">
-    </restaurant-kpi-card>
-
-    <restaurant-kpi-card 
-      label="GILs Pendientes" 
-      [value]="kpis().gilsPendientes" 
-      icon="file-text" 
+    <restaurant-kpi-card
+      label="Generados"
+      [value]="kpiGenerados()"
+      icon="file-text"
       iconColor="orange">
+    </restaurant-kpi-card>
+
+    <restaurant-kpi-card
+      label="Reversados"
+      [value]="kpiReversados()"
+      icon="undo-2"
+      iconColor="red">
     </restaurant-kpi-card>
   </div>
 
@@ -100,7 +94,7 @@
     </tbody>
     
     <div dtFooter class="dt-footer">
-      <span class="table-pagination__info">Mostrando 4 de 12 registros de consolidados</span>
+      <span class="table-pagination__info">Mostrando {{ consolidados().length }} consolidado(s)</span>
       <div class="pagination-btns">
         <button class="pagination-btn" disabled>
           <span class="material-symbols-outlined">chevron_left</span>

--- a/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-list/consolidado-list.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/consolidado-page/consolidado-list/consolidado-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { ButtonComponent, DataTableComponent, KpiCardComponent, StatusBadgeComponent } from '@restaurant/shared/ui';
@@ -6,13 +6,6 @@ import { ExportarConsolidadoModalComponent } from '../components/exportar-consol
 import { ReversarConsolidadoModalComponent } from '../components/reversar-consolidado-modal/reversar-consolidado-modal.component';
 import { Consolidado } from '../../../models/consolidado.model';
 import { ConsolidadoFacade } from '../../../data-access/consolidado.facade';
-
-interface ConsolidadoKpis {
-  retencionZese: number;
-  ivaAcumulado: number;
-  totalEjecutado: number;
-  gilsPendientes: number;
-}
 
 @Component({
   selector: 'restaurant-consolidado-list',
@@ -35,12 +28,19 @@ export class ConsolidadoListComponent implements OnInit {
   selectedReversarItem = signal<Consolidado | null>(null);
   isReversarBlocked    = signal(false);
 
-  kpis = signal<ConsolidadoKpis>({
-    retencionZese:  1452890,
-    ivaAcumulado:   3842120.45,
-    totalEjecutado: 12980500,
-    gilsPendientes: 14,
-  });
+  // ── KPIs derivados de la lista real ─────────────────────────────────────
+  kpiTotalEjecutado = computed(() =>
+    this.consolidados().reduce((acc, c) => acc + c.totales.totalGeneral, 0)
+  );
+  kpiContabilizados = computed(() =>
+    this.consolidados().filter(c => c.estado === 'CONTABILIZADO').length
+  );
+  kpiGenerados = computed(() =>
+    this.consolidados().filter(c => c.estado === 'GENERADO').length
+  );
+  kpiReversados = computed(() =>
+    this.consolidados().filter(c => c.estado === 'REVERSADO').length
+  );
 
   ngOnInit(): void {
     this.facade.loadAll();

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimientos-list/movimientos-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimientos-list/movimientos-list.component.html
@@ -39,40 +39,36 @@
   <!-- KPIs Bento Grid -->
   <div class="kpi-grid">
     <restaurant-kpi-card
-      label="ENTRADAS HOY"
-      value="142"
+      label="ENTRADAS"
+      [value]="kpiEntradas()"
       icon="log-in"
-      iconColor="green"
-      trend="+12%"
-      [trendUp]="true"
-    ></restaurant-kpi-card>
+      iconColor="green">
+    </restaurant-kpi-card>
 
     <restaurant-kpi-card
-      label="SALIDAS HOY"
-      value="86"
+      label="SALIDAS"
+      [value]="kpiSalidas()"
       icon="log-out"
-      iconColor="orange"
-      trend="-4%"
-      [trendUp]="false"
-    ></restaurant-kpi-card>
+      iconColor="orange">
+    </restaurant-kpi-card>
 
     <restaurant-kpi-card
       label="VALOR ENTRADAS"
-      value="$4.2M"
+      [value]="kpiValorEntradas() | currency:'COP':'symbol-narrow':'1.0-0'"
       icon="banknote"
       iconColor="blue"
-      trend="Semana Actual"
-      [trendUp]="null"
-    ></restaurant-kpi-card>
+      trend="Total cargado"
+      [trendUp]="null">
+    </restaurant-kpi-card>
 
     <restaurant-kpi-card
       label="PENDIENTES"
-      value="09"
+      [value]="kpiPendientes()"
       icon="alert-circle"
       iconColor="red"
       trend="Requieren verificación"
-      [trendUp]="null"
-    ></restaurant-kpi-card>
+      [trendUp]="null">
+    </restaurant-kpi-card>
   </div>
 
   <!-- Main Data Table Container -->
@@ -144,7 +140,7 @@
       }
     </tbody>
     <div dtFooter class="dt-footer">
-      <span class="table-pagination__info">Mostrando 4 de 12 registros de movimientos</span>
+      <span class="table-pagination__info">Mostrando {{ movimientos().length }} movimiento(s)</span>
       <div class="pagination-btns">
         <button class="pagination-btn" disabled>
           <span class="material-symbols-outlined">chevron_left</span>

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimientos-list/movimientos-list.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimientos-list/movimientos-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { KpiCardComponent, DataTableComponent, LucideIconComponent, ButtonComponent, StatusBadgeComponent } from '@restaurant/shared/ui';
@@ -27,6 +27,14 @@ export class MovimientosListComponent implements OnInit {
   // ── Estado reactivo desde facade ─────────────────────────────────────────
   movimientos = this.facade.movimientos;
   loading     = this.facade.loading;
+
+  // ── KPIs derivados del listado cargado ───────────────────────────────────
+  kpiEntradas      = computed(() => this.movimientos().filter(m => m.tipo === 'ENTRADA').length);
+  kpiSalidas       = computed(() => this.movimientos().filter(m => m.tipo === 'SALIDA').length);
+  kpiValorEntradas = computed(() =>
+    this.movimientos().filter(m => m.tipo === 'ENTRADA').reduce((acc, m) => acc + m.valor, 0)
+  );
+  kpiPendientes    = computed(() => this.movimientos().filter(m => m.estado === 'Pendiente').length);
 
   ngOnInit(): void {
     this.facade.loadAll();

--- a/libs/inventario/inventario/src/lib/pages/requisiciones-page/requisiciones-dashboard/requisiciones-dashboard.component.html
+++ b/libs/inventario/inventario/src/lib/pages/requisiciones-page/requisiciones-dashboard/requisiciones-dashboard.component.html
@@ -21,17 +21,17 @@
        KPI ROW
        ═══════════════════════════════════════════════════════════════════════ -->
   <div class="kpi-grid">
-    <restaurant-kpi-card label="BORRADORES" value="03" icon="file-edit"
+    <restaurant-kpi-card label="BORRADORES" [value]="kpiBorradores()" icon="file-edit"
       iconColor="blue" trend="Pendientes de envío" [trendUp]="null"></restaurant-kpi-card>
 
-    <restaurant-kpi-card label="ENVIADAS" value="05" icon="send"
+    <restaurant-kpi-card label="ENVIADAS" [value]="kpiEnviadas()" icon="send"
       iconColor="orange" trend="Esperando aprobación" [trendUp]="null"></restaurant-kpi-card>
 
-    <restaurant-kpi-card label="EN DESPACHO" value="02" icon="truck"
+    <restaurant-kpi-card label="EN DESPACHO" [value]="kpiEnDespacho()" icon="truck"
       iconColor="green" trend="En preparación" [trendUp]="null"></restaurant-kpi-card>
 
-    <restaurant-kpi-card label="FIRMADAS" value="18" icon="check-circle"
-      iconColor="green" trend="Completadas este mes" [trendUp]="true"></restaurant-kpi-card>
+    <restaurant-kpi-card label="FIRMADAS" [value]="kpiFirmadas()" icon="check-circle"
+      iconColor="green" trend="Completadas" [trendUp]="null"></restaurant-kpi-card>
   </div>
 
   <!-- ═══════════════════════════════════════════════════════════════════════
@@ -44,88 +44,40 @@
       <div class="kanban-column__header">
         <div class="kanban-column__title-group">
           <h3 class="kanban-column__title">Borrador</h3>
-          <span class="kanban-column__count">03</span>
+          <span class="kanban-column__count">{{ borradores().length }}</span>
         </div>
       </div>
       <div class="kanban-column__cards">
-        <!-- Card 1 -->
-        <div class="kanban-card kanban-card--borrador" routerLink="detalle/0895">
-          <div class="kanban-card__header">
-            <div style="display: flex; align-items: center; gap: 8px;">
-              <span class="kanban-card__id">REQ-2024-0895</span>
-              <span class="kanban-card__badge kanban-card__badge--borrador">
-                <lucide-icon name="file-edit" [size]="12"></lucide-icon>
-                Borrador
+        @for (req of borradores(); track req.id) {
+          <div class="kanban-card kanban-card--borrador" [routerLink]="['detalle', req.id]">
+            <div class="kanban-card__header">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span class="kanban-card__id">REQ-{{ req.numero }}</span>
+                <span class="kanban-card__badge kanban-card__badge--borrador">
+                  <lucide-icon name="file-edit" [size]="12"></lucide-icon>
+                  Borrador
+                </span>
+              </div>
+              <button class="kanban-card__menu">
+                <lucide-icon name="more-vertical" [size]="16"></lucide-icon>
+              </button>
+            </div>
+            <p class="kanban-card__desc">{{ req.programa }} — Ficha {{ req.fichaId }}</p>
+            <div class="kanban-card__meta">
+              <span class="kanban-card__meta-item">
+                <lucide-icon name="package" [size]="14"></lucide-icon>
+                {{ req.items.length }} ítem(s)
+              </span>
+              <span class="kanban-card__meta-item">
+                <lucide-icon name="clock" [size]="14"></lucide-icon>
+                {{ req.fecha }}
               </span>
             </div>
-            <button class="kanban-card__menu">
-              <lucide-icon name="more-vertical" [size]="16"></lucide-icon>
-            </button>
           </div>
-          <p class="kanban-card__desc">Cocina Básica — Ficha 2560893</p>
-          <div class="kanban-card__meta">
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="package" [size]="14"></lucide-icon>
-              8 ítems
-            </span>
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="clock" [size]="14"></lucide-icon>
-              Hace 2h
-            </span>
-          </div>
-        </div>
-        <!-- Card 2 -->
-        <div class="kanban-card kanban-card--borrador" routerLink="detalle/0896">
-          <div class="kanban-card__header">
-            <div style="display: flex; align-items: center; gap: 8px;">
-              <span class="kanban-card__id">REQ-2024-0896</span>
-              <span class="kanban-card__badge kanban-card__badge--borrador">
-                <lucide-icon name="file-edit" [size]="12"></lucide-icon>
-                Borrador
-              </span>
-            </div>
-            <button class="kanban-card__menu">
-              <lucide-icon name="more-vertical" [size]="16"></lucide-icon>
-            </button>
-          </div>
-          <p class="kanban-card__desc">Repostería Avanzada — Ficha 2560894</p>
-          <div class="kanban-card__meta">
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="package" [size]="14"></lucide-icon>
-              5 ítems
-            </span>
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="clock" [size]="14"></lucide-icon>
-              Hace 1d
-            </span>
-          </div>
-        </div>
-        <!-- Card 3 -->
-        <div class="kanban-card kanban-card--borrador" routerLink="detalle/0897">
-          <div class="kanban-card__header">
-            <div style="display: flex; align-items: center; gap: 8px;">
-              <span class="kanban-card__id">REQ-2024-0897</span>
-              <span class="kanban-card__badge kanban-card__badge--borrador">
-                <lucide-icon name="file-edit" [size]="12"></lucide-icon>
-                Borrador
-              </span>
-            </div>
-            <button class="kanban-card__menu">
-              <lucide-icon name="more-vertical" [size]="16"></lucide-icon>
-            </button>
-          </div>
-          <p class="kanban-card__desc">Cocina Internacional — Ficha 2560891</p>
-          <div class="kanban-card__meta">
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="package" [size]="14"></lucide-icon>
-              12 ítems
-            </span>
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="clock" [size]="14"></lucide-icon>
-              Hace 3d
-            </span>
-          </div>
-        </div>
+        }
+        @if (borradores().length === 0) {
+          <p class="kanban-empty">Sin borradores</p>
+        }
       </div>
     </div>
 
@@ -134,60 +86,40 @@
       <div class="kanban-column__header">
         <div class="kanban-column__title-group">
           <h3 class="kanban-column__title">Pendiente Aprobación</h3>
-          <span class="kanban-column__count kanban-column__count--warning">05</span>
+          <span class="kanban-column__count kanban-column__count--warning">{{ enviadas().length }}</span>
         </div>
       </div>
       <div class="kanban-column__cards">
-        <div class="kanban-card kanban-card--enviada" routerLink="detalle/0892">
-          <div class="kanban-card__header">
-            <div style="display: flex; align-items: center; gap: 8px;">
-              <span class="kanban-card__id">REQ-2024-0892</span>
-              <span class="kanban-card__badge kanban-card__badge--enviada">
-                <lucide-icon name="send" [size]="12"></lucide-icon>
-                Enviada
+        @for (req of enviadas(); track req.id) {
+          <div class="kanban-card kanban-card--enviada" [routerLink]="['detalle', req.id]">
+            <div class="kanban-card__header">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span class="kanban-card__id">REQ-{{ req.numero }}</span>
+                <span class="kanban-card__badge kanban-card__badge--enviada">
+                  <lucide-icon name="send" [size]="12"></lucide-icon>
+                  Enviada
+                </span>
+              </div>
+              <button class="kanban-card__menu">
+                <lucide-icon name="more-vertical" [size]="16"></lucide-icon>
+              </button>
+            </div>
+            <p class="kanban-card__desc">{{ req.programa }} — Ficha {{ req.fichaId }}</p>
+            <div class="kanban-card__meta">
+              <span class="kanban-card__meta-item">
+                <lucide-icon name="package" [size]="14"></lucide-icon>
+                {{ req.items.length }} ítem(s)
+              </span>
+              <span class="kanban-card__meta-item">
+                <lucide-icon name="clock" [size]="14"></lucide-icon>
+                {{ req.fecha }}
               </span>
             </div>
-            <button class="kanban-card__menu">
-              <lucide-icon name="more-vertical" [size]="16"></lucide-icon>
-            </button>
           </div>
-          <p class="kanban-card__desc">Panadería Francesa — Ficha 2560892</p>
-          <div class="kanban-card__meta">
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="package" [size]="14"></lucide-icon>
-              10 ítems
-            </span>
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="clock" [size]="14"></lucide-icon>
-              15 Oct
-            </span>
-          </div>
-        </div>
-        <div class="kanban-card kanban-card--enviada" routerLink="detalle/0893">
-          <div class="kanban-card__header">
-            <div style="display: flex; align-items: center; gap: 8px;">
-              <span class="kanban-card__id">REQ-2024-0893</span>
-              <span class="kanban-card__badge kanban-card__badge--enviada">
-                <lucide-icon name="send" [size]="12"></lucide-icon>
-                Enviada
-              </span>
-            </div>
-            <button class="kanban-card__menu">
-              <lucide-icon name="more-vertical" [size]="16"></lucide-icon>
-            </button>
-          </div>
-          <p class="kanban-card__desc">Gastronomía Básica — Ficha 2560890</p>
-          <div class="kanban-card__meta">
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="package" [size]="14"></lucide-icon>
-              6 ítems
-            </span>
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="clock" [size]="14"></lucide-icon>
-              14 Oct
-            </span>
-          </div>
-        </div>
+        }
+        @if (enviadas().length === 0) {
+          <p class="kanban-empty">Sin enviadas</p>
+        }
       </div>
     </div>
 
@@ -196,30 +128,35 @@
       <div class="kanban-column__header">
         <div class="kanban-column__title-group">
           <h3 class="kanban-column__title">En Despacho</h3>
-          <span class="kanban-column__count kanban-column__count--info">02</span>
+          <span class="kanban-column__count kanban-column__count--info">{{ enDespacho().length }}</span>
         </div>
       </div>
       <div class="kanban-column__cards">
-        <div class="kanban-card kanban-card--despacho" routerLink="despacho/0890">
-          <div class="kanban-card__header">
-            <span class="kanban-card__id">REQ-2024-0890</span>
-            <span class="kanban-card__badge kanban-card__badge--despacho">
-              <lucide-icon name="truck" [size]="12"></lucide-icon>
-              En preparación
-            </span>
+        @for (req of enDespacho(); track req.id) {
+          <div class="kanban-card kanban-card--despacho" [routerLink]="['despacho', req.id]">
+            <div class="kanban-card__header">
+              <span class="kanban-card__id">REQ-{{ req.numero }}</span>
+              <span class="kanban-card__badge kanban-card__badge--despacho">
+                <lucide-icon name="truck" [size]="12"></lucide-icon>
+                En preparación
+              </span>
+            </div>
+            <p class="kanban-card__desc">{{ req.programa }} — Ficha {{ req.fichaId }}</p>
+            <div class="kanban-card__meta">
+              <span class="kanban-card__meta-item">
+                <lucide-icon name="package" [size]="14"></lucide-icon>
+                {{ req.items.length }} ítem(s)
+              </span>
+              <span class="kanban-card__meta-item">
+                <lucide-icon name="clock" [size]="14"></lucide-icon>
+                {{ req.fecha }}
+              </span>
+            </div>
           </div>
-          <p class="kanban-card__desc">Cocina Colombiana — Ficha 2560889</p>
-          <div class="kanban-card__meta">
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="package" [size]="14"></lucide-icon>
-              7 ítems
-            </span>
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="clock" [size]="14"></lucide-icon>
-              10 Oct
-            </span>
-          </div>
-        </div>
+        }
+        @if (enDespacho().length === 0) {
+          <p class="kanban-empty">Sin despachos activos</p>
+        }
       </div>
     </div>
 
@@ -228,50 +165,35 @@
       <div class="kanban-column__header">
         <div class="kanban-column__title-group">
           <h3 class="kanban-column__title">Firmadas</h3>
-          <span class="kanban-column__count kanban-column__count--success">02</span>
+          <span class="kanban-column__count kanban-column__count--success">{{ firmadas().length }}</span>
         </div>
       </div>
       <div class="kanban-column__cards">
-        <div class="kanban-card kanban-card--firmada" routerLink="detalle/0888">
-          <div class="kanban-card__header">
-            <span class="kanban-card__id">REQ-2024-0888</span>
-            <span class="kanban-card__badge kanban-card__badge--firmada">
-              <lucide-icon name="shield-check" [size]="12"></lucide-icon>
-              Verificada
-            </span>
+        @for (req of firmadas(); track req.id) {
+          <div class="kanban-card kanban-card--firmada" [routerLink]="['detalle', req.id]">
+            <div class="kanban-card__header">
+              <span class="kanban-card__id">REQ-{{ req.numero }}</span>
+              <span class="kanban-card__badge kanban-card__badge--firmada">
+                <lucide-icon name="shield-check" [size]="12"></lucide-icon>
+                Firmada
+              </span>
+            </div>
+            <p class="kanban-card__desc">{{ req.programa }} — Ficha {{ req.fichaId }}</p>
+            <div class="kanban-card__meta">
+              <span class="kanban-card__meta-item">
+                <lucide-icon name="package" [size]="14"></lucide-icon>
+                {{ req.items.length }} ítem(s)
+              </span>
+              <span class="kanban-card__meta-item">
+                <lucide-icon name="clock" [size]="14"></lucide-icon>
+                {{ req.fecha }}
+              </span>
+            </div>
           </div>
-          <p class="kanban-card__desc">Técnicas de Cocción — Ficha 2560887</p>
-          <div class="kanban-card__meta">
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="package" [size]="14"></lucide-icon>
-              15 ítems
-            </span>
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="clock" [size]="14"></lucide-icon>
-              05 Oct
-            </span>
-          </div>
-        </div>
-        <div class="kanban-card kanban-card--firmada" routerLink="detalle/0885">
-          <div class="kanban-card__header">
-            <span class="kanban-card__id">REQ-2024-0885</span>
-            <span class="kanban-card__badge kanban-card__badge--firmada">
-              <lucide-icon name="shield-check" [size]="12"></lucide-icon>
-              Verificada
-            </span>
-          </div>
-          <p class="kanban-card__desc">Mesa y Bar — Ficha 2560886</p>
-          <div class="kanban-card__meta">
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="package" [size]="14"></lucide-icon>
-              9 ítems
-            </span>
-            <span class="kanban-card__meta-item">
-              <lucide-icon name="clock" [size]="14"></lucide-icon>
-              02 Oct
-            </span>
-          </div>
-        </div>
+        }
+        @if (firmadas().length === 0) {
+          <p class="kanban-empty">Sin firmadas</p>
+        }
       </div>
     </div>
 

--- a/libs/inventario/inventario/src/lib/pages/requisiciones-page/requisiciones-dashboard/requisiciones-dashboard.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/requisiciones-page/requisiciones-dashboard/requisiciones-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit } from '@angular/core';
 
 import { Router, RouterModule } from '@angular/router';
 import {
@@ -34,6 +34,12 @@ export class RequisicionesDashboardComponent implements OnInit {
   kpiEnviadas   = this.facade.kpiEnviadas;
   kpiEnDespacho = this.facade.kpiEnDespacho;
   kpiFirmadas   = this.facade.kpiFirmadas;
+
+  // ── Grupos para el tablero kanban ─────────────────────────────────────────
+  borradores = computed(() => this.requisiciones().filter(r => r.estado === 'BORRADOR'));
+  enviadas   = computed(() => this.requisiciones().filter(r => r.estado === 'ENVIADA'));
+  enDespacho = computed(() => this.requisiciones().filter(r => r.estado === 'DESPACHADA'));
+  firmadas   = computed(() => this.requisiciones().filter(r => r.estado === 'FIRMADA'));
 
   ngOnInit(): void {
     this.facade.loadAll();


### PR DESCRIPTION
## Resumen

Elimina todos los datos quemados (mock data) de las vistas de Consolidado de Ejecución, Entradas/Salidas y Requisición Diaria, reemplazándolos con `computed()` signals reactivos que se derivan de la data real del backend.

### Cambios por componente

**`movimientos-list` — Entradas y Salidas**
- KPI cards antes: `value="142"`, `value="86"`, `value="$4.2M"`, `value="09"` (hardcodeados)
- Ahora: `kpiEntradas`, `kpiSalidas`, `kpiValorEntradas`, `kpiPendientes` — todos `computed()` desde `movimientos()`

**`consolidado-list` — KPI cards**
- Antes: `kpis = signal<ConsolidadoKpis>({ retencionZese: 1452890, ivaAcumulado: 3842120... })` inventado
- Ahora: `kpiTotalEjecutado`, `kpiContabilizados`, `kpiGenerados`, `kpiReversados` derivados de `consolidados()`
- Footer del listado también dinámico

**`consolidado-detail` — KPI cards + tablas**
- Antes: header `#CON-2023-0842`, KPI `$142,500,000 / "28 Formatos"`, arrays `subtotales[]`, `ejecucion[]`, `gils[]` con datos 2023 inventados
- Ahora: todo ligado a `consolidado()`. Tabla de subtotales usa `subtotalesPorTipo` (computed que agrupa `lineas[]` por tipo). Tabla de líneas itera el modelo real. Listado de GILs eliminado (no existe en el modelo). Modal reversar usa datos reales. Importa `CurrencyPipe`.

**`requisiciones-dashboard` — KPI cards + Kanban**
- KPI cards antes: `value="03"/"05"/"02"/"18"` — ahora `[value]="kpiBorradores()"` etc. (ya venían de la facade)
- Kanban board: reemplazado completamente. Antes ~12 tarjetas hardcodeadas con nombres ficticios de 2024. Ahora `@for` sobre `borradores()`, `enviadas()`, `enDespacho()`, `firmadas()` con estado vacío por columna.

## Plan de pruebas

- [ ] Consolidado list: KPIs muestran 0 hasta que el backend responde, luego se actualizan
- [ ] Consolidado detail: header, KPIs y tablas muestran datos del consolidado real seleccionado
- [ ] Movimientos list: KPIs a 0 al entrar (sin producto seleccionado), se llenan al cargar un kardex
- [ ] Requisiciones dashboard: kanban muestra tarjetas reales agrupadas por estado; columnas vacías muestran placeholder