### PR TITLE
feat(frontend): mejoras validacion en actividades de cocina y fix url…

### DIFF
--- a/libs/cocina/cocina/src/index.ts
+++ b/libs/cocina/cocina/src/index.ts
@@ -1,3 +1,5 @@
 export * from './lib/cocina.routes';
 export * from './lib/data-access/cocina.facade';
+export * from './lib/data-access/actividad.service';
+export * from './lib/data-access/evaluacion.service';
 export * from './lib/models/cocina.model';

--- a/libs/cocina/cocina/src/lib/data-access/actividad.service.ts
+++ b/libs/cocina/cocina/src/lib/data-access/actividad.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+// ── DTOs alineados con el backend ─────────────────────────────────────────────
+
+export interface ActividadDTO {
+  id: number;
+  nombre: string;
+  /** formato ISO: 'YYYY-MM-DD' */
+  fecha: string;
+  jornada: string;
+  ficha: string;
+  trimestre: string;
+  estado: 'Activa' | 'Finalizada' | 'Pendiente';
+}
+
+export type CreateActividadDTO = Omit<ActividadDTO, 'id' | 'estado'>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Injectable({ providedIn: 'root' })
+export class ActividadService {
+  private http = inject(HttpClient);
+  private readonly BASE = 'http://localhost:8080/api/actividades';
+
+  /** Obtiene todas las actividades ordenadas por fecha desc */
+  getAll(): Observable<ActividadDTO[]> {
+    return this.http.get<ActividadDTO[]>(this.BASE);
+  }
+
+  /** Crea una nueva actividad; el backend asigna id y estado='Pendiente' */
+  create(dto: CreateActividadDTO): Observable<ActividadDTO> {
+    return this.http.post<ActividadDTO>(this.BASE, dto);
+  }
+
+  /** Actualiza solo el estado de una actividad */
+  updateEstado(id: number, estado: string): Observable<ActividadDTO> {
+    return this.http.patch<ActividadDTO>(`${this.BASE}/${id}/estado`, { estado });
+  }
+
+  /** Elimina una actividad */
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.BASE}/${id}`);
+  }
+}

--- a/libs/cocina/cocina/src/lib/data-access/cocina.facade.ts
+++ b/libs/cocina/cocina/src/lib/data-access/cocina.facade.ts
@@ -1,4 +1,8 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
+import { ActividadService, ActividadDTO, CreateActividadDTO } from './actividad.service';
+import { EvaluacionService, EvaluacionRequestDTO } from './evaluacion.service';
+
+// ── Interfaces públicas ───────────────────────────────────────────────────────
 
 export interface AprendizMock {
   id: number;
@@ -10,58 +14,172 @@ export interface AprendizMock {
   inactivo?: boolean;
 }
 
-export interface ActividadMock {
-  id: number;
-  nombre: string;
-  fecha: string;
-  jornada: string;
-  ficha: string;
-  trimestre: string;
-  estado: 'Activa' | 'Finalizada' | 'Pendiente';
-}
+export type ActividadMock = ActividadDTO;
 
+// ── Mock de aprendices ────────────────────────────────────────────────────────
+// Los aprendices pertenecen a otro microservicio.
+// Este mock se usa mientras ese servicio no esté disponible.
+// Cuando esté listo, simplemente se reemplaza APRENDICES_MOCK por una llamada HTTP.
 const APRENDICES_MOCK: AprendizMock[] = [
   { id: 1, nombreCompleto: 'Camila Rodriguez Torres',  inicial: 'C', ficha: '2561234', jornada: 'Diurna',   estado: 'Pendiente' },
   { id: 2, nombreCompleto: 'Andrés Felipe Mora',       inicial: 'A', ficha: '2561234', jornada: 'Diurna',   estado: 'Pendiente' },
   { id: 3, nombreCompleto: 'Laura Valentina Gómez',    inicial: 'L', ficha: '2489012', jornada: 'Mixta',    estado: 'Pendiente' },
   { id: 4, nombreCompleto: 'María Fernanda Castro',    inicial: 'M', ficha: '2561234', jornada: 'Diurna',   estado: 'Pendiente' },
   { id: 5, nombreCompleto: 'Valeria Ospina Herrera',   inicial: 'V', ficha: '2632456', jornada: 'Mixta',    estado: 'Pendiente' },
-  { id: 6, nombreCompleto: 'Juan Pérez Inactivo',      inicial: 'J', ficha: '0000000', jornada: 'Diurna',   estado: 'Pendiente', inactivo: true },
-  { id: 7, nombreCompleto: 'Ana López Inactiva',       inicial: 'A', ficha: '0000000', jornada: 'Nocturna', estado: 'Pendiente', inactivo: true }
+  { id: 6, nombreCompleto: 'Juan Pérez',               inicial: 'J', ficha: '2561234', jornada: 'Diurna',   estado: 'Pendiente', inactivo: true },
+  { id: 7, nombreCompleto: 'Ana López',                inicial: 'A', ficha: '2489012', jornada: 'Nocturna', estado: 'Pendiente', inactivo: true },
 ];
 
-const ACTIVIDADES_MOCK: ActividadMock[] = [
-  { id: 1, nombre: 'Fundamentos de Cocina',       fecha: '2026-05-10', jornada: 'Diurna',   ficha: '2561234', trimestre: 'Trimestre 1', estado: 'Activa' },
-  { id: 2, nombre: 'Técnicas de Corte',           fecha: '2026-05-08', jornada: 'Mixta',     ficha: '2489012', trimestre: 'Trimestre 1', estado: 'Activa' },
-  { id: 3, nombre: 'Preparación de Salsas',       fecha: '2026-05-05', jornada: 'Diurna',    ficha: '2561234', trimestre: 'Trimestre 2', estado: 'Pendiente' },
-  { id: 4, nombre: 'Repostería Básica',           fecha: '2026-04-28', jornada: 'Nocturna',  ficha: '2632456', trimestre: 'Trimestre 1', estado: 'Finalizada' },
-  { id: 5, nombre: 'Higiene y Manipulación',      fecha: '2026-04-20', jornada: 'Diurna',    ficha: '2561234', trimestre: 'Trimestre 2', estado: 'Finalizada' },
-];
+// ─────────────────────────────────────────────────────────────────────────────
 
 @Injectable({ providedIn: 'root' })
 export class CocinaFacade {
-  readonly aprendices = signal<AprendizMock[]>(APRENDICES_MOCK);
-  readonly actividades = signal<ActividadMock[]>(ACTIVIDADES_MOCK);
 
-  actualizarEstado(id: number, estado: 'Aprobó' | 'No Aprobó'): void {
-    this.aprendices.update(aprendices => 
-      aprendices.map(a => a.id === id ? { ...a, estado } : a)
-    );
+  private actividadService = inject(ActividadService);
+  private evaluacionService = inject(EvaluacionService);
+
+  // ── Estado reactivo ─────────────────────────────────────────────────────────
+  readonly actividades = signal<ActividadMock[]>([]);
+
+  /**
+   * Lista de aprendices con sus estados de evaluación.
+   * Inicia desde el mock; los estados se actualizan consultando la BD.
+   */
+  readonly aprendices = signal<AprendizMock[]>([...APRENDICES_MOCK]);
+
+  // ── Loading / error ─────────────────────────────────────────────────────────
+  readonly cargandoActividades = signal<boolean>(false);
+  readonly errorActividades = signal<string | null>(null);
+  readonly cargandoAprendices = signal<boolean>(false);
+
+  // ── Actividades (propiedad de este microservicio) ────────────────────────────
+
+  /** Carga actividades desde el backend */
+  cargarActividades(): void {
+    this.cargandoActividades.set(true);
+    this.errorActividades.set(null);
+
+    this.actividadService.getAll().subscribe({
+      next: (data) => {
+        this.actividades.set(data as ActividadMock[]);
+        this.cargandoActividades.set(false);
+      },
+      error: (err) => {
+        console.error('[CocinaFacade] Error cargando actividades:', err);
+        this.errorActividades.set('No se pudieron cargar las actividades. Verifica que el backend esté activo.');
+        this.cargandoActividades.set(false);
+      },
+    });
   }
 
-  crearActividad(data: Omit<ActividadMock, 'id' | 'estado'>): void {
-    const nextId = Math.max(...this.actividades().map(a => a.id), 0) + 1;
-    const nueva: ActividadMock = { ...data, id: nextId, estado: 'Pendiente' };
-    this.actividades.update(list => [nueva, ...list]);
+  /** Crea una nueva actividad y la refleja en el estado local */
+  crearActividad(data: CreateActividadDTO): void {
+    this.actividadService.create(data).subscribe({
+      next: (nueva) => {
+        this.actividades.update(list => [nueva as ActividadMock, ...list]);
+      },
+      error: (err) => {
+        console.error('[CocinaFacade] Error creando actividad:', err);
+      },
+    });
   }
 
+  /** Actualiza el estado de una actividad */
   actualizarEstadoActividad(id: number, estado: 'Activa' | 'Finalizada' | 'Pendiente'): void {
-    this.actividades.update(list =>
-      list.map(a => a.id === id ? { ...a, estado } : a)
-    );
+    this.actividadService.updateEstado(id, estado).subscribe({
+      next: (updated) => {
+        this.actividades.update(list =>
+          list.map(a => a.id === id ? { ...a, estado: updated.estado } : a)
+        );
+      },
+      error: (err) => {
+        console.error('[CocinaFacade] Error actualizando estado de actividad:', err);
+      },
+    });
   }
 
+  /** Elimina una actividad */
   eliminarActividad(id: number): void {
-    this.actividades.update(list => list.filter(a => a.id !== id));
+    this.actividadService.delete(id).subscribe({
+      next: () => {
+        this.actividades.update(list => list.filter(a => a.id !== id));
+      },
+      error: (err) => {
+        console.error('[CocinaFacade] Error eliminando actividad:', err);
+      },
+    });
+  }
+
+  // ── Evaluaciones ─────────────────────────────────────────────────────────────
+
+  /**
+   * Carga los estados de evaluación persistidos en BD para una actividad
+   * y los cruza con el mock de aprendices.
+   * Esto garantiza que al recargar la página se vean los estados correctos.
+   */
+  cargarEstadosEvaluacion(actividadId: number): void {
+    this.cargandoAprendices.set(true);
+    // Siempre arrancamos desde el mock limpio
+    this.aprendices.set([...APRENDICES_MOCK]);
+
+    this.evaluacionService.getEvaluacionesPorActividad(actividadId).subscribe({
+      next: (evaluaciones) => {
+        if (evaluaciones.length > 0) {
+          // Actualizar estado de cada aprendiz según lo que está en BD
+          this.aprendices.update(lista =>
+            lista.map(aprendiz => {
+              const eval_ = evaluaciones.find(e => e.aprendizId === aprendiz.id);
+              if (eval_) {
+                return { ...aprendiz, estado: eval_.estado };
+              }
+              return aprendiz;
+            })
+          );
+        }
+        this.cargandoAprendices.set(false);
+      },
+      error: (err) => {
+        // Si el backend falla, seguimos mostrando el mock sin estados
+        console.warn('[CocinaFacade] No se pudieron cargar evaluaciones previas:', err);
+        this.cargandoAprendices.set(false);
+      },
+    });
+  }
+
+  /**
+   * Persiste la evaluación en el backend y actualiza el estado local del aprendiz.
+   * Funciona para evaluación individual y masiva.
+   */
+  evaluarAprendices(actividadId: number, requests: EvaluacionRequestDTO[]): void {
+    this.evaluacionService.evaluarAprendices(actividadId, requests).subscribe({
+      next: () => {
+        // Actualización optimista del estado local
+        this.aprendices.update(lista =>
+          lista.map(aprendiz => {
+            const req = requests.find(r => r.aprendizId === aprendiz.id);
+            if (req) {
+              const nuevoEstado: 'Aprobó' | 'No Aprobó' =
+                req.resultado === 'aprobo' ? 'Aprobó' : 'No Aprobó';
+              return { ...aprendiz, estado: nuevoEstado };
+            }
+            return aprendiz;
+          })
+        );
+        console.log('[CocinaFacade] Evaluación guardada en BD ✅');
+      },
+      error: (err) => {
+        console.error('[CocinaFacade] Error al guardar evaluación:', err);
+      },
+    });
+  }
+
+  /**
+   * Evaluación individual sin actividadId (actualización solo local).
+   * Se usa como fallback cuando no hay contexto de actividad.
+   */
+  actualizarEstado(aprendizId: number, estado: 'Aprobó' | 'No Aprobó'): void {
+    this.aprendices.update(lista =>
+      lista.map(a => a.id === aprendizId ? { ...a, estado } : a)
+    );
   }
 }

--- a/libs/cocina/cocina/src/lib/data-access/evaluacion.service.ts
+++ b/libs/cocina/cocina/src/lib/data-access/evaluacion.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+// ── DTOs alineados con el backend ─────────────────────────────────────────────
+
+/**
+ * Registro de evaluación guardado en la BD.
+ * El frontend cruza este dato con su lista de aprendices (mock o microservicio externo).
+ */
+export interface EvaluacionResponseDTO {
+  aprendizId: number;
+  estado: 'Aprobó' | 'No Aprobó';
+  observaciones: string;
+}
+
+export interface EvaluacionRequestDTO {
+  aprendizId: number;
+  observaciones: string;
+  /** 'aprobo' | 'no_aprobo' */
+  resultado: 'aprobo' | 'no_aprobo';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Injectable({ providedIn: 'root' })
+export class EvaluacionService {
+  private http = inject(HttpClient);
+  private readonly BASE = 'http://localhost:8080/api/actividades';
+
+  /**
+   * Obtiene los registros de evaluación persistidos en BD para una actividad.
+   * El frontend usa esta lista para actualizar el estado de cada aprendiz del mock.
+   */
+  getEvaluacionesPorActividad(actividadId: number): Observable<EvaluacionResponseDTO[]> {
+    return this.http.get<EvaluacionResponseDTO[]>(`${this.BASE}/${actividadId}/evaluaciones`);
+  }
+
+  /**
+   * Persiste la evaluación de uno o más aprendices en la BD.
+   * Funciona para evaluación individual y masiva.
+   */
+  evaluarAprendices(actividadId: number, requests: EvaluacionRequestDTO[]): Observable<void> {
+    return this.http.post<void>(`${this.BASE}/${actividadId}/evaluar`, requests);
+  }
+}

--- a/libs/cocina/cocina/src/lib/pages/actividad-page/actividad-page.component.html
+++ b/libs/cocina/cocina/src/lib/pages/actividad-page/actividad-page.component.html
@@ -24,6 +24,8 @@
           type="date"
           class="form-input"
           placeholder="dd/mm/aaaa"
+          min="2020-01-01"
+          max="2050-12-31"
           (change)="fecha.set($any($event.target).value)"
         />
       </div>
@@ -100,7 +102,7 @@
           <button id="btn-ver-actividades" class="btn-outline" type="button" (click)="verActividades()">
             VER ACTIVIDADES
           </button>
-          <button id="btn-crear-actividad" class="btn-primary" type="button" (click)="crearActividad()">
+          <button id="btn-crear-actividad" class="btn-primary" type="button" [disabled]="!isFormValid()" (click)="crearActividad()">
             CREAR ACTIVIDAD
           </button>
         </div>

--- a/libs/cocina/cocina/src/lib/pages/actividad-page/actividad-page.component.scss
+++ b/libs/cocina/cocina/src/lib/pages/actividad-page/actividad-page.component.scss
@@ -149,7 +149,7 @@
   color: white;
   border: none;
   padding: 10px 28px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: 9999px !important;
   font-size: var(--text-sm, 0.875rem);
   font-weight: 700;
   letter-spacing: 0.5px;
@@ -165,6 +165,14 @@
   &:active {
     transform: scale(0.98);
   }
+
+  &:disabled {
+    background: var(--color-border, #e2e8f0);
+    color: var(--color-text-muted, #94a3b8);
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+  }
 }
 
 .btn-outline {
@@ -172,7 +180,7 @@
   color: var(--color-primario);
   border: 1.5px solid var(--color-primario);
   padding: 10px 28px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: 9999px !important;
   font-size: var(--text-sm, 0.875rem);
   font-weight: 700;
   letter-spacing: 0.5px;

--- a/libs/cocina/cocina/src/lib/pages/actividad-page/actividad-page.component.ts
+++ b/libs/cocina/cocina/src/lib/pages/actividad-page/actividad-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -42,9 +42,28 @@ export class ActividadPageComponent {
     { value: 'trimestre2', label: 'Trimestre 2' },
     { value: 'trimestre3', label: 'Trimestre 3' },
     { value: 'trimestre4', label: 'Trimestre 4' },
+    { value: 'trimestre5', label: 'Trimestre 5' },
+    { value: 'trimestre6', label: 'Trimestre 6' },
+    { value: 'trimestre7', label: 'Trimestre 7' },
   ];
 
+  isFormValid = computed(() => {
+    const f = this.fecha();
+    const n = this.nombreActividad().trim();
+    const j = this.jornada();
+    const nf = this.numeroFicha().trim();
+    const t = this.trimestre();
+
+    if (!f || !n || !j || !nf || !t) return false;
+
+    const year = parseInt(f.split('-')[0], 10);
+    if (isNaN(year) || year < 2020 || year > 2050) return false;
+
+    return true;
+  });
+
   crearActividad(): void {
+    if (!this.isFormValid()) return;
 
     const jornadaLabel =
       this.jornadas.find(j => j.value === this.jornada())?.label ??

--- a/libs/cocina/cocina/src/lib/pages/actividades-list-page/actividades-list-page.component.scss
+++ b/libs/cocina/cocina/src/lib/pages/actividades-list-page/actividades-list-page.component.scss
@@ -237,7 +237,7 @@
   color: white;
   border: none;
   padding: 10px 28px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: 9999px !important;
   font-size: var(--text-sm, 0.875rem);
   font-weight: 700;
   letter-spacing: 0.5px;

--- a/libs/cocina/cocina/src/lib/pages/actividades-list-page/actividades-list-page.component.ts
+++ b/libs/cocina/cocina/src/lib/pages/actividades-list-page/actividades-list-page.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  OnInit,
   computed,
   inject,
   signal,
@@ -19,11 +20,13 @@ import { CocinaFacade } from '../../data-access/cocina.facade';
   styleUrl: './actividades-list-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ActividadesListPageComponent {
+export class ActividadesListPageComponent implements OnInit {
   private facade = inject(CocinaFacade);
   private router = inject(Router);
 
   readonly actividades = this.facade.actividades;
+  readonly cargando = this.facade.cargandoActividades;
+  readonly error = this.facade.errorActividades;
 
   /** Filtro por número de ficha */
   readonly filtroFicha = signal<string>('');
@@ -34,6 +37,11 @@ export class ActividadesListPageComponent {
     if (!filtro) return this.actividades();
     return this.actividades().filter(a => a.ficha.includes(filtro));
   });
+
+  ngOnInit(): void {
+    // Cargar actividades desde el backend al entrar a la página
+    this.facade.cargarActividades();
+  }
 
   onFiltroChange(valor: string): void {
     this.filtroFicha.set(valor);

--- a/libs/cocina/cocina/src/lib/pages/evaluacion-individual-page/evaluacion-individual-page.component.scss
+++ b/libs/cocina/cocina/src/lib/pages/evaluacion-individual-page/evaluacion-individual-page.component.scss
@@ -270,7 +270,7 @@
   color: white;
   border: none;
   padding: 10px 22px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: 9999px !important;
   font-size: var(--text-sm, 0.875rem);
   font-weight: 700;
   letter-spacing: 0.5px;

--- a/libs/cocina/cocina/src/lib/pages/evaluacion-individual-page/evaluacion-individual-page.component.ts
+++ b/libs/cocina/cocina/src/lib/pages/evaluacion-individual-page/evaluacion-individual-page.component.ts
@@ -9,6 +9,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { CocinaFacade } from '../../data-access/cocina.facade';
+import { EvaluacionRequestDTO } from '../../data-access/evaluacion.service';
 import { LucideIconComponent } from '@restaurant/shared/ui';
 
 // ─── Modelo ──────────────────────────────────────────────────────────────────
@@ -23,7 +24,7 @@ export interface AprendizIndividualMock {
   actividad: string | null;
 }
 
-// ─── Datos mock ───────────────────────────────────────────────────────────────
+// ─── Datos mock (fallback cuando no hay datos del backend) ───────────────────
 
 const APRENDIZ_MOCK: AprendizIndividualMock = {
   id: 1,
@@ -50,6 +51,9 @@ export class EvaluacionIndividualPageComponent implements OnInit {
   // ── Datos ────────────────────────────────────────────────────────────────
   readonly aprendiz = signal<AprendizIndividualMock>(APRENDIZ_MOCK);
 
+  /** ID de la actividad en la que se evalúa (viene por queryParam 'actividadId') */
+  actividadId: number | null = null;
+
   // ── Estado del formulario ─────────────────────────────────────────────────
   /** Texto del textarea de observaciones (bidireccional con ngModel) */
   observaciones = '';
@@ -66,6 +70,12 @@ export class EvaluacionIndividualPageComponent implements OnInit {
   ngOnInit(): void {
     this.route.queryParams.subscribe(params => {
       const id = Number(params['id']);
+      const actId = Number(params['actividadId']);
+
+      // Guardar el ID de la actividad para poder persistir la evaluación
+      if (actId) {
+        this.actividadId = actId;
+      }
 
       if (id) {
         const aprendizEncontrado = this.facade
@@ -103,7 +113,7 @@ export class EvaluacionIndividualPageComponent implements OnInit {
    * @param resultado 'aprobo' | 'no_aprobo'
    */
   submitEvaluacionIndividual(resultado: 'aprobo' | 'no_aprobo'): void {
-    const payload = {
+    const payload: EvaluacionRequestDTO = {
       aprendizId: this.aprendiz().id,
       observaciones: this.observaciones.trim(),
       resultado,
@@ -114,15 +124,14 @@ export class EvaluacionIndividualPageComponent implements OnInit {
       JSON.stringify(payload, null, 2)
     );
 
-    const estadoStr =
-      resultado === 'aprobo'
-        ? 'Aprobó'
-        : 'No Aprobó';
-
-    this.facade.actualizarEstado(
-      this.aprendiz().id,
-      estadoStr
-    );
+    // Persistir en backend si tenemos el actividadId (flujo normal desde masiva-page)
+    if (this.actividadId) {
+      this.facade.evaluarAprendices(this.actividadId, [payload]);
+    } else {
+      // Fallback: actualización local optimista si no hay contexto de actividad
+      const estadoStr = resultado === 'aprobo' ? 'Aprobó' : 'No Aprobó';
+      this.facade.actualizarEstado(this.aprendiz().id, estadoStr);
+    }
 
     // Limpiar formulario y cerrar menú
     this.observaciones = '';

--- a/libs/cocina/cocina/src/lib/pages/evaluacion-masiva-page/evaluacion-masiva-page.component.scss
+++ b/libs/cocina/cocina/src/lib/pages/evaluacion-masiva-page/evaluacion-masiva-page.component.scss
@@ -59,7 +59,7 @@
   color: white;
   border: none;
   padding: 10px 28px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: 9999px !important;
   font-size: var(--text-sm, 0.875rem);
   font-weight: 700;
   letter-spacing: 0.5px;
@@ -90,7 +90,7 @@
   color: var(--color-primario);
   border: 1.5px solid var(--color-primario);
   padding: 10px 28px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: 9999px !important;
   font-size: var(--text-sm, 0.875rem);
   font-weight: 700;
   letter-spacing: 0.5px;
@@ -522,7 +522,7 @@
   color: white;
   border: none;
   padding: 10px 22px;
-  border-radius: var(--radius-md, 8px);
+  border-radius: 9999px !important;
   font-size: var(--text-sm, 0.875rem);
   font-weight: 700;
   letter-spacing: 0.5px;

--- a/libs/cocina/cocina/src/lib/pages/evaluacion-masiva-page/evaluacion-masiva-page.component.ts
+++ b/libs/cocina/cocina/src/lib/pages/evaluacion-masiva-page/evaluacion-masiva-page.component.ts
@@ -98,6 +98,12 @@ export class EvaluacionMasivaPageComponent implements OnInit {
 
       if (id) {
         this.actividadId.set(id);
+        // Cargar aprendices con su estado de evaluación para esta actividad
+        this.facade.cargarEstadosEvaluacion(id);
+        // Cargar actividades si no están cargadas (para mostrar info de la actividad)
+        if (this.facade.actividades().length === 0) {
+          this.facade.cargarActividades();
+        }
       }
     });
   }
@@ -216,20 +222,26 @@ export class EvaluacionMasivaPageComponent implements OnInit {
   ): void {
 
     const ids = Array.from(this.seleccionados());
+    const actividadId = this.actividadId();
 
-    const estadoStr =
-      resultado === 'aprobo'
-        ? 'Aprobó'
-        : 'No Aprobó';
-
-    for (const id of ids) {
-      this.facade.actualizarEstado(id, estadoStr);
+    if (actividadId && ids.length > 0) {
+      // Enviar todas las evaluaciones al backend en una sola petición
+      const requests = ids.map(aprendizId => ({
+        aprendizId,
+        resultado,
+        observaciones: '',
+      }));
+      this.facade.evaluarAprendices(actividadId, requests);
+    } else {
+      // Fallback: actualización local si no hay actividadId
+      const estadoStr = resultado === 'aprobo' ? 'Aprobó' : 'No Aprobó';
+      for (const id of ids) {
+        this.facade.actualizarEstado(id, estadoStr);
+      }
     }
 
     this.seleccionados.set(new Set());
-
     this.menuEvaluarAbierto.set(false);
-
     this.modoSeleccionAbierto.set(false);
   }
 
@@ -239,11 +251,10 @@ export class EvaluacionMasivaPageComponent implements OnInit {
   }
 
   goToIndividual(id: number): void {
-
     this.router.navigate(
       ['/app/cocina/evaluacion-individual'],
       {
-        queryParams: { id },
+        queryParams: { id, actividadId: this.actividadId() },
       }
     );
   }

--- a/libs/inventario/inventario/src/lib/data-access/services/actas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/actas.service.ts
@@ -11,7 +11,7 @@ import {
 import { ActaResponse } from '../api/legalization.api';
 import { actaFromApi } from '../mappers/legalization.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 const ACCION_ESTADO: Record<string, string> = {
   PENDIENTE_FIRMAS: 'enviar-a-firmas',

--- a/libs/inventario/inventario/src/lib/data-access/services/alertas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/alertas.service.ts
@@ -9,7 +9,7 @@ import { ResumenAlertasResponse } from '../api/reporting.api';
 import { alertaFromApi, umbralFromApi } from '../mappers/alerts.mapper';
 import { resumenAlertasFromApi } from '../mappers/reporting.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class AlertasService {

--- a/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
@@ -19,7 +19,7 @@ import {
   bienFormToRequest,
 } from '../mappers/catalog.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class BienesService {

--- a/libs/inventario/inventario/src/lib/data-access/services/conciliacion.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/conciliacion.service.ts
@@ -22,7 +22,7 @@ import {
   diferenciaFromApi,
 } from '../mappers/reconciliation.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class ConciliacionService {

--- a/libs/inventario/inventario/src/lib/data-access/services/consolidado.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/consolidado.service.ts
@@ -9,7 +9,7 @@ import { EjecucionPresupuestalItemResponse } from '../api/reporting.api';
 import { consolidadoFromApi } from '../mappers/budget.mapper';
 import { ejecucionPresupuestalFromApi } from '../mappers/reporting.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class ConsolidadoService {

--- a/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
@@ -14,7 +14,7 @@ import {
 } from '../api/sourcing.api';
 import { facturaFromApi, conciliacionGilFromApi } from '../mappers/sourcing.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class FacturasService {

--- a/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
@@ -25,7 +25,7 @@ import {
 } from '../mappers/inventory.mapper';
 import { kardexValorizadoFromApi } from '../mappers/reporting.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class MovimientosService {

--- a/libs/inventario/inventario/src/lib/data-access/services/paquete.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/paquete.service.ts
@@ -6,7 +6,7 @@ import { PaqueteProbatorio } from '../../models/paquete.model';
 import { PaqueteResponse, CrearPaqueteRequest, TrazabilidadRequest } from '../api/legalization.api';
 import { paqueteFromApi } from '../mappers/legalization.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class PaqueteService {

--- a/libs/inventario/inventario/src/lib/data-access/services/presupuesto.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/presupuesto.service.ts
@@ -26,7 +26,7 @@ import {
 } from '../api/budget.api';
 import { rubroFromApi, compromisoFromApi, presupuestoDetalleFromApi, resumenPresupuestosFromApi } from '../mappers/budget.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class PresupuestoService {

--- a/libs/inventario/inventario/src/lib/data-access/services/reporting.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/reporting.service.ts
@@ -6,7 +6,7 @@ import { ConsumoItem, TrazabilidadDocumental } from '../../models/reporting.mode
 import { ConsumoItemResponse, TrazabilidadDocumentalItemResponse } from '../api/reporting.api';
 import { consumoFromApi, trazabilidadFromApi } from '../mappers/reporting.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class ReportingService {

--- a/libs/inventario/inventario/src/lib/data-access/services/requisiciones.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/requisiciones.service.ts
@@ -6,7 +6,7 @@ import { Requisicion } from '../../models/requisicion.model';
 import { RequisicionResponse } from '../api/legalization.api';
 import { requisicionFromApi } from '../mappers/legalization.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class RequisicionesService {

--- a/libs/inventario/inventario/src/lib/data-access/services/solicitudes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/solicitudes.service.ts
@@ -25,7 +25,7 @@ import {
 import { gilFromApi } from '../mappers/sourcing.mapper';
 import { solicitudSesionFromApi } from '../mappers/training.mapper';
 
-const API = '/api/v1';
+const API = 'http://localhost:8080/api/v1';
 
 @Injectable({ providedIn: 'root' })
 export class SolicitudesService {

--- a/package-lock.json
+++ b/package-lock.json
@@ -427,7 +427,6 @@
       "integrity": "sha512-50HrZQ2S/t9bWDEg30qqkwHUCH+k7pmslPqHLMFe0q+oUNaL5Ru+fi/L84bDzqRP/0mkeIIY2rOuUWrw6ZpGvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
@@ -456,7 +455,6 @@
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -467,7 +465,6 @@
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -478,7 +475,6 @@
       "integrity": "sha512-3PmlXbegeMsCNhK26jI068Rr8wArGGMWjvWd9IVHaFhXxkcc3xHjCiqYaz8uRj9Rz+Ra4ToC7qU/Rwgy72qJ9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "19.2.26",
         "jsonc-parser": "3.3.1",
@@ -498,7 +494,6 @@
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -553,6 +548,7 @@
       "integrity": "sha512-BaUSLSyS+43fzDoJkTMkGqNdCXq3fGnUZsfXTmrlZPJf5AYFbgAlAPGZXDJyoNWw43fux+DafdlrlKcYUSgSIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.4.0",
         "eslint-scope": "9.1.2"
@@ -934,6 +930,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.21.tgz",
       "integrity": "sha512-BjVpJYaC0T73nIT4BCOR5jcFUcXAFe2kKPlSDfD8mjBl8+Ug3Uy/Xs3Blx/6IKDLwNkbCUAxo/IwT+zzpTYNpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -950,6 +947,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.21.tgz",
       "integrity": "sha512-XufWMAUS0gNKE29LkDFf21eTxdBN2WIcN/3ownqfYqKwDzMMpUAm5EEjPYfn0b/2/b5OYGNJrU4yeTHoz0Bt7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -963,6 +961,7 @@
       "integrity": "sha512-Bo0lCIm1YZ18b4abP7InqP9q3uxcOzbVxYwdZYTiht4mrV5HUTBjsI5Yn8GL7eXXpjmY4e1CrdDe81+nNDn+0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -995,6 +994,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.21.tgz",
       "integrity": "sha512-sZMWyxh6dkuT6F90epkM1F7E2WJeduHoA9PRHYChIIVFnBd0VKITxpfrwRQS44IPJAtR456/5twtrcCNBALweQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1038,6 +1038,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.21.tgz",
       "integrity": "sha512-hhsB2dv4Iq8SMmh50fYkMA2IOQ7JGXfQSBS4pPC3zj5njVQZtSNEJ/il8QNjYyw/KsMSFffhA/if6vSAumYvUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1060,6 +1061,7 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.21.tgz",
       "integrity": "sha512-8MLfjHVnVs7CLd6ZY9dbwtJfqFqKx9thr0dKzHdlPc/lorGckQ6aco6yOQnPuIeUVIp/zqxokFba27q7Z1aGxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1104,6 +1106,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3879,6 +3882,7 @@
       "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.2.1",
         "@inquirer/confirm": "^5.1.14",
@@ -5103,6 +5107,7 @@
       "integrity": "sha512-c9siKVjcgT2gtDdOTqEr+GaP2X/PWAS0OV424ljKLstFL1lcS/BIsxWFDmxPPl5hDByAH+1q4YhC1LWY4LNDQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/bridge-react-webpack-plugin": "0.9.1",
         "@module-federation/data-prefetch": "0.9.1",
@@ -5395,6 +5400,7 @@
       "integrity": "sha512-BWQsGT4EWscV9bx3bVHEwp6lERBsiYm7rnPiDpwd2fx+hGEpz1IM9Pz35VryHNDXYxw7MzaAuwTMM+L7uN8OYQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "2.4.0",
         "@module-federation/webpack-bundler-runtime": "2.4.0"
@@ -5585,6 +5591,7 @@
       "integrity": "sha512-JQZ//ab+lEXoU2DHAH+JtYASGzxEjXB0s4rU+6VJXc8c+oUPxH3kWIwzjdncg2mcWBmC1140DCk+K+kDfOZ5CQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.9.1",
         "@module-federation/webpack-bundler-runtime": "0.9.1"
@@ -6093,6 +6100,7 @@
       "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-20.1.0.tgz",
       "integrity": "sha512-o8j3CGAGedm+BIb+QDhNXrVaU//n9uF0wH0HZWtXHmW1mjRBaQiUA+ZPMUkDwAeN8KuOcoIEC+2QUXxXGVI7ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -7805,6 +7813,7 @@
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -8902,6 +8911,7 @@
       "integrity": "sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime-tools": "0.22.0",
         "@rspack/binding": "1.7.11",
@@ -9705,6 +9715,7 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -9849,6 +9860,7 @@
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -10030,6 +10042,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -10137,6 +10150,7 @@
       "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -10248,6 +10262,7 @@
       "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.59.4",
@@ -10536,6 +10551,7 @@
       "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -10583,6 +10599,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10649,6 +10666,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11292,6 +11310,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -11573,6 +11592,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -12018,7 +12038,6 @@
       "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-what": "^4.1.8"
       },
@@ -13094,6 +13113,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13567,6 +13587,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -14000,6 +14021,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14709,6 +14731,7 @@
       "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -15485,7 +15508,6 @@
       "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.13"
       },
@@ -16073,6 +16095,7 @@
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -16544,7 +16567,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16736,6 +16758,7 @@
       "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
@@ -17714,6 +17737,7 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -18026,6 +18050,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -18449,7 +18474,6 @@
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -18474,7 +18498,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -18492,7 +18515,6 @@
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -18506,7 +18528,6 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -18517,7 +18538,6 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -18534,7 +18554,6 @@
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -18548,8 +18567,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ordered-binary": {
       "version": "1.6.1",
@@ -19145,6 +19163,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -20458,6 +20477,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -20535,6 +20555,7 @@
       "integrity": "sha512-gF/juR1aX02lZHkvwxdF80SapkQeg2fetoDF6gIQkNbSw5YEUFspMkyGTjPjgZSgIHuZpy+Wz4PlebKnLXMjdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
         "colorjs.io": "^0.5.0",
@@ -20993,8 +21014,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -21980,6 +22000,7 @@
       "integrity": "sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "~4.3.3",
         "debug": "^4.3.2",
@@ -22270,6 +22291,7 @@
       "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -22691,7 +22713,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -22797,6 +22820,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23018,6 +23042,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -23643,6 +23668,7 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -24504,6 +24530,7 @@
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -24559,6 +24586,7 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -24724,6 +24752,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -24742,7 +24771,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }


### PR DESCRIPTION
- Se implemento validacion reactiva de campos en el formulario de creacion de actividades.

- Se definieron fechas minimas (2020) y maximas (2050) permitidas.

- Se añadieron trimestres adicionales 5, 6 y 7 en la UI.

- Se aplico styling a boton deshabilitado.

- Se cambiaron paths relativos /api/v1 a endpoints completos localhost:8080 en servicios del modulo de inventario para resolver bug de parseo.

## Descripción
Este PR introduce mejoras de validación clave en el formulario de creación de actividades del módulo de Cocina, garantizando la integridad de los datos antes de enviarlos. Además, soluciona un bug importante en el módulo de Inventario donde las peticiones HTTP fallaban por intentar consultar el puerto del frontend (4200) en lugar del backend de Docker (8080).
## Tipo de cambio
- [x] `feat` — nueva funcionalidad
- [x] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente
## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [x] `cocina` · [ ] `bar` · [ ] `restaurante`
- [x] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`
## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [x] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [x] Sin `any` en TypeScript
- [x] Sin estilos inline en templates
- [x] Sin colores/espaciados fuera de `_variables.scss`
## Cambios principales
- Agregué validación reactiva en el formulario de actividad mediante el signal `isFormValid` para impedir que se cree la actividad si hay campos obligatorios vacíos (dejando "pasos" como opcional).
- Modifiqué el campo de fecha de actividad para que acepte estrictamente años entre 2020 y 2050 (tanto en validación HTML como de TS).
- Agregué los trimestres 5, 6 y 7 como nuevas opciones en el formulario.
- Agregué retroalimentación visual (styling de botón deshabilitado) cuando el formulario no es válido.
- Modifiqué los endpoints de todos los servicios del módulo `inventario` que apuntaban a `/api/v1` para que usen la ruta completa `http://localhost:8080/api/v1` y evitar el parseo de HTML.
## RF relacionado
RF-C 4.10 Gestión de Actividades Académicas
