### PR TITLE
feat(auth): agregar columnas ficha, programa y permisos + vistas cuentas, roles e historial

### DIFF
--- a/libs/auth/usuarios/src/lib/data-access/store/actions/usuarios.actions.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/actions/usuarios.actions.ts
@@ -2,6 +2,7 @@ import { createActionGroup, emptyProps, props } from '@ngrx/store';
 import { PaginatedResponse } from '@restaurant/shared/models';
 import {
   ActualizarUsuarioRequest,
+  AsignacionMasivaRequest,
   CrearUsuarioRequest,
   ExportarConfig,
   FiltrosUsuarios,
@@ -70,6 +71,11 @@ export const UsuariosActions = createActionGroup({
     'Cargar Roles Detalle':         emptyProps(),
     'Cargar Roles Detalle Exitoso': props<{ roles: RolDetalle[] }>(),
     'Cargar Roles Detalle Fallido': props<{ error: string }>(),
+
+    // ── Asignación masiva de rol ──────────────────────────────────────────────
+    'Asignar Rol Masivo':           props<{ request: AsignacionMasivaRequest }>(),
+    'Asignar Rol Masivo Exitoso':   emptyProps(),
+    'Asignar Rol Masivo Fallido':   props<{ error: string }>(),
 
     // ── Historial ─────────────────────────────────────────────────────────────
     'Cargar Historial':             emptyProps(),

--- a/libs/auth/usuarios/src/lib/data-access/store/effects/usuarios.effects.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/effects/usuarios.effects.ts
@@ -195,6 +195,22 @@ export const cargarRolesDetalle$ = createEffect(
   { functional: true },
 );
 
+export const asignarRolMasivo$ = createEffect(
+  (actions$ = inject(Actions), svc = inject(UsuariosService)) =>
+    actions$.pipe(
+      ofType(UsuariosActions.asignarRolMasivo),
+      concatMap(({ request }) =>
+        svc.asignarRolMasivo(request).pipe(
+          map(() => UsuariosActions.asignarRolMasivoExitoso()),
+          catchError((err: unknown) =>
+            of(UsuariosActions.asignarRolMasivoFallido({ error: extractErrorMessage(err) })),
+          ),
+        ),
+      ),
+    ),
+  { functional: true },
+);
+
 export const cargarHistorial$ = createEffect(
   (actions$ = inject(Actions), svc = inject(UsuariosService)) =>
     actions$.pipe(

--- a/libs/auth/usuarios/src/lib/data-access/store/reducers/usuarios.reducer.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/reducers/usuarios.reducer.ts
@@ -24,6 +24,7 @@ export interface UsuariosState {
   loadingHistorial:    boolean;
   rolesDetalle:        RolDetalle[];
   loadingRolesDetalle: boolean;
+  loadingAsignacion:   boolean;
 }
 
 const initialState: UsuariosState = {
@@ -43,6 +44,7 @@ const initialState: UsuariosState = {
   loadingHistorial:    false,
   rolesDetalle:        [],
   loadingRolesDetalle: false,
+  loadingAsignacion:   false,
 };
 
 export const usuariosFeature = createFeature({
@@ -186,6 +188,17 @@ export const usuariosFeature = createFeature({
     })),
     on(UsuariosActions.cargarRolesDetalleFallido, (state, { error }) => ({
       ...state, loadingRolesDetalle: false, error,
+    })),
+
+    // ── Asignación masiva de rol ──────────────────────────────────────────────
+    on(UsuariosActions.asignarRolMasivo, state => ({
+      ...state, loadingAsignacion: true, error: null,
+    })),
+    on(UsuariosActions.asignarRolMasivoExitoso, state => ({
+      ...state, loadingAsignacion: false,
+    })),
+    on(UsuariosActions.asignarRolMasivoFallido, (state, { error }) => ({
+      ...state, loadingAsignacion: false, error,
     })),
 
     // ── Historial ─────────────────────────────────────────────────────────────

--- a/libs/auth/usuarios/src/lib/data-access/store/selectors/usuarios.selectors.ts
+++ b/libs/auth/usuarios/src/lib/data-access/store/selectors/usuarios.selectors.ts
@@ -18,6 +18,7 @@ export const {
   selectLoadingHistorial,
   selectRolesDetalle,
   selectLoadingRolesDetalle,
+  selectLoadingAsignacion,
 } = usuariosFeature;
 
 export const selectTotalActivos = createSelector(

--- a/libs/auth/usuarios/src/lib/data-access/usuarios.facade.ts
+++ b/libs/auth/usuarios/src/lib/data-access/usuarios.facade.ts
@@ -3,6 +3,7 @@ import { Store } from '@ngrx/store';
 import { AppState } from '@restaurant/shared/state';
 import {
   ActualizarUsuarioRequest,
+  AsignacionMasivaRequest,
   CrearUsuarioRequest,
   ExportarConfig,
   FiltrosUsuarios,
@@ -18,6 +19,7 @@ import {
   selectImportando,
   selectLoading,
   selectLoadingAccion,
+  selectLoadingAsignacion,
   selectLoadingHistorial,
   selectLoadingRolesDetalle,
   selectMensajeExport,
@@ -55,6 +57,7 @@ export class UsuariosFacade {
   readonly loadingHistorial$    = this.store.select(selectLoadingHistorial);
   readonly rolesDetalle$        = this.store.select(selectRolesDetalle);
   readonly loadingRolesDetalle$ = this.store.select(selectLoadingRolesDetalle);
+  readonly loadingAsignacion$   = this.store.select(selectLoadingAsignacion);
 
   // ── Comandos ──────────────────────────────────────────────────────────────
   cargarUsuarios(filtros?: Partial<FiltrosUsuarios>): void {
@@ -111,5 +114,9 @@ export class UsuariosFacade {
 
   cargarRolesDetalle(): void {
     this.store.dispatch(UsuariosActions.cargarRolesDetalle());
+  }
+
+  asignarRolMasivo(request: AsignacionMasivaRequest): void {
+    this.store.dispatch(UsuariosActions.asignarRolMasivo({ request }));
   }
 }

--- a/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
+++ b/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
@@ -5,6 +5,7 @@ import { BaseHttpService } from '@restaurant/shared/api';
 import { PaginatedResponse } from '@restaurant/shared/models';
 import {
   ActualizarUsuarioRequest,
+  AsignacionMasivaRequest,
   CrearUsuarioRequest,
   ExportarConfig,
   FiltrosUsuarios,
@@ -73,6 +74,10 @@ export class UsuariosService extends BaseHttpService {
       this.buildUrl(`${this.resource}/importar`),
       formData,
     );
+  }
+
+  asignarRolMasivo(request: AsignacionMasivaRequest): Observable<void> {
+    return this.http.put<void>(this.buildUrl(`${this.resource}/roles/masivo`), request);
   }
 
   getHistorial(): Observable<HistorialItem[]> {

--- a/libs/auth/usuarios/src/lib/models/usuarios.model.ts
+++ b/libs/auth/usuarios/src/lib/models/usuarios.model.ts
@@ -7,6 +7,9 @@ export interface UsuarioDetalle extends Usuario {
   ultimoAcceso:     string | null;
   cuentaBloqueada:  boolean;
   intentosFallidos: number;
+  ficha?:           string;
+  programa?:        string;
+  totalPermisos?:   number;
 }
 
 export interface CrearUsuarioRequest {
@@ -73,6 +76,11 @@ export interface RolDetalle {
   descripcion:   string;
   permisos:      PermisoItem[];
   totalUsuarios: number;
+}
+
+export interface AsignacionMasivaRequest {
+  usuarioIds: string[];
+  idRol:      string;
 }
 
 export interface HistorialItem {

--- a/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.html
@@ -27,32 +27,26 @@
 
   <!-- Filtros -->
   <div class="cuentas-page__filters">
-    <button
-      class="cuentas-page__filter-btn"
-      [class.cuentas-page__filter-btn--active]="filtroEstado() === 'todos'"
-      type="button"
-      (click)="filtroEstado.set('todos')"
-    >
-      Todos
-    </button>
-    <button
-      class="cuentas-page__filter-btn"
-      [class.cuentas-page__filter-btn--active]="filtroEstado() === 'bloqueados'"
-      type="button"
-      (click)="filtroEstado.set('bloqueados')"
-    >
-      <lucide-icon name="lock" [size]="14"></lucide-icon>
-      Bloqueados
-    </button>
-    <button
-      class="cuentas-page__filter-btn"
-      [class.cuentas-page__filter-btn--active]="filtroEstado() === 'activos'"
-      type="button"
-      (click)="filtroEstado.set('activos')"
-    >
-      <lucide-icon name="shield-check" [size]="14"></lucide-icon>
-      Activos
-    </button>
+    <div class="cuentas-page__search-wrapper">
+      <lucide-icon name="search" [size]="16" class="cuentas-page__search-icon"></lucide-icon>
+      <input
+        class="cuentas-page__search-input"
+        type="text"
+        placeholder="Buscar por nombre o email..."
+        [value]="busqueda()"
+        (input)="busqueda.set($any($event.target).value)"
+      >
+    </div>
+    <div class="cuentas-page__filter-selects">
+      <div class="cuentas-page__select-wrapper">
+        <select class="cuentas-page__select" (change)="filtroEstado.set($any($event.target).value)">
+          <option value="todos">Todos</option>
+          <option value="bloqueados">Bloqueados</option>
+          <option value="activos">Activos</option>
+        </select>
+        <lucide-icon name="filter" [size]="14" class="cuentas-page__select-icon"></lucide-icon>
+      </div>
+    </div>
   </div>
 
   @if (loading()) {

--- a/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.scss
@@ -14,41 +14,93 @@
     }
   }
 
+  // ── Filtros ───────────────────────────────────────────────────────────────
+
   &__filters {
     display: flex;
-    gap: var(--space-2);
     align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-superficie-contenedor-bajo);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
     flex-wrap: wrap;
   }
 
-  &__filter-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    padding: var(--space-2) var(--space-4);
+  &__search-wrapper {
+    position: relative;
+    flex: 1;
+    min-width: 200px;
+  }
+
+  &__search-icon {
+    position: absolute;
+    left: var(--space-3);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-text-secondary);
+    pointer-events: none;
+  }
+
+  &__search-input {
+    width: 100%;
+    padding: var(--space-2) var(--space-3) var(--space-2) calc(var(--space-3) + 16px + var(--space-2));
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
-    background: transparent;
-    color: var(--color-text-secondary);
+    background: var(--color-surface-primary);
+    color: var(--color-text-primary);
     font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
     font-family: var(--font-family-base);
-    cursor: pointer;
-    transition: background var(--duration-fast) var(--ease-standard),
-                color       var(--duration-fast) var(--ease-standard),
-                border-color var(--duration-fast) var(--ease-standard);
+    box-sizing: border-box;
 
-    &--active {
-      background: var(--color-primario);
-      color: var(--color-en-primario);
-      border-color: var(--color-primario);
-    }
+    &::placeholder { color: var(--color-text-secondary); }
 
-    &:not(&--active):hover {
-      background: var(--color-superficie-contenedor);
-      color: var(--color-text-primary);
+    &:focus {
+      outline: 2px solid var(--color-primario);
+      outline-offset: 2px;
+      border-color: transparent;
     }
   }
+
+  &__filter-selects {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  &__select-wrapper {
+    position: relative;
+  }
+
+  &__select {
+    appearance: none;
+    padding: var(--space-2) calc(var(--space-3) + 14px + var(--space-2)) var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-primary);
+    color: var(--color-text-primary);
+    font-size: var(--font-size-sm);
+    font-family: var(--font-family-base);
+    cursor: pointer;
+
+    &:focus {
+      outline: 2px solid var(--color-primario);
+      outline-offset: 2px;
+      border-color: transparent;
+    }
+  }
+
+  &__select-icon {
+    position: absolute;
+    right: var(--space-3);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-text-secondary);
+    pointer-events: none;
+  }
+
+  // ── Tabla ─────────────────────────────────────────────────────────────────
 
   &__user {
     display: flex;

--- a/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/cuentas-page/cuentas-page.component.ts
@@ -22,8 +22,6 @@ import { UsuarioRolBadgeComponent } from '../../components/usuario-rol-badge/usu
 import { UsuariosFacade } from '../../data-access/usuarios.facade';
 import { UsuarioDetalle } from '../../models/usuarios.model';
 
-type FiltroEstado = 'todos' | 'bloqueados' | 'activos';
-
 @Component({
   selector: 'restaurant-cuentas-page',
   standalone: true,
@@ -50,18 +48,27 @@ export class CuentasPageComponent implements OnInit {
   readonly loading  = toSignal(this.facade.loading$,  { initialValue: false });
   readonly error    = toSignal(this.facade.error$,    { initialValue: null });
 
-  readonly filtroEstado = signal<FiltroEstado>('todos');
+  readonly filtroEstado = signal<'todos' | 'bloqueados' | 'activos'>('todos');
+  readonly busqueda     = signal('');
 
   readonly usuariosFiltrados = computed(() => {
-    const estado = this.filtroEstado();
-    const todos  = this.usuarios();
-    if (estado === 'bloqueados') return todos.filter(u => u.cuentaBloqueada);
-    if (estado === 'activos')    return todos.filter(u => !u.cuentaBloqueada);
-    return todos;
+    const filtro = this.filtroEstado();
+    const q      = this.busqueda().toLowerCase();
+    return this.usuarios().filter(u => {
+      const matchBusq = !q ||
+        u.nombre.toLowerCase().includes(q) ||
+        u.apellidos.toLowerCase().includes(q) ||
+        u.email.toLowerCase().includes(q);
+      const matchEstado =
+        filtro === 'todos'       ||
+        (filtro === 'bloqueados' &&  u.cuentaBloqueada) ||
+        (filtro === 'activos'    && !u.cuentaBloqueada);
+      return matchBusq && matchEstado;
+    });
   });
 
   readonly totalBloqueadas = computed(() =>
-    this.usuarios().filter(u => u.cuentaBloqueada).length
+    this.usuarios().filter(u =>  u.cuentaBloqueada).length
   );
 
   readonly totalActivas = computed(() =>

--- a/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.html
@@ -53,18 +53,35 @@
 
   <!-- Filtros -->
   <div class="lista-page__filters">
-    <restaurant-search-filter
-      label="Buscar"
-      placeholder="Nombre, email o documento..."
-      [value]="busqueda()"
-      (valueChange)="busqueda.set($event)"
-    ></restaurant-search-filter>
-    <restaurant-select-filter
-      label="Rol"
-      [value]="rolFiltro()"
-      [options]="rolOpciones()"
-      (valueChange)="rolFiltro.set($event)"
-    ></restaurant-select-filter>
+    <div class="lista-page__search-wrapper">
+      <lucide-icon name="search" [size]="16" class="lista-page__search-icon"></lucide-icon>
+      <input
+        class="lista-page__search-input"
+        type="text"
+        placeholder="Buscar por nombre o email..."
+        [value]="busqueda()"
+        (input)="busqueda.set($any($event.target).value)"
+      >
+    </div>
+    <div class="lista-page__filter-selects">
+      <div class="lista-page__select-wrapper">
+        <select class="lista-page__select" (change)="rolFiltro.set($any($event.target).value)">
+          <option value="">Todos los roles</option>
+          @for (rol of rolesDisponibles; track rol) {
+            <option [value]="rol">{{ rol }}</option>
+          }
+        </select>
+        <lucide-icon name="filter" [size]="14" class="lista-page__select-icon"></lucide-icon>
+      </div>
+      <div class="lista-page__select-wrapper">
+        <select class="lista-page__select" (change)="estadoFiltro.set($any($event.target).value)">
+          <option value="todos">Todos</option>
+          <option value="activos">Activos</option>
+          <option value="inactivos">Inactivos</option>
+        </select>
+        <lucide-icon name="filter" [size]="14" class="lista-page__select-icon"></lucide-icon>
+      </div>
+    </div>
   </div>
 
   <!-- Tabla -->

--- a/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.scss
@@ -84,9 +84,86 @@
 
   &__filters {
     display: flex;
-    gap: var(--space-4);
-    align-items: flex-end;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-superficie-contenedor-bajo);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
     flex-wrap: wrap;
+  }
+
+  &__search-wrapper {
+    position: relative;
+    flex: 1;
+    min-width: 200px;
+  }
+
+  &__search-icon {
+    position: absolute;
+    left: var(--space-3);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-text-secondary);
+    pointer-events: none;
+  }
+
+  &__search-input {
+    width: 100%;
+    padding: var(--space-2) var(--space-3) var(--space-2) calc(var(--space-3) + 16px + var(--space-2));
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-primary);
+    color: var(--color-text-primary);
+    font-size: var(--font-size-sm);
+    font-family: var(--font-family-base);
+    box-sizing: border-box;
+
+    &::placeholder { color: var(--color-text-secondary); }
+
+    &:focus {
+      outline: 2px solid var(--color-primario);
+      outline-offset: 2px;
+      border-color: transparent;
+    }
+  }
+
+  &__filter-selects {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  &__select-wrapper {
+    position: relative;
+  }
+
+  &__select {
+    appearance: none;
+    padding: var(--space-2) calc(var(--space-3) + 14px + var(--space-2)) var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-primary);
+    color: var(--color-text-primary);
+    font-size: var(--font-size-sm);
+    font-family: var(--font-family-base);
+    cursor: pointer;
+
+    &:focus {
+      outline: 2px solid var(--color-primario);
+      outline-offset: 2px;
+      border-color: transparent;
+    }
+  }
+
+  &__select-icon {
+    position: absolute;
+    right: var(--space-3);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-text-secondary);
+    pointer-events: none;
   }
 
   &__loading,

--- a/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/lista-page/lista-page.component.ts
@@ -14,8 +14,6 @@ import {
   DataTableComponent,
   KpiCardComponent,
   LucideIconComponent,
-  SearchFilterComponent,
-  SelectFilterComponent,
 } from '@restaurant/shared/ui';
 import { ExportarUsuariosComponent } from '../../components/exportar-usuarios/exportar-usuarios.component';
 import { ImportarUsuariosComponent } from '../../components/importar-usuarios/importar-usuarios.component';
@@ -28,7 +26,6 @@ import {
   CrearUsuarioRequest,
   ExportarConfig,
   ImportarUsuariosRequest,
-  RolOpcion,
   UsuarioDetalle,
 } from '../../models/usuarios.model';
 
@@ -65,8 +62,6 @@ const MOCK_USUARIOS: UsuarioDetalle[] = [
     DataTableComponent,
     KpiCardComponent,
     LucideIconComponent,
-    SearchFilterComponent,
-    SelectFilterComponent,
     ExportarUsuariosComponent,
     ImportarUsuariosComponent,
     UsuarioFormComponent,
@@ -88,14 +83,11 @@ export class ListaPageComponent implements OnInit {
   readonly resultadoImport = toSignal(this.facade.resultadoImport$, { initialValue: null });
   readonly mensajeExport   = toSignal(this.facade.mensajeExport$,   { initialValue: null });
 
-  private readonly roles = toSignal(this.facade.roles$, { initialValue: [] as RolOpcion[] });
-  readonly rolOpciones   = computed(() => [
-    { value: '', label: 'Todos los roles' },
-    ...this.roles().map(r => ({ value: r.idRol, label: r.nombreRol })),
-  ]);
+  readonly rolesDisponibles = Object.values(Rol);
 
-  readonly busqueda          = signal('');
-  readonly rolFiltro         = signal('');
+  readonly busqueda     = signal('');
+  readonly rolFiltro    = signal('');
+  readonly estadoFiltro = signal<'todos' | 'activos' | 'inactivos'>('todos');
   readonly mostrarExportar   = signal(false);
   readonly mostrarImportar   = signal(false);
   readonly mostrarFormulario = signal(false);
@@ -105,15 +97,19 @@ export class ListaPageComponent implements OnInit {
   private readonly usandoMock      = computed(() => this.usuarios().length === 0);
 
   readonly usuariosFiltrados = computed(() => {
-    const q   = this.busqueda().toLowerCase();
-    const rol = this.rolFiltro();
+    const q      = this.busqueda().toLowerCase();
+    const rol    = this.rolFiltro();
+    const estado = this.estadoFiltro();
     return this.usuarios().filter(u => {
-      const matchBusq = !q ||
+      const matchBusq   = !q ||
         u.nombre.toLowerCase().includes(q) ||
         u.apellidos.toLowerCase().includes(q) ||
         u.email.toLowerCase().includes(q);
-      const matchRol = !rol || u.rol === rol;
-      return matchBusq && matchRol;
+      const matchRol    = !rol || u.rol === rol;
+      const matchEstado = estado === 'todos' ||
+        (estado === 'activos'   &&  u.activo) ||
+        (estado === 'inactivos' && !u.activo);
+      return matchBusq && matchRol && matchEstado;
     });
   });
 

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.html
@@ -1,6 +1,7 @@
 <div class="roles-page">
 
   <restaurant-page-header
+<<<<<<< HEAD
     title="Roles del Sistema"
     subtitle="Permisos y alcance de cada rol del restaurante"
   ></restaurant-page-header>
@@ -58,19 +59,72 @@
               <li class="roles-page__permiso">
                 <lucide-icon name="check" [size]="13" class="roles-page__permiso-icon"></lucide-icon>
                 <span>{{ p.nombre }}</span>
+=======
+    title="Roles y Permisos"
+    subtitle="Gestión de roles de simulación para aprendices SENA"
+  ></restaurant-page-header>
+
+  <!-- KPI Cards -->
+  <div class="roles-page__kpis">
+    <restaurant-kpi-card
+      label="Total Aprendices"
+      [value]="totalAprendices().toString()"
+      icon="users"
+      iconColor="blue"
+    ></restaurant-kpi-card>
+    <restaurant-kpi-card
+      label="Con Rol Asignado"
+      [value]="totalConRol().toString()"
+      icon="shield-check"
+      iconColor="green"
+    ></restaurant-kpi-card>
+  </div>
+
+  <!-- SECCIÓN 1: Cards de roles de simulación -->
+  <section class="roles-page__section">
+    <h2 class="roles-page__section-title">Roles de Simulación</h2>
+    <div class="roles-page__grid">
+      @for (rol of rolesInfo; track rol.rol) {
+        <div class="roles-page__card roles-page__card--{{ getRolClass(rol.rol) }}">
+
+          <div class="roles-page__card-header">
+            <div class="roles-page__card-icon">
+              <lucide-icon [name]="rol.icono" [size]="22"></lucide-icon>
+            </div>
+            <div class="roles-page__card-meta">
+              <h3 class="roles-page__card-title">{{ rol.etiqueta }}</h3>
+              <p class="roles-page__card-desc">{{ rol.descripcion }}</p>
+            </div>
+          </div>
+
+          <ul class="roles-page__permisos">
+            @for (permiso of rol.permisos; track permiso) {
+              <li class="roles-page__permiso">
+                <lucide-icon name="check" [size]="13" class="roles-page__permiso-icon"></lucide-icon>
+                <span>{{ permiso }}</span>
+>>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
               </li>
             }
           </ul>
 
+<<<<<<< HEAD
           <!-- Footer -->
           <div class="roles-page__card-footer">
             <lucide-icon name="users" [size]="14" class="roles-page__footer-icon"></lucide-icon>
             <span class="roles-page__footer-label">
               {{ r.totalUsuarios }} usuario{{ r.totalUsuarios === 1 ? '' : 's' }}
+=======
+          <div class="roles-page__card-footer">
+            <lucide-icon name="users" [size]="14" class="roles-page__footer-icon"></lucide-icon>
+            <span class="roles-page__footer-label">
+              {{ conteoPorRol().get(rol.rol) ?? 0 }}
+              aprendice{{ (conteoPorRol().get(rol.rol) ?? 0) === 1 ? '' : 's' }}
+>>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
             </span>
           </div>
 
         </div>
+<<<<<<< HEAD
       } @empty {
         <div class="roles-page__empty-cell">
           <restaurant-empty-state
@@ -81,5 +135,125 @@
       }
     </div>
   }
+=======
+      }
+    </div>
+  </section>
+
+  <!-- SECCIÓN 2: Tabla de aprendices -->
+  <section class="roles-page__section">
+    <h2 class="roles-page__section-title">Aprendices</h2>
+
+    <!-- Toolbar de asignación masiva -->
+    <div class="roles-page__toolbar">
+      <label class="roles-page__check-all">
+        <input
+          class="roles-page__checkbox"
+          type="checkbox"
+          [checked]="todosSeleccionados()"
+          (change)="onToggleTodos()"
+        >
+        Seleccionar todos
+      </label>
+
+      @if (seleccionados().size > 0) {
+        <span class="roles-page__badge-count">
+          {{ seleccionados().size }} seleccionado{{ seleccionados().size === 1 ? '' : 's' }}
+        </span>
+      }
+
+      <select
+        class="roles-page__rol-select"
+        [value]="rolAsignacion()"
+        (change)="onRolChange($event)"
+      >
+        <option value="">Seleccionar rol...</option>
+        @for (r of rolesInfo; track r.rol) {
+          <option [value]="r.rol">{{ r.etiqueta }}</option>
+        }
+      </select>
+
+      <button
+        class="roles-page__asignar-btn"
+        type="button"
+        [disabled]="!puedeAsignar() || loadingAsignacion()"
+        (click)="onAsignarRol()"
+      >
+        @if (loadingAsignacion()) {
+          <lucide-icon name="loader-circle" [size]="14"></lucide-icon>
+          Asignando...
+        } @else {
+          <lucide-icon name="user-check" [size]="14"></lucide-icon>
+          Asignar Rol
+        }
+      </button>
+    </div>
+
+    @if (loading()) {
+      <restaurant-loading-skeleton [lines]="5"></restaurant-loading-skeleton>
+    } @else {
+      <restaurant-data-table>
+        <thead>
+          <tr>
+            <th class="roles-page__col-check"></th>
+            <th>Aprendiz</th>
+            <th>Rol actual</th>
+            <th>Ficha</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (u of aprendices(); track u.id) {
+            <tr [class.roles-page__row--selected]="estaSeleccionado(u.id)">
+              <td class="roles-page__col-check">
+                <input
+                  class="roles-page__checkbox"
+                  type="checkbox"
+                  [checked]="estaSeleccionado(u.id)"
+                  (change)="onToggleSeleccion(u.id)"
+                >
+              </td>
+              <td>
+                <div class="roles-page__user">
+                  <restaurant-usuario-avatar
+                    [nombre]="u.nombre"
+                    [apellidos]="u.apellidos"
+                  ></restaurant-usuario-avatar>
+                  <div>
+                    <p class="roles-page__user-name">{{ u.nombre }} {{ u.apellidos }}</p>
+                    <p class="roles-page__user-email">{{ u.email }}</p>
+                  </div>
+                </div>
+              </td>
+              <td>
+                <restaurant-usuario-rol-badge [rol]="u.rol"></restaurant-usuario-rol-badge>
+              </td>
+              <td class="roles-page__ficha">{{ u.ficha || '—' }}</td>
+              <td>
+                <button
+                  class="roles-page__action-btn"
+                  type="button"
+                  (click)="onToggleSeleccion(u.id)"
+                  [attr.aria-label]="'Seleccionar ' + u.nombre"
+                >
+                  <lucide-icon name="user-cog" [size]="16"></lucide-icon>
+                </button>
+              </td>
+            </tr>
+          } @empty {
+            <tr>
+              <td colspan="5" class="roles-page__empty-cell">
+                <restaurant-empty-state
+                  title="Sin aprendices"
+                  message="No se encontraron aprendices registrados en el sistema."
+                ></restaurant-empty-state>
+              </td>
+            </tr>
+          }
+        </tbody>
+      </restaurant-data-table>
+    }
+  </section>
+>>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
 
 </div>

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.html
@@ -1,65 +1,6 @@
 <div class="roles-page">
 
   <restaurant-page-header
-<<<<<<< HEAD
-    title="Roles del Sistema"
-    subtitle="Permisos y alcance de cada rol del restaurante"
-  ></restaurant-page-header>
-
-  @if (error()) {
-    <restaurant-alert type="error" [message]="error()!"></restaurant-alert>
-  }
-
-  <!-- KPI Cards -->
-  <div class="roles-page__kpis">
-    <restaurant-kpi-card
-      label="Total Roles"
-      [value]="totalRoles().toString()"
-      icon="shield"
-      iconColor="blue"
-    ></restaurant-kpi-card>
-    <restaurant-kpi-card
-      label="Total Permisos"
-      [value]="totalPermisos().toString()"
-      icon="key"
-      iconColor="orange"
-    ></restaurant-kpi-card>
-  </div>
-
-  <!-- Búsqueda -->
-  <restaurant-search-filter
-    label="Filtrar roles"
-    placeholder="Buscar por nombre o descripción..."
-    [value]="busqueda()"
-    (valueChange)="busqueda.set($event)"
-  ></restaurant-search-filter>
-
-  <!-- Grid de roles -->
-  @if (loading()) {
-    <restaurant-loading-skeleton [lines]="6"></restaurant-loading-skeleton>
-  } @else {
-    <div class="roles-page__grid">
-      @for (r of rolesFiltrados(); track r.id) {
-        <div class="roles-page__card roles-page__card--{{ getRolClass(r.nombre) }}">
-
-          <!-- Card header -->
-          <div class="roles-page__card-header">
-            <div class="roles-page__card-icon">
-              <lucide-icon [name]="getIcono(r.nombre)" [size]="22"></lucide-icon>
-            </div>
-            <div class="roles-page__card-meta">
-              <h3 class="roles-page__card-title">{{ r.nombre }}</h3>
-              <p class="roles-page__card-desc">{{ r.descripcion }}</p>
-            </div>
-          </div>
-
-          <!-- Permisos -->
-          <ul class="roles-page__permisos">
-            @for (p of r.permisos; track p.id) {
-              <li class="roles-page__permiso">
-                <lucide-icon name="check" [size]="13" class="roles-page__permiso-icon"></lucide-icon>
-                <span>{{ p.nombre }}</span>
-=======
     title="Roles y Permisos"
     subtitle="Gestión de roles de simulación para aprendices SENA"
   ></restaurant-page-header>
@@ -102,40 +43,19 @@
               <li class="roles-page__permiso">
                 <lucide-icon name="check" [size]="13" class="roles-page__permiso-icon"></lucide-icon>
                 <span>{{ permiso }}</span>
->>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
               </li>
             }
           </ul>
 
-<<<<<<< HEAD
-          <!-- Footer -->
-          <div class="roles-page__card-footer">
-            <lucide-icon name="users" [size]="14" class="roles-page__footer-icon"></lucide-icon>
-            <span class="roles-page__footer-label">
-              {{ r.totalUsuarios }} usuario{{ r.totalUsuarios === 1 ? '' : 's' }}
-=======
           <div class="roles-page__card-footer">
             <lucide-icon name="users" [size]="14" class="roles-page__footer-icon"></lucide-icon>
             <span class="roles-page__footer-label">
               {{ conteoPorRol().get(rol.rol) ?? 0 }}
               aprendice{{ (conteoPorRol().get(rol.rol) ?? 0) === 1 ? '' : 's' }}
->>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
             </span>
           </div>
 
         </div>
-<<<<<<< HEAD
-      } @empty {
-        <div class="roles-page__empty-cell">
-          <restaurant-empty-state
-            title="Sin resultados"
-            message="No se encontraron roles que coincidan con la búsqueda."
-          ></restaurant-empty-state>
-        </div>
-      }
-    </div>
-  }
-=======
       }
     </div>
   </section>
@@ -254,6 +174,5 @@
       </restaurant-data-table>
     }
   </section>
->>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
 
 </div>

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.scss
@@ -1,7 +1,11 @@
 .roles-page {
   display: flex;
   flex-direction: column;
+<<<<<<< HEAD
   gap: var(--space-6);
+=======
+  gap: var(--space-8);
+>>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
   padding: var(--space-6);
 
   // ── KPI Cards ─────────────────────────────────────────────────────────────
@@ -10,6 +14,7 @@
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: var(--space-4);
+<<<<<<< HEAD
 
     @media (max-width: 480px) {
       grid-template-columns: 1fr;
@@ -17,17 +22,48 @@
   }
 
   // ── Grid ──────────────────────────────────────────────────────────────────
+=======
+
+    @media (max-width: 480px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  // ── Secciones ─────────────────────────────────────────────────────────────
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  &__section-title {
+    font-family: var(--font-family-headline);
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-heading);
+    margin: 0;
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  // ── Grid de cards ─────────────────────────────────────────────────────────
+>>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
 
   &__grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-5);
+    grid-template-columns: repeat(5, 1fr);
+    gap: var(--space-4);
 
-    @media (max-width: 1024px) {
+    @media (max-width: 1200px) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    @media (max-width: 768px) {
       grid-template-columns: repeat(2, 1fr);
     }
 
-    @media (max-width: 640px) {
+    @media (max-width: 480px) {
       grid-template-columns: 1fr;
     }
   }
@@ -44,11 +80,11 @@
     background: var(--color-surface-primary);
     border-radius: var(--radius-xl);
     border: 1px solid var(--color-border);
+    border-top: 3px solid var(--card-accent);
     box-shadow: var(--shadow-sm);
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    border-top: 3px solid var(--card-accent);
     transition: box-shadow var(--duration-fast) var(--ease-standard),
                 transform   var(--duration-fast) var(--ease-standard);
 
@@ -57,15 +93,9 @@
       transform: translateY(-2px);
     }
 
-    // ── Per-role accent colors ─────────────────────────────────────────────
-
-    &--admin      { --card-accent: var(--color-rol-administrador); }
-    &--contadora  { --card-accent: var(--color-rol-contadora); }
-    &--instructor { --card-accent: var(--color-rol-instructor); }
-    &--chef       { --card-accent: var(--color-rol-chef); }
-    &--lider-bar  { --card-accent: var(--color-rol-lider-bar); }
     &--mesero     { --card-accent: var(--color-rol-mesero); }
     &--bartender  { --card-accent: var(--color-rol-bartender); }
+    &--chef       { --card-accent: var(--color-rol-chef); }
     &--auxiliar   { --card-accent: var(--color-rol-auxiliar); }
     &--cajero     { --card-accent: var(--color-rol-cajero); }
     &--admin-cocina { --card-accent: var(--color-rol-chef); }
@@ -83,8 +113,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 42px;
-    height: 42px;
+    width: 40px;
+    height: 40px;
     border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--card-accent) 12%, transparent);
     color: var(--card-accent);
@@ -97,12 +127,10 @@
   }
 
   &__card-title {
-    font-family: var(--font-family-headline);
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-semibold);
     color: var(--color-text-heading);
     margin: 0 0 var(--space-1);
-    word-break: break-word;
   }
 
   &__card-desc {
@@ -112,12 +140,12 @@
     line-height: 1.4;
   }
 
-  // ── Permisos list ─────────────────────────────────────────────────────────
+  // ── Permisos ──────────────────────────────────────────────────────────────
 
   &__permisos {
     list-style: none;
     margin: 0;
-    padding: var(--space-1) var(--space-4) var(--space-3);
+    padding: 0 var(--space-4) var(--space-3);
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
@@ -157,5 +185,148 @@
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-medium);
     color: var(--color-text-secondary);
+  }
+
+  // ── Toolbar de asignación ──────────────────────────────────────────────────
+
+  &__toolbar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-superficie-contenedor-bajo);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  &__check-all {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  &__checkbox {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: var(--color-primario);
+  }
+
+  &__badge-count {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-full);
+    background: var(--color-brand-primary-soft);
+    color: var(--color-brand-primary-strong);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+  }
+
+  &__rol-select {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-primary);
+    color: var(--color-text-primary);
+    font-size: var(--font-size-sm);
+    font-family: var(--font-family-base);
+    cursor: pointer;
+    min-width: 180px;
+
+    &:focus {
+      outline: 2px solid var(--color-primario);
+      outline-offset: 2px;
+    }
+  }
+
+  &__asignar-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-primario);
+    color: var(--color-en-primario);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    font-family: var(--font-family-base);
+    cursor: pointer;
+    transition: background var(--duration-fast) var(--ease-standard);
+    margin-left: auto;
+
+    &:hover:not(:disabled) {
+      background: var(--color-primario-hover);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  // ── Tabla ─────────────────────────────────────────────────────────────────
+
+  &__col-check {
+    width: 44px;
+  }
+
+  &__row--selected {
+    background: var(--color-brand-primary-soft);
+  }
+
+  &__user {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  &__user-name {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+    margin: 0;
+  }
+
+  &__user-email {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  &__ficha {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+  }
+
+  &__action-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: transparent;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    transition: background var(--duration-fast) var(--ease-standard),
+                color    var(--duration-fast) var(--ease-standard);
+
+    &:hover {
+      background: var(--color-superficie-contenedor);
+      color: var(--color-text-primary);
+    }
+  }
+
+  &__empty-cell {
+    text-align: center;
+    padding: var(--space-8);
   }
 }

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.scss
@@ -1,11 +1,7 @@
 .roles-page {
   display: flex;
   flex-direction: column;
-<<<<<<< HEAD
-  gap: var(--space-6);
-=======
   gap: var(--space-8);
->>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
   padding: var(--space-6);
 
   // ── KPI Cards ─────────────────────────────────────────────────────────────
@@ -14,15 +10,6 @@
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: var(--space-4);
-<<<<<<< HEAD
-
-    @media (max-width: 480px) {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  // ── Grid ──────────────────────────────────────────────────────────────────
-=======
 
     @media (max-width: 480px) {
       grid-template-columns: 1fr;
@@ -48,7 +35,6 @@
   }
 
   // ── Grid de cards ─────────────────────────────────────────────────────────
->>>>>>> d718d77 (feat(auth): mejorar filtros lista-page y cuentas-page con barra unificada)
 
   &__grid {
     display: grid;

--- a/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/roles-page/roles-page.component.ts
@@ -9,44 +9,75 @@ import {
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Rol } from '@restaurant/shared/models';
 import {
-  AlertComponent,
+  DataTableComponent,
   EmptyStateComponent,
   KpiCardComponent,
   LoadingSkeletonComponent,
   LucideIconComponent,
   PageHeaderComponent,
-  SearchFilterComponent,
 } from '@restaurant/shared/ui';
-import { ROL_CLASS_MAP } from '../../util/rol-class.util';
+import { UsuarioAvatarComponent } from '../../components/usuario-avatar/usuario-avatar.component';
+import { UsuarioRolBadgeComponent } from '../../components/usuario-rol-badge/usuario-rol-badge.component';
 import { UsuariosFacade } from '../../data-access/usuarios.facade';
-import { RolDetalle } from '../../models/usuarios.model';
+import { AsignacionMasivaRequest, UsuarioDetalle } from '../../models/usuarios.model';
+import { getRolClass } from '../../util/rol-class.util';
 
-const ICONO_MAP: Record<string, string> = {
-  ADMINISTRADOR:   'shield',
-  CONTADORA:       'banknote',
-  INSTRUCTOR:      'graduation-cap',
-  CHEF:            'chef-hat',
-  LIDER_BAR:       'coffee',
-  MESERO:          'utensils',
-  BARTENDER:       'glass-water',
-  AUXILIAR_COCINA: 'package',
-  CAJERO:          'calculator',
-  ADMIN_COCINA:    'chef-hat',
-  ADMIN_BAR:       'coffee',
-};
+interface RolSimulacionInfo {
+  readonly rol:         Rol;
+  readonly icono:       string;
+  readonly etiqueta:    string;
+  readonly descripcion: string;
+  readonly permisos:    readonly string[];
+}
+
+const ROLES_SIMULACION_INFO: readonly RolSimulacionInfo[] = [
+  {
+    rol: Rol.MESERO, icono: 'utensils', etiqueta: 'Mesero',
+    descripcion: 'Atención al cliente y toma de pedidos',
+    permisos: ['Ver mesas', 'Tomar pedidos', 'Ver comandas'],
+  },
+  {
+    rol: Rol.BARTENDER, icono: 'coffee', etiqueta: 'Bartender',
+    descripcion: 'Preparación de bebidas',
+    permisos: ['Ver comandas bar', 'Recetas bebidas'],
+  },
+  {
+    rol: Rol.CHEF, icono: 'chef-hat', etiqueta: 'Chef',
+    descripcion: 'Operaciones de cocina',
+    permisos: ['Ver comandas', 'Gestionar recetas', 'Ver menú'],
+  },
+  {
+    rol: Rol.AUXILIAR_COCINA, icono: 'package', etiqueta: 'Auxiliar Cocina',
+    descripcion: 'Apoyo en operaciones de cocina',
+    permisos: ['Ver comandas', 'Ver ingredientes'],
+  },
+  {
+    rol: Rol.CAJERO, icono: 'receipt', etiqueta: 'Cajero',
+    descripcion: 'Gestión de caja y pagos',
+    permisos: ['Gestionar caja', 'Ver facturas'],
+  },
+];
+
+const ROLES_SIMULACION_SET = new Set<string>(ROLES_SIMULACION_INFO.map(r => r.rol));
+
+const ROLES_STAFF = new Set<string>([
+  Rol.ADMINISTRADOR, Rol.CONTADORA, Rol.INSTRUCTOR,
+  Rol.LIDER_BAR, Rol.ADMIN_COCINA, Rol.ADMIN_BAR,
+]);
 
 @Component({
   selector: 'restaurant-roles-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    AlertComponent,
+    DataTableComponent,
     EmptyStateComponent,
     KpiCardComponent,
     LoadingSkeletonComponent,
     LucideIconComponent,
     PageHeaderComponent,
-    SearchFilterComponent,
+    UsuarioAvatarComponent,
+    UsuarioRolBadgeComponent,
   ],
   templateUrl: './roles-page.component.html',
   styleUrl:    './roles-page.component.scss',
@@ -54,34 +85,79 @@ const ICONO_MAP: Record<string, string> = {
 export class RolesPageComponent implements OnInit {
   private readonly facade = inject(UsuariosFacade);
 
-  readonly roles   = toSignal(this.facade.rolesDetalle$,        { initialValue: [] as RolDetalle[] });
-  readonly loading = toSignal(this.facade.loadingRolesDetalle$, { initialValue: false });
-  readonly error   = toSignal(this.facade.error$,               { initialValue: null });
+  readonly usuarios          = toSignal(this.facade.usuarios$,          { initialValue: [] as UsuarioDetalle[] });
+  readonly loading           = toSignal(this.facade.loading$,           { initialValue: false });
+  readonly loadingAsignacion = toSignal(this.facade.loadingAsignacion$, { initialValue: false });
 
-  readonly busqueda = signal('');
+  readonly rolesInfo = ROLES_SIMULACION_INFO;
 
-  readonly rolesFiltrados = computed(() => {
-    const q = this.busqueda().toLowerCase();
-    if (!q) return this.roles();
-    return this.roles().filter(r =>
-      r.nombre.toLowerCase().includes(q) || r.descripcion.toLowerCase().includes(q)
-    );
+  readonly aprendices = computed(() =>
+    this.usuarios().filter(u => !ROLES_STAFF.has(u.rol as string)),
+  );
+
+  readonly totalAprendices = computed(() => this.aprendices().length);
+  readonly totalConRol     = computed(() =>
+    this.aprendices().filter(u => ROLES_SIMULACION_SET.has(u.rol as string)).length,
+  );
+
+  readonly conteoPorRol = computed(() => {
+    const mapa = new Map<string, number>();
+    for (const u of this.aprendices()) {
+      mapa.set(u.rol as string, (mapa.get(u.rol as string) ?? 0) + 1);
+    }
+    return mapa;
   });
 
-  readonly totalRoles    = computed(() => this.roles().length);
-  readonly totalPermisos = computed(() =>
-    this.roles().reduce((sum, r) => sum + r.permisos.length, 0)
+  readonly seleccionados  = signal<Set<string>>(new Set());
+  readonly rolAsignacion  = signal('');
+
+  readonly todosSeleccionados = computed(() => {
+    const lista = this.aprendices();
+    return lista.length > 0 && lista.every(u => this.seleccionados().has(u.id));
+  });
+
+  readonly puedeAsignar = computed(() =>
+    this.seleccionados().size > 0 && this.rolAsignacion() !== '',
   );
 
   ngOnInit(): void {
-    this.facade.cargarRolesDetalle();
+    this.facade.cargarUsuarios();
   }
 
-  getRolClass(nombre: string): string {
-    return ROL_CLASS_MAP[nombre as Rol] ?? 'default';
+  onToggleSeleccion(id: string): void {
+    this.seleccionados.update(set => {
+      const next = new Set(set);
+      if (next.has(id)) { next.delete(id); } else { next.add(id); }
+      return next;
+    });
   }
 
-  getIcono(nombre: string): string {
-    return ICONO_MAP[nombre] ?? 'shield';
+  onToggleTodos(): void {
+    if (this.todosSeleccionados()) {
+      this.seleccionados.set(new Set());
+    } else {
+      this.seleccionados.set(new Set(this.aprendices().map(u => u.id)));
+    }
+  }
+
+  onRolChange(event: Event): void {
+    this.rolAsignacion.set((event.target as HTMLSelectElement).value);
+  }
+
+  onAsignarRol(): void {
+    const request: AsignacionMasivaRequest = {
+      usuarioIds: [...this.seleccionados()],
+      idRol:      this.rolAsignacion(),
+    };
+    this.facade.asignarRolMasivo(request);
+    this.seleccionados.set(new Set());
+  }
+
+  estaSeleccionado(id: string): boolean {
+    return this.seleccionados().has(id);
+  }
+
+  getRolClass(rol: string): string {
+    return getRolClass(rol as Rol);
   }
 }


### PR DESCRIPTION
…signals (#151)

## Resumen

Elimina todos los datos quemados (mock data) de las vistas de Consolidado de Ejecución, Entradas/Salidas y Requisición Diaria, reemplazándolos con `computed()` signals reactivos que se derivan de la data real del backend.

## Descripción
Completa el módulo de usuarios con columnas faltantes en la tabla
y vistas de cuentas, roles e historial conectadas al facade.

## Tipo de cambio
- [x] `feat` — nueva funcionalidad

## Scope
- [x] `auth` · [x] `usuarios`

## Checklist obligatorio
- [x] `nx affected:lint --base=develop` → 0 errores
- [x] Sin `any` en TypeScript
- [x] Sin estilos inline en templates
- [x] Solo tokens CSS var(--)

## Cambios principales
- Agregué columnas Teléfono, Ficha/Programa y Permisos a la tabla de usuarios
- Implementé cuentas-page completa conectada al facade
- Implementé historial-page completa conectada al facade
- Agregué rutas lazy para roles, cuentas e historial

## RF relacionado
HU2.1 — Gestión de usuarios
HU2.1.3 — Gestión de cuentas
HU2.7 — Historial de actividades