### PR TITLE
chore(config): agregar proxy de desarrollo para microservicios

### DIFF
--- a/apps/restaurant-app/project.json
+++ b/apps/restaurant-app/project.json
@@ -32,7 +32,8 @@
     "serve": {
       "executor": "@angular/build:dev-server",
       "options": {
-        "buildTarget": "restaurant-app:build:development"
+        "buildTarget": "restaurant-app:build:development",
+        "proxyConfig": "apps/restaurant-app/proxy.conf.json"
       }
     }
   }

--- a/apps/restaurant-app/proxy.conf.json
+++ b/apps/restaurant-app/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "http://localhost:8081",
+    "secure": false,
+    "changeOrigin": true
+  }
+}


### PR DESCRIPTION
Closes #155

## Tipo de cambio
- [x] Maintenance/tooling

## Resumen

- Se crea `apps/restaurant-app/proxy.conf.json` con la redirección de `/api` a `http://localhost:8081` (inventario)
- Se actualiza `apps/restaurant-app/project.json` para referenciar el proxy en el target `serve`
- El archivo está diseñado para escalar: cada microservicio agrega una entrada con su ruta y puerto

## Cambios

| Archivo | Cambio |
|---------|--------|
| `apps/restaurant-app/proxy.conf.json` | Nuevo — define redirección `/api` → `http://localhost:8081` |
| `apps/restaurant-app/project.json` | Agrega `proxyConfig` al target `serve` |

## Plan de prueba

- [x] `npx nx serve restaurant-app` levanta sin errores
- [x] Requests a `/api/*` se redirigen al backend en `localhost:8081`
- [x] No se modificaron servicios Angular — rutas relativas intactas

## Checklist

- [x] Vinculado a issue aprobado (#155)
- [x] Conventional commit format
- [x] Sin `Co-Authored-By`