### PR TITLE
feat(auth): implementar cuentas-page e historial-page conectados al facade

### DIFF
--- a/libs/auth/usuarios/src/lib/data-access/store/actions/usuarios.actions.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/actions/usuarios.actions.ts
@@ -8,6 +8,7 @@ import {
   HistorialItem,
   ImportarUsuariosRequest,
   ImportarUsuariosResponse,
+  RolDetalle,
   RolOpcion,
   UsuarioDetalle,
 } from '../../../models/usuarios.model';
@@ -64,6 +65,11 @@ export const UsuariosActions = createActionGroup({
     'Exportar Usuarios':            props<{ config: ExportarConfig }>(),
     'Exportar Usuarios Exitoso':    emptyProps(),
     'Exportar Usuarios Fallido':    props<{ error: string }>(),
+
+    // ── Roles detalle ─────────────────────────────────────────────────────────
+    'Cargar Roles Detalle':         emptyProps(),
+    'Cargar Roles Detalle Exitoso': props<{ roles: RolDetalle[] }>(),
+    'Cargar Roles Detalle Fallido': props<{ error: string }>(),
 
     // ── Historial ─────────────────────────────────────────────────────────────
     'Cargar Historial':             emptyProps(),

--- a/libs/auth/usuarios/src/lib/data-access/store/actions/usuarios.actions.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/actions/usuarios.actions.ts
@@ -5,6 +5,7 @@ import {
   CrearUsuarioRequest,
   ExportarConfig,
   FiltrosUsuarios,
+  HistorialItem,
   ImportarUsuariosRequest,
   ImportarUsuariosResponse,
   RolOpcion,
@@ -63,6 +64,11 @@ export const UsuariosActions = createActionGroup({
     'Exportar Usuarios':            props<{ config: ExportarConfig }>(),
     'Exportar Usuarios Exitoso':    emptyProps(),
     'Exportar Usuarios Fallido':    props<{ error: string }>(),
+
+    // ── Historial ─────────────────────────────────────────────────────────────
+    'Cargar Historial':             emptyProps(),
+    'Cargar Historial Exitoso':     props<{ historial: HistorialItem[] }>(),
+    'Cargar Historial Fallido':     props<{ error: string }>(),
 
     // ── Selección local ───────────────────────────────────────────────────────
     'Seleccionar Usuario':          props<{ usuario: UsuarioDetalle }>(),

--- a/libs/auth/usuarios/src/lib/data-access/store/effects/usuarios.effects.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/effects/usuarios.effects.ts
@@ -179,6 +179,22 @@ export const exportarUsuarios$ = createEffect(
   { functional: true },
 );
 
+export const cargarRolesDetalle$ = createEffect(
+  (actions$ = inject(Actions), svc = inject(UsuariosService)) =>
+    actions$.pipe(
+      ofType(UsuariosActions.cargarRolesDetalle),
+      switchMap(() =>
+        svc.getRolesDetalle().pipe(
+          map(roles => UsuariosActions.cargarRolesDetalleExitoso({ roles })),
+          catchError((err: unknown) =>
+            of(UsuariosActions.cargarRolesDetalleFallido({ error: extractErrorMessage(err) })),
+          ),
+        ),
+      ),
+    ),
+  { functional: true },
+);
+
 export const cargarHistorial$ = createEffect(
   (actions$ = inject(Actions), svc = inject(UsuariosService)) =>
     actions$.pipe(

--- a/libs/auth/usuarios/src/lib/data-access/store/effects/usuarios.effects.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/effects/usuarios.effects.ts
@@ -179,6 +179,22 @@ export const exportarUsuarios$ = createEffect(
   { functional: true },
 );
 
+export const cargarHistorial$ = createEffect(
+  (actions$ = inject(Actions), svc = inject(UsuariosService)) =>
+    actions$.pipe(
+      ofType(UsuariosActions.cargarHistorial),
+      switchMap(() =>
+        svc.getHistorial().pipe(
+          map(historial => UsuariosActions.cargarHistorialExitoso({ historial })),
+          catchError((err: unknown) =>
+            of(UsuariosActions.cargarHistorialFallido({ error: extractErrorMessage(err) })),
+          ),
+        ),
+      ),
+    ),
+  { functional: true },
+);
+
 // Corrección 4 — recargar lista tras crear/eliminar
 export const recargarTrasCrear$ = createEffect(
   (actions$ = inject(Actions)) =>

--- a/libs/auth/usuarios/src/lib/data-access/store/reducers/usuarios.reducer.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/reducers/usuarios.reducer.ts
@@ -1,5 +1,5 @@
 import { createFeature, createReducer, on } from '@ngrx/store';
-import { ImportarUsuariosResponse, RolOpcion, UsuarioDetalle } from '../../../models/usuarios.model';
+import { HistorialItem, ImportarUsuariosResponse, RolOpcion, UsuarioDetalle } from '../../../models/usuarios.model';
 import { UsuariosActions } from '../actions/usuarios.actions';
 
 export interface MensajeExport {
@@ -20,6 +20,8 @@ export interface UsuariosState {
   importando:          boolean;
   resultadoImport:     ImportarUsuariosResponse | null;
   mensajeExport:       MensajeExport | null;
+  historial:           HistorialItem[];
+  loadingHistorial:    boolean;
 }
 
 const initialState: UsuariosState = {
@@ -35,6 +37,8 @@ const initialState: UsuariosState = {
   importando:          false,
   resultadoImport:     null,
   mensajeExport:       null,
+  historial:           [],
+  loadingHistorial:    false,
 };
 
 export const usuariosFeature = createFeature({
@@ -167,6 +171,17 @@ export const usuariosFeature = createFeature({
       loadingAccion: false,
       error,
       mensajeExport: { texto: error, tipo: 'error' as const },
+    })),
+
+    // ── Historial ─────────────────────────────────────────────────────────────
+    on(UsuariosActions.cargarHistorial, state => ({
+      ...state, loadingHistorial: true,
+    })),
+    on(UsuariosActions.cargarHistorialExitoso, (state, { historial }) => ({
+      ...state, loadingHistorial: false, historial,
+    })),
+    on(UsuariosActions.cargarHistorialFallido, (state, { error }) => ({
+      ...state, loadingHistorial: false, error,
     })),
 
     // ── Selección local ───────────────────────────────────────────────────────

--- a/libs/auth/usuarios/src/lib/data-access/store/reducers/usuarios.reducer.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/reducers/usuarios.reducer.ts
@@ -1,5 +1,5 @@
 import { createFeature, createReducer, on } from '@ngrx/store';
-import { HistorialItem, ImportarUsuariosResponse, RolOpcion, UsuarioDetalle } from '../../../models/usuarios.model';
+import { HistorialItem, ImportarUsuariosResponse, RolDetalle, RolOpcion, UsuarioDetalle } from '../../../models/usuarios.model';
 import { UsuariosActions } from '../actions/usuarios.actions';
 
 export interface MensajeExport {
@@ -22,6 +22,8 @@ export interface UsuariosState {
   mensajeExport:       MensajeExport | null;
   historial:           HistorialItem[];
   loadingHistorial:    boolean;
+  rolesDetalle:        RolDetalle[];
+  loadingRolesDetalle: boolean;
 }
 
 const initialState: UsuariosState = {
@@ -39,6 +41,8 @@ const initialState: UsuariosState = {
   mensajeExport:       null,
   historial:           [],
   loadingHistorial:    false,
+  rolesDetalle:        [],
+  loadingRolesDetalle: false,
 };
 
 export const usuariosFeature = createFeature({
@@ -171,6 +175,17 @@ export const usuariosFeature = createFeature({
       loadingAccion: false,
       error,
       mensajeExport: { texto: error, tipo: 'error' as const },
+    })),
+
+    // ── Roles detalle ─────────────────────────────────────────────────────────
+    on(UsuariosActions.cargarRolesDetalle, state => ({
+      ...state, loadingRolesDetalle: true,
+    })),
+    on(UsuariosActions.cargarRolesDetalleExitoso, (state, { roles }) => ({
+      ...state, loadingRolesDetalle: false, rolesDetalle: roles,
+    })),
+    on(UsuariosActions.cargarRolesDetalleFallido, (state, { error }) => ({
+      ...state, loadingRolesDetalle: false, error,
     })),
 
     // ── Historial ─────────────────────────────────────────────────────────────

--- a/libs/auth/usuarios/src/lib/data-access/store/selectors/usuarios.selectors.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/selectors/usuarios.selectors.ts
@@ -16,6 +16,8 @@ export const {
   selectMensajeExport,
   selectHistorial,
   selectLoadingHistorial,
+  selectRolesDetalle,
+  selectLoadingRolesDetalle,
 } = usuariosFeature;
 
 export const selectTotalActivos = createSelector(

--- a/libs/auth/usuarios/src/lib/data-access/store/selectors/usuarios.selectors.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/selectors/usuarios.selectors.ts
@@ -14,6 +14,8 @@ export const {
   selectImportando,
   selectResultadoImport,
   selectMensajeExport,
+  selectHistorial,
+  selectLoadingHistorial,
 } = usuariosFeature;
 
 export const selectTotalActivos = createSelector(

--- a/libs/auth/usuarios/src/lib/data-access/usuarios.facade.ts
+++ b/libs/auth/usuarios/src/lib/data-access/usuarios.facade.ts
@@ -14,9 +14,11 @@ import { UsuariosState } from './store/reducers/usuarios.reducer';
 import {
   selectError,
   selectHayError,
+  selectHistorial,
   selectImportando,
   selectLoading,
   selectLoadingAccion,
+  selectLoadingHistorial,
   selectMensajeExport,
   selectResultadoImport,
   selectRoles,
@@ -47,6 +49,8 @@ export class UsuariosFacade {
   readonly resultadoImport$     = this.store.select(selectResultadoImport);
   readonly mensajeExport$       = this.store.select(selectMensajeExport);
   readonly hayError$            = this.store.select(selectHayError);
+  readonly historial$           = this.store.select(selectHistorial);
+  readonly loadingHistorial$    = this.store.select(selectLoadingHistorial);
 
   // ── Comandos ──────────────────────────────────────────────────────────────
   cargarUsuarios(filtros?: Partial<FiltrosUsuarios>): void {
@@ -95,5 +99,9 @@ export class UsuariosFacade {
 
   limpiarSeleccion(): void {
     this.store.dispatch(UsuariosActions.limpiarSeleccion());
+  }
+
+  cargarHistorial(): void {
+    this.store.dispatch(UsuariosActions.cargarHistorial());
   }
 }

--- a/libs/auth/usuarios/src/lib/data-access/usuarios.facade.ts
+++ b/libs/auth/usuarios/src/lib/data-access/usuarios.facade.ts
@@ -19,9 +19,11 @@ import {
   selectLoading,
   selectLoadingAccion,
   selectLoadingHistorial,
+  selectLoadingRolesDetalle,
   selectMensajeExport,
   selectResultadoImport,
   selectRoles,
+  selectRolesDetalle,
   selectTotalActivos,
   selectTotalElements,
   selectTotalInactivos,
@@ -51,6 +53,8 @@ export class UsuariosFacade {
   readonly hayError$            = this.store.select(selectHayError);
   readonly historial$           = this.store.select(selectHistorial);
   readonly loadingHistorial$    = this.store.select(selectLoadingHistorial);
+  readonly rolesDetalle$        = this.store.select(selectRolesDetalle);
+  readonly loadingRolesDetalle$ = this.store.select(selectLoadingRolesDetalle);
 
   // ── Comandos ──────────────────────────────────────────────────────────────
   cargarUsuarios(filtros?: Partial<FiltrosUsuarios>): void {
@@ -103,5 +107,9 @@ export class UsuariosFacade {
 
   cargarHistorial(): void {
     this.store.dispatch(UsuariosActions.cargarHistorial());
+  }
+
+  cargarRolesDetalle(): void {
+    this.store.dispatch(UsuariosActions.cargarRolesDetalle());
   }
 }

--- a/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
+++ b/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
@@ -11,6 +11,7 @@ import {
   HistorialItem,
   ImportarUsuariosRequest,
   ImportarUsuariosResponse,
+  RolDetalle,
   RolOpcion,
   UsuarioDetalle,
 } from '../models/usuarios.model';
@@ -34,6 +35,10 @@ export class UsuariosService extends BaseHttpService {
 
   getRoles(): Observable<RolOpcion[]> {
     return this.http.get<RolOpcion[]>(this.buildUrl('roles'));
+  }
+
+  getRolesDetalle(): Observable<RolDetalle[]> {
+    return this.http.get<RolDetalle[]>(this.buildUrl('roles'));
   }
 
   crearUsuario(data: CrearUsuarioRequest): Observable<UsuarioDetalle> {

--- a/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
+++ b/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
@@ -8,6 +8,7 @@ import {
   CrearUsuarioRequest,
   ExportarConfig,
   FiltrosUsuarios,
+  HistorialItem,
   ImportarUsuariosRequest,
   ImportarUsuariosResponse,
   RolOpcion,
@@ -67,6 +68,10 @@ export class UsuariosService extends BaseHttpService {
       this.buildUrl(`${this.resource}/importar`),
       formData,
     );
+  }
+
+  getHistorial(): Observable<HistorialItem[]> {
+    return this.http.get<HistorialItem[]>(this.buildUrl(`${this.resource}/historial`));
   }
 
   exportarUsuarios(config: ExportarConfig): Observable<Blob> {

--- a/libs/auth/usuarios/src/lib/models/usuarios.model.ts
+++ b/libs/auth/usuarios/src/lib/models/usuarios.model.ts
@@ -59,3 +59,13 @@ export interface ExportarConfig {
   incluirInactivos: boolean;
   rol:              string;
 }
+
+export interface HistorialItem {
+  id:            string;
+  usuarioNombre: string;
+  usuarioEmail:  string;
+  accion:        'LOGIN' | 'LOGOUT' | 'CREAR' | 'EDITAR' | 'ELIMINAR' | 'BLOQUEO';
+  fecha:         string;
+  ip:            string;
+  detalles:      string;
+}

--- a/libs/auth/usuarios/src/lib/models/usuarios.model.ts
+++ b/libs/auth/usuarios/src/lib/models/usuarios.model.ts
@@ -60,6 +60,21 @@ export interface ExportarConfig {
   rol:              string;
 }
 
+export interface PermisoItem {
+  id:          string;
+  nombre:      string;
+  descripcion: string;
+  activo:      boolean;
+}
+
+export interface RolDetalle {
+  id:            string;
+  nombre:        string;
+  descripcion:   string;
+  permisos:      PermisoItem[];
+  totalUsuarios: number;
+}
+
 export interface HistorialItem {
   id:            string;
   usuarioNombre: string;

--- a/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.html
@@ -1,20 +1,146 @@
 <div class="cuentas-page">
 
-  <!-- Header -->
-  <div class="cuentas-page__header">
-    <h1 class="cuentas-page__title">Gestión de Cuentas</h1>
-    <p class="cuentas-page__subtitle">Bloqueo, desbloqueo e historial de accesos por usuario</p>
+  <restaurant-page-header
+    title="Gestión de Cuentas"
+    subtitle="Bloqueo, desbloqueo e historial de accesos por usuario"
+  ></restaurant-page-header>
+
+  @if (error()) {
+    <restaurant-alert type="error" [message]="error()!"></restaurant-alert>
+  }
+
+  <!-- KPI Cards -->
+  <div class="cuentas-page__kpis">
+    <restaurant-kpi-card
+      label="Cuentas Bloqueadas"
+      [value]="totalBloqueadas().toString()"
+      icon="lock"
+      iconColor="red"
+    ></restaurant-kpi-card>
+    <restaurant-kpi-card
+      label="Cuentas Activas"
+      [value]="totalActivas().toString()"
+      icon="shield-check"
+      iconColor="green"
+    ></restaurant-kpi-card>
   </div>
 
-  <!-- Empty state -->
-  <div class="cuentas-page__empty">
-    <div class="cuentas-page__empty-icon">
-      <lucide-icon name="shield-check" [size]="48"></lucide-icon>
-    </div>
-    <restaurant-empty-state
-      title="Funcionalidad pendiente"
-      message="Esta funcionalidad estará disponible cuando se conecte el backend. Permite bloquear/desbloquear cuentas y ver historial de accesos."
-    ></restaurant-empty-state>
+  <!-- Filtros -->
+  <div class="cuentas-page__filters">
+    <button
+      class="cuentas-page__filter-btn"
+      [class.cuentas-page__filter-btn--active]="filtroEstado() === 'todos'"
+      type="button"
+      (click)="filtroEstado.set('todos')"
+    >
+      Todos
+    </button>
+    <button
+      class="cuentas-page__filter-btn"
+      [class.cuentas-page__filter-btn--active]="filtroEstado() === 'bloqueados'"
+      type="button"
+      (click)="filtroEstado.set('bloqueados')"
+    >
+      <lucide-icon name="lock" [size]="14"></lucide-icon>
+      Bloqueados
+    </button>
+    <button
+      class="cuentas-page__filter-btn"
+      [class.cuentas-page__filter-btn--active]="filtroEstado() === 'activos'"
+      type="button"
+      (click)="filtroEstado.set('activos')"
+    >
+      <lucide-icon name="shield-check" [size]="14"></lucide-icon>
+      Activos
+    </button>
   </div>
+
+  @if (loading()) {
+    <restaurant-loading-skeleton [lines]="5"></restaurant-loading-skeleton>
+  } @else {
+    <restaurant-data-table>
+      <thead>
+        <tr>
+          <th>Usuario</th>
+          <th>Rol</th>
+          <th>Intentos fallidos</th>
+          <th>Estado cuenta</th>
+          <th>Último acceso</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (u of usuariosFiltrados(); track u.id) {
+          <tr>
+            <td>
+              <div class="cuentas-page__user">
+                <restaurant-usuario-avatar
+                  [nombre]="u.nombre"
+                  [apellidos]="u.apellidos"
+                ></restaurant-usuario-avatar>
+                <div>
+                  <p class="cuentas-page__user-name">{{ u.nombre }} {{ u.apellidos }}</p>
+                  <p class="cuentas-page__user-email">{{ u.email }}</p>
+                </div>
+              </div>
+            </td>
+            <td>
+              <restaurant-usuario-rol-badge [rol]="u.rol"></restaurant-usuario-rol-badge>
+            </td>
+            <td>
+              <span
+                class="cuentas-page__intentos"
+                [class.cuentas-page__intentos--alert]="u.intentosFallidos > 0"
+              >
+                {{ u.intentosFallidos }}
+              </span>
+            </td>
+            <td>
+              <span
+                class="cuentas-page__estado"
+                [class.cuentas-page__estado--bloqueada]="u.cuentaBloqueada"
+                [class.cuentas-page__estado--activa]="!u.cuentaBloqueada"
+              >
+                {{ u.cuentaBloqueada ? 'Bloqueada' : 'Activa' }}
+              </span>
+            </td>
+            <td class="cuentas-page__last-access">
+              {{ (u.ultimoAcceso | date:'dd/MM/yyyy HH:mm') || '—' }}
+            </td>
+            <td>
+              @if (u.cuentaBloqueada) {
+                <button
+                  class="cuentas-page__action-btn cuentas-page__action-btn--unlock"
+                  type="button"
+                  (click)="onDesbloquear(u.id)"
+                >
+                  <lucide-icon name="unlock" [size]="14"></lucide-icon>
+                  Desbloquear
+                </button>
+              } @else {
+                <button
+                  class="cuentas-page__action-btn cuentas-page__action-btn--lock"
+                  type="button"
+                  (click)="onBloquear(u.id)"
+                >
+                  <lucide-icon name="lock" [size]="14"></lucide-icon>
+                  Bloquear
+                </button>
+              }
+            </td>
+          </tr>
+        } @empty {
+          <tr>
+            <td colspan="6" class="cuentas-page__empty-cell">
+              <restaurant-empty-state
+                title="Sin resultados"
+                message="No hay cuentas que coincidan con el filtro seleccionado."
+              ></restaurant-empty-state>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </restaurant-data-table>
+  }
 
 </div>

--- a/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.scss
@@ -2,43 +2,146 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
+  padding: var(--space-6);
 
-  &__header {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
+  &__kpis {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-4);
+
+    @media (max-width: 640px) {
+      grid-template-columns: 1fr;
+    }
   }
 
-  &__title {
-    font-family: var(--font-family-headline);
-    font-size: var(--font-size-2xl);
-    font-weight: var(--font-weight-bold);
-    color: var(--color-text-heading);
+  &__filters {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  &__filter-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    font-family: var(--font-family-base);
+    cursor: pointer;
+    transition: background var(--duration-fast) var(--ease-standard),
+                color       var(--duration-fast) var(--ease-standard),
+                border-color var(--duration-fast) var(--ease-standard);
+
+    &--active {
+      background: var(--color-primario);
+      color: var(--color-en-primario);
+      border-color: var(--color-primario);
+    }
+
+    &:not(&--active):hover {
+      background: var(--color-superficie-contenedor);
+      color: var(--color-text-primary);
+    }
+  }
+
+  &__user {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  &__user-name {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
     margin: 0;
   }
 
-  &__subtitle {
-    font-size: var(--font-size-sm);
+  &__user-email {
+    font-size: var(--font-size-xs);
     color: var(--color-text-secondary);
     margin: 0;
   }
 
-  &__empty {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--space-4);
-    padding: var(--space-12) var(--space-6);
+  &__intentos {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+
+    &--alert {
+      color: var(--color-error-text);
+      font-weight: var(--font-weight-semibold);
+    }
   }
 
-  &__empty-icon {
-    display: flex;
+  &__estado {
+    display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 80px;
-    height: 80px;
+    padding: 2px var(--space-2);
     border-radius: var(--radius-full);
-    background: var(--color-brand-primary-soft);
-    color: var(--color-brand-primary-strong);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    white-space: nowrap;
+
+    &--activa {
+      background: var(--color-success-bg);
+      color: var(--color-success-text);
+    }
+
+    &--bloqueada {
+      background: var(--color-error-bg);
+      color: var(--color-error-text);
+    }
+  }
+
+  &__last-access {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+  }
+
+  &__action-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-3);
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    font-family: var(--font-family-base);
+    cursor: pointer;
+    transition: background var(--duration-fast) var(--ease-standard),
+                color      var(--duration-fast) var(--ease-standard);
+
+    &--unlock {
+      background: var(--color-brand-primary-soft);
+      color: var(--color-brand-primary-strong);
+
+      &:hover {
+        background: var(--color-primario);
+        color: var(--color-en-primario);
+      }
+    }
+
+    &--lock {
+      background: var(--color-error-bg);
+      color: var(--color-error-text);
+
+      &:hover {
+        background: var(--color-error-text);
+        color: var(--color-surface-primary);
+      }
+    }
+  }
+
+  &__empty-cell {
+    padding: var(--space-8);
+    text-align: center;
   }
 }

--- a/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.ts
@@ -1,15 +1,82 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
 } from '@angular/core';
-import { EmptyStateComponent, LucideIconComponent } from '@restaurant/shared/ui';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { DatePipe } from '@angular/common';
+import {
+  AlertComponent,
+  DataTableComponent,
+  EmptyStateComponent,
+  KpiCardComponent,
+  LoadingSkeletonComponent,
+  LucideIconComponent,
+  PageHeaderComponent,
+} from '@restaurant/shared/ui';
+import { UsuarioAvatarComponent } from '../../components/usuario-avatar/usuario-avatar.component';
+import { UsuarioRolBadgeComponent } from '../../components/usuario-rol-badge/usuario-rol-badge.component';
+import { UsuariosFacade } from '../../data-access/usuarios.facade';
+import { UsuarioDetalle } from '../../models/usuarios.model';
+
+type FiltroEstado = 'todos' | 'bloqueados' | 'activos';
 
 @Component({
   selector: 'restaurant-cuentas-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [EmptyStateComponent, LucideIconComponent],
+  imports: [
+    DatePipe,
+    AlertComponent,
+    DataTableComponent,
+    EmptyStateComponent,
+    KpiCardComponent,
+    LoadingSkeletonComponent,
+    LucideIconComponent,
+    PageHeaderComponent,
+    UsuarioAvatarComponent,
+    UsuarioRolBadgeComponent,
+  ],
   templateUrl: './cuentas-page.component.html',
   styleUrl:    './cuentas-page.component.scss',
 })
-export class CuentasPageComponent {}
+export class CuentasPageComponent implements OnInit {
+  private readonly facade = inject(UsuariosFacade);
+
+  readonly usuarios = toSignal(this.facade.usuarios$, { initialValue: [] as UsuarioDetalle[] });
+  readonly loading  = toSignal(this.facade.loading$,  { initialValue: false });
+  readonly error    = toSignal(this.facade.error$,    { initialValue: null });
+
+  readonly filtroEstado = signal<FiltroEstado>('todos');
+
+  readonly usuariosFiltrados = computed(() => {
+    const estado = this.filtroEstado();
+    const todos  = this.usuarios();
+    if (estado === 'bloqueados') return todos.filter(u => u.cuentaBloqueada);
+    if (estado === 'activos')    return todos.filter(u => !u.cuentaBloqueada);
+    return todos;
+  });
+
+  readonly totalBloqueadas = computed(() =>
+    this.usuarios().filter(u => u.cuentaBloqueada).length
+  );
+
+  readonly totalActivas = computed(() =>
+    this.usuarios().filter(u => !u.cuentaBloqueada).length
+  );
+
+  ngOnInit(): void {
+    this.facade.cargarUsuarios();
+  }
+
+  onDesbloquear(id: string): void {
+    this.facade.desbloquearCuenta(id);
+  }
+
+  onBloquear(id: string): void {
+    this.facade.desactivarUsuario(id);
+  }
+}

--- a/libs/auth/usuarios/src/lib/pages/historial-page/historial-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/historial-page/historial-page.component.html
@@ -1,0 +1,71 @@
+<div class="historial-page">
+
+  <restaurant-page-header
+    title="Historial de Actividades"
+    subtitle="Registro de acciones realizadas por los usuarios del sistema"
+  ></restaurant-page-header>
+
+  <!-- Filtros -->
+  <div class="historial-page__filters">
+    <restaurant-search-filter
+      label="Buscar usuario"
+      placeholder="Nombre o email..."
+      [value]="busqueda()"
+      (valueChange)="busqueda.set($event)"
+    ></restaurant-search-filter>
+    <restaurant-select-filter
+      label="Tipo de acción"
+      [value]="filtroAccion()"
+      [options]="accionOpciones"
+      (valueChange)="filtroAccion.set($event)"
+    ></restaurant-select-filter>
+  </div>
+
+  @if (loading()) {
+    <restaurant-loading-skeleton [lines]="8"></restaurant-loading-skeleton>
+  } @else {
+    <restaurant-data-table>
+      <thead>
+        <tr>
+          <th>Usuario</th>
+          <th>Acción</th>
+          <th>Fecha y hora</th>
+          <th>IP</th>
+          <th>Detalles</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (item of historialFiltrado(); track item.id) {
+          <tr>
+            <td>
+              <div class="historial-page__user">
+                <p class="historial-page__user-name">{{ item.usuarioNombre }}</p>
+                <p class="historial-page__user-email">{{ item.usuarioEmail }}</p>
+              </div>
+            </td>
+            <td>
+              <span class="accion-badge accion-badge--{{ getAccionClass(item.accion) }}">
+                {{ item.accion }}
+              </span>
+            </td>
+            <td class="historial-page__fecha">
+              {{ item.fecha | date:'dd/MM/yyyy HH:mm' }}
+            </td>
+            <td class="historial-page__ip">{{ item.ip }}</td>
+            <td class="historial-page__detalles">{{ item.detalles }}</td>
+          </tr>
+        } @empty {
+          <tr>
+            <td colspan="5" class="historial-page__empty-cell">
+              <restaurant-empty-state
+                title="Sin actividad registrada"
+                message="No se encontraron registros con los filtros aplicados."
+              ></restaurant-empty-state>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </restaurant-data-table>
+  }
+
+</div>

--- a/libs/auth/usuarios/src/lib/pages/historial-page/historial-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/historial-page/historial-page.component.scss
@@ -1,0 +1,88 @@
+.historial-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: var(--space-6);
+
+  &__filters {
+    display: flex;
+    gap: var(--space-4);
+    align-items: flex-end;
+    flex-wrap: wrap;
+  }
+
+  &__user {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  &__user-name {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+    margin: 0;
+  }
+
+  &__user-email {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  &__fecha,
+  &__ip {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+  }
+
+  &__detalles {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-primary);
+    max-width: 240px;
+  }
+
+  &__empty-cell {
+    padding: var(--space-8);
+    text-align: center;
+  }
+}
+
+.accion-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+
+  &--login {
+    background: var(--color-success-bg);
+    color: var(--color-success-text);
+  }
+
+  &--logout {
+    background: var(--color-superficie-contenedor);
+    color: var(--color-text-secondary);
+  }
+
+  &--crear {
+    background: var(--color-info-bg);
+    color: var(--color-info-text);
+  }
+
+  &--editar {
+    background: var(--color-warning-bg);
+    color: var(--color-warning-text);
+  }
+
+  &--eliminar,
+  &--bloqueo {
+    background: var(--color-error-bg);
+    color: var(--color-error-text);
+  }
+}

--- a/libs/auth/usuarios/src/lib/pages/historial-page/historial-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/historial-page/historial-page.component.ts
@@ -1,0 +1,77 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { DatePipe } from '@angular/common';
+import {
+  DataTableComponent,
+  EmptyStateComponent,
+  LoadingSkeletonComponent,
+  LucideIconComponent,
+  PageHeaderComponent,
+  SearchFilterComponent,
+  SelectFilterComponent,
+} from '@restaurant/shared/ui';
+import { UsuariosFacade } from '../../data-access/usuarios.facade';
+import { HistorialItem } from '../../models/usuarios.model';
+
+@Component({
+  selector: 'restaurant-historial-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DatePipe,
+    DataTableComponent,
+    EmptyStateComponent,
+    LoadingSkeletonComponent,
+    LucideIconComponent,
+    PageHeaderComponent,
+    SearchFilterComponent,
+    SelectFilterComponent,
+  ],
+  templateUrl: './historial-page.component.html',
+  styleUrl:    './historial-page.component.scss',
+})
+export class HistorialPageComponent implements OnInit {
+  private readonly facade = inject(UsuariosFacade);
+
+  readonly historial = toSignal(this.facade.historial$,        { initialValue: [] as HistorialItem[] });
+  readonly loading   = toSignal(this.facade.loadingHistorial$, { initialValue: false });
+
+  readonly busqueda     = signal('');
+  readonly filtroAccion = signal('');
+
+  readonly accionOpciones: { value: string; label: string }[] = [
+    { value: '',         label: 'Todas las acciones' },
+    { value: 'LOGIN',    label: 'Inicio de sesión'   },
+    { value: 'LOGOUT',   label: 'Cierre de sesión'   },
+    { value: 'CREAR',    label: 'Creación'            },
+    { value: 'EDITAR',   label: 'Edición'             },
+    { value: 'ELIMINAR', label: 'Eliminación'         },
+    { value: 'BLOQUEO',  label: 'Bloqueo'             },
+  ];
+
+  readonly historialFiltrado = computed(() => {
+    const q      = this.busqueda().toLowerCase();
+    const accion = this.filtroAccion();
+    return this.historial().filter(item => {
+      const matchBusq   = !q || item.usuarioNombre.toLowerCase().includes(q) ||
+                                item.usuarioEmail.toLowerCase().includes(q);
+      const matchAccion = !accion || item.accion === accion;
+      return matchBusq && matchAccion;
+    });
+  });
+
+  ngOnInit(): void {
+    this.facade.cargarHistorial();
+  }
+
+  getAccionClass(accion: string): string {
+    return accion.toLowerCase();
+  }
+}

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.html
@@ -1,59 +1,85 @@
 <div class="roles-page">
 
-  <!-- Header -->
-  <div class="roles-page__header">
-    <div class="roles-page__header-text">
-      <h1 class="roles-page__title">Roles y Permisos</h1>
-      <p class="roles-page__subtitle">Configuración de accesos por rol del sistema</p>
-    </div>
-    <div class="roles-page__header-stats">
-      <span class="roles-page__stat">
-        <lucide-icon name="shield" [size]="16"></lucide-icon>
-        {{ totalRoles }} roles definidos
-      </span>
-      <span class="roles-page__stat">
-        <lucide-icon name="users" [size]="16"></lucide-icon>
-        {{ totalUsuarios }} usuarios activos
-      </span>
-    </div>
+  <restaurant-page-header
+    title="Roles del Sistema"
+    subtitle="Permisos y alcance de cada rol del restaurante"
+  ></restaurant-page-header>
+
+  @if (error()) {
+    <restaurant-alert type="error" [message]="error()!"></restaurant-alert>
+  }
+
+  <!-- KPI Cards -->
+  <div class="roles-page__kpis">
+    <restaurant-kpi-card
+      label="Total Roles"
+      [value]="totalRoles().toString()"
+      icon="shield"
+      iconColor="blue"
+    ></restaurant-kpi-card>
+    <restaurant-kpi-card
+      label="Total Permisos"
+      [value]="totalPermisos().toString()"
+      icon="key"
+      iconColor="orange"
+    ></restaurant-kpi-card>
   </div>
+
+  <!-- Búsqueda -->
+  <restaurant-search-filter
+    label="Filtrar roles"
+    placeholder="Buscar por nombre o descripción..."
+    [value]="busqueda()"
+    (valueChange)="busqueda.set($event)"
+  ></restaurant-search-filter>
 
   <!-- Grid de roles -->
-  <div class="roles-page__grid">
-    @for (item of roles; track item.rol) {
-      <div class="roles-page__card roles-page__card--{{ getRolClass(item.rol) }}">
+  @if (loading()) {
+    <restaurant-loading-skeleton [lines]="6"></restaurant-loading-skeleton>
+  } @else {
+    <div class="roles-page__grid">
+      @for (r of rolesFiltrados(); track r.id) {
+        <div class="roles-page__card roles-page__card--{{ getRolClass(r.nombre) }}">
 
-        <!-- Card header -->
-        <div class="roles-page__card-header">
-          <div class="roles-page__card-icon">
-            <lucide-icon [name]="item.icono" [size]="22"></lucide-icon>
+          <!-- Card header -->
+          <div class="roles-page__card-header">
+            <div class="roles-page__card-icon">
+              <lucide-icon [name]="getIcono(r.nombre)" [size]="22"></lucide-icon>
+            </div>
+            <div class="roles-page__card-meta">
+              <h3 class="roles-page__card-title">{{ r.nombre }}</h3>
+              <p class="roles-page__card-desc">{{ r.descripcion }}</p>
+            </div>
           </div>
-          <div class="roles-page__card-meta">
-            <h3 class="roles-page__card-title">{{ item.rol }}</h3>
-            <p class="roles-page__card-desc">{{ item.descripcion }}</p>
+
+          <!-- Permisos -->
+          <ul class="roles-page__permisos">
+            @for (p of r.permisos; track p.id) {
+              <li class="roles-page__permiso">
+                <lucide-icon name="check" [size]="13" class="roles-page__permiso-icon"></lucide-icon>
+                <span>{{ p.nombre }}</span>
+              </li>
+            }
+          </ul>
+
+          <!-- Footer -->
+          <div class="roles-page__card-footer">
+            <lucide-icon name="users" [size]="14" class="roles-page__footer-icon"></lucide-icon>
+            <span class="roles-page__footer-label">
+              {{ r.totalUsuarios }} usuario{{ r.totalUsuarios === 1 ? '' : 's' }}
+            </span>
           </div>
+
         </div>
-
-        <!-- Permisos -->
-        <ul class="roles-page__permisos">
-          @for (permiso of item.permisos; track permiso) {
-            <li class="roles-page__permiso">
-              <lucide-icon name="check" [size]="13" class="roles-page__permiso-icon"></lucide-icon>
-              <span>{{ permiso }}</span>
-            </li>
-          }
-        </ul>
-
-        <!-- Footer -->
-        <div class="roles-page__card-footer">
-          <lucide-icon name="users" [size]="14" class="roles-page__footer-icon"></lucide-icon>
-          <span class="roles-page__footer-label">
-            {{ item.totalUsuarios }} usuario{{ item.totalUsuarios === 1 ? '' : 's' }}
-          </span>
+      } @empty {
+        <div class="roles-page__empty-cell">
+          <restaurant-empty-state
+            title="Sin resultados"
+            message="No se encontraron roles que coincidan con la búsqueda."
+          ></restaurant-empty-state>
         </div>
-
-      </div>
-    }
-  </div>
+      }
+    </div>
+  }
 
 </div>

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.scss
@@ -2,53 +2,18 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
+  padding: var(--space-6);
 
-  // ── Header ────────────────────────────────────────────────────────────────
+  // ── KPI Cards ─────────────────────────────────────────────────────────────
 
-  &__header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
+  &__kpis {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     gap: var(--space-4);
-    flex-wrap: wrap;
-  }
 
-  &__header-text {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-  }
-
-  &__title {
-    font-family: var(--font-family-headline);
-    font-size: var(--font-size-2xl);
-    font-weight: var(--font-weight-bold);
-    color: var(--color-text-heading);
-    margin: 0;
-  }
-
-  &__subtitle {
-    font-size: var(--font-size-sm);
-    color: var(--color-text-secondary);
-    margin: 0;
-  }
-
-  &__header-stats {
-    display: flex;
-    gap: var(--space-4);
-    flex-wrap: wrap;
-  }
-
-  &__stat {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    font-size: var(--font-size-sm);
-    color: var(--color-text-secondary);
-    background: var(--color-superficie-contenedor-bajo);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-full);
-    padding: var(--space-1) var(--space-3);
+    @media (max-width: 480px) {
+      grid-template-columns: 1fr;
+    }
   }
 
   // ── Grid ──────────────────────────────────────────────────────────────────
@@ -65,6 +30,10 @@
     @media (max-width: 640px) {
       grid-template-columns: 1fr;
     }
+  }
+
+  &__empty-cell {
+    grid-column: 1 / -1;
   }
 
   // ── Card ──────────────────────────────────────────────────────────────────
@@ -99,6 +68,8 @@
     &--bartender  { --card-accent: var(--color-rol-bartender); }
     &--auxiliar   { --card-accent: var(--color-rol-auxiliar); }
     &--cajero     { --card-accent: var(--color-rol-cajero); }
+    &--admin-cocina { --card-accent: var(--color-rol-chef); }
+    &--admin-bar    { --card-accent: var(--color-rol-lider-bar); }
   }
 
   &__card-header {

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.ts
@@ -1,98 +1,87 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
 } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { Rol } from '@restaurant/shared/models';
-import { LucideIconComponent } from '@restaurant/shared/ui';
-import { getRolClass } from '../../util/rol-class.util';
+import {
+  AlertComponent,
+  EmptyStateComponent,
+  KpiCardComponent,
+  LoadingSkeletonComponent,
+  LucideIconComponent,
+  PageHeaderComponent,
+  SearchFilterComponent,
+} from '@restaurant/shared/ui';
+import { ROL_CLASS_MAP } from '../../util/rol-class.util';
+import { UsuariosFacade } from '../../data-access/usuarios.facade';
+import { RolDetalle } from '../../models/usuarios.model';
 
-interface RolInfo {
-  readonly rol:           Rol;
-  readonly icono:         string;
-  readonly descripcion:   string;
-  readonly permisos:      readonly string[];
-  readonly totalUsuarios: number;
-}
-
-const MOCK_ROLES: readonly RolInfo[] = [
-  {
-    rol: Rol.ADMINISTRADOR,
-    icono: 'shield',
-    descripcion: 'Acceso total al sistema',
-    permisos: ['Gestión de usuarios', 'Reportes completos', 'Configuración del sistema', 'Inventario', 'Caja'],
-    totalUsuarios: 1,
-  },
-  {
-    rol: Rol.CONTADORA,
-    icono: 'banknote',
-    descripcion: 'Gestión financiera y reportes',
-    permisos: ['Reportes financieros', 'Presupuesto', 'Facturas', 'Caja'],
-    totalUsuarios: 1,
-  },
-  {
-    rol: Rol.INSTRUCTOR,
-    icono: 'graduation-cap',
-    descripcion: 'Gestión académica y evaluaciones',
-    permisos: ['Evaluaciones', 'Actividades', 'Recetas', 'Reportes académicos'],
-    totalUsuarios: 2,
-  },
-  {
-    rol: Rol.CHEF,
-    icono: 'chef-hat',
-    descripcion: 'Operaciones de cocina',
-    permisos: ['Comandas', 'Recetas', 'Menú', 'Ingredientes'],
-    totalUsuarios: 3,
-  },
-  {
-    rol: Rol.LIDER_BAR,
-    icono: 'coffee',
-    descripcion: 'Operaciones de bar y barismo',
-    permisos: ['Comandas bar', 'Recetas bebidas', 'Menú bar'],
-    totalUsuarios: 1,
-  },
-  {
-    rol: Rol.MESERO,
-    icono: 'utensils',
-    descripcion: 'Atención al cliente',
-    permisos: ['Mesas', 'Pedidos', 'Comandas'],
-    totalUsuarios: 3,
-  },
-  {
-    rol: Rol.BARTENDER,
-    icono: 'glass-water',
-    descripcion: 'Preparación de bebidas',
-    permisos: ['Comandas bar', 'Recetas bebidas'],
-    totalUsuarios: 2,
-  },
-  {
-    rol: Rol.AUXILIAR_COCINA,
-    icono: 'package',
-    descripcion: 'Apoyo en operaciones de cocina',
-    permisos: ['Comandas', 'Ingredientes'],
-    totalUsuarios: 2,
-  },
-  {
-    rol: Rol.CAJERO,
-    icono: 'calculator',
-    descripcion: 'Gestión de caja y pagos',
-    permisos: ['Caja', 'Pagos', 'Facturas'],
-    totalUsuarios: 2,
-  },
-];
+const ICONO_MAP: Record<string, string> = {
+  ADMINISTRADOR:   'shield',
+  CONTADORA:       'banknote',
+  INSTRUCTOR:      'graduation-cap',
+  CHEF:            'chef-hat',
+  LIDER_BAR:       'coffee',
+  MESERO:          'utensils',
+  BARTENDER:       'glass-water',
+  AUXILIAR_COCINA: 'package',
+  CAJERO:          'calculator',
+  ADMIN_COCINA:    'chef-hat',
+  ADMIN_BAR:       'coffee',
+};
 
 @Component({
   selector: 'restaurant-roles-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [LucideIconComponent],
+  imports: [
+    AlertComponent,
+    EmptyStateComponent,
+    KpiCardComponent,
+    LoadingSkeletonComponent,
+    LucideIconComponent,
+    PageHeaderComponent,
+    SearchFilterComponent,
+  ],
   templateUrl: './roles-page.component.html',
   styleUrl:    './roles-page.component.scss',
 })
-export class RolesPageComponent {
-  readonly roles = MOCK_ROLES;
+export class RolesPageComponent implements OnInit {
+  private readonly facade = inject(UsuariosFacade);
 
-  readonly totalUsuarios = MOCK_ROLES.reduce((sum, r) => sum + r.totalUsuarios, 0);
-  readonly totalRoles    = MOCK_ROLES.length;
+  readonly roles   = toSignal(this.facade.rolesDetalle$,        { initialValue: [] as RolDetalle[] });
+  readonly loading = toSignal(this.facade.loadingRolesDetalle$, { initialValue: false });
+  readonly error   = toSignal(this.facade.error$,               { initialValue: null });
 
-  readonly getRolClass = getRolClass;
+  readonly busqueda = signal('');
+
+  readonly rolesFiltrados = computed(() => {
+    const q = this.busqueda().toLowerCase();
+    if (!q) return this.roles();
+    return this.roles().filter(r =>
+      r.nombre.toLowerCase().includes(q) || r.descripcion.toLowerCase().includes(q)
+    );
+  });
+
+  readonly totalRoles    = computed(() => this.roles().length);
+  readonly totalPermisos = computed(() =>
+    this.roles().reduce((sum, r) => sum + r.permisos.length, 0)
+  );
+
+  ngOnInit(): void {
+    this.facade.cargarRolesDetalle();
+  }
+
+  getRolClass(nombre: string): string {
+    return ROL_CLASS_MAP[nombre as Rol] ?? 'default';
+  }
+
+  getIcono(nombre: string): string {
+    return ICONO_MAP[nombre] ?? 'shield';
+  }
 }

--- a/libs/auth/usuarios/src/lib/usuarios.routes.ts
+++ b/libs/auth/usuarios/src/lib/usuarios.routes.ts
@@ -35,4 +35,11 @@ export const USUARIOS_ROUTES: Routes = [
         m => m.HistorialPageComponent,
       ),
   },
+  {
+    path: 'roles',
+    loadComponent: () =>
+      import('./pages/roles-page/roles-page.component').then(
+        m => m.RolesPageComponent,
+      ),
+  },
 ];

--- a/libs/auth/usuarios/src/lib/usuarios.routes.ts
+++ b/libs/auth/usuarios/src/lib/usuarios.routes.ts
@@ -21,4 +21,18 @@ export const USUARIOS_ROUTES: Routes = [
     redirectTo: '',
     pathMatch: 'full',
   },
+  {
+    path: 'cuentas',
+    loadComponent: () =>
+      import('./pages/cuentas-page/cuentas-page.component').then(
+        m => m.CuentasPageComponent,
+      ),
+  },
+  {
+    path: 'historial',
+    loadComponent: () =>
+      import('./pages/historial-page/historial-page.component').then(
+        m => m.HistorialPageComponent,
+      ),
+  },
 ];


### PR DESCRIPTION
…acade

## Descripción
Implementa las vistas pendientes del módulo usuarios listas
para conectar el backend.

## Tipo de cambio
- [x] `feat` — nueva funcionalidad

## Scope
- [x] `auth` · [x] `usuarios`

## Checklist obligatorio
- [x] `nx affected:lint --base=develop` → 0 errores
- [x] PR tiene menos de 400 líneas modificadas
- [x] Un solo scope tocado
- [x] Sin `any` en TypeScript
- [x] Sin estilos inline en templates
- [x] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
- Implementé cuentas-page con KPIs, filtros y tabla conectada al facade
- Implementé historial-page con filtros por usuario y tipo de acción
- Agregué HistorialItem al modelo, getHistorial() al service
- Agregué actions, reducer, selectors, effects y facade para historial
- Agregué rutas lazy para cuentas e historial en usuarios.routes.ts

## RF relacionado
HU2.1.3 — Gestión de cuentas
HU2.7 — Historial de actividades