### PR TITLE
feat(inventario): centralizar categorías de productos alimenticios

### DIFF
--- a/libs/inventario/inventario/src/lib/models/categorias.model.ts
+++ b/libs/inventario/inventario/src/lib/models/categorias.model.ts
@@ -1,0 +1,9 @@
+export const CATEGORIAS_BIEN = [
+  'Perecederos',
+  'Fruver',
+  'Abarrotes y Secos',
+  'Bebidas y Líquidos',
+  'Repostería y Congelados',
+] as const;
+
+export type CategoriaBien = (typeof CATEGORIAS_BIEN)[number];

--- a/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.ts
@@ -5,6 +5,7 @@ import {
 
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Bien, BienFormDto } from '../../../models/inventario.model';
+import { CATEGORIAS_BIEN } from '../../../models/categorias.model';
 
 @Component({
   selector: 'restaurant-bien-form',
@@ -27,10 +28,7 @@ export class BienFormComponent implements OnInit {
 
   form!: FormGroup;
 
-  readonly CATEGORIAS = [
-    'Equipos de Cómputo', 'Mobiliario', 'Papelería', 'Cocina',
-    'Audiovisuales', 'Herramientas', 'Electrodomésticos', 'Otro',
-  ];
+  readonly CATEGORIAS = CATEGORIAS_BIEN;
 
   readonly isEdit = computed(() => this.mode === 'edit');
   readonly umBloqueada = computed(() => this.mode === 'edit' && !!this.bien?.tieneHistorial);

--- a/libs/inventario/inventario/src/lib/ui/pages/bien-export/bien-export.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/pages/bien-export/bien-export.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BienExportConfig } from '../../../models/inventario.model';
+import { CATEGORIAS_BIEN } from '../../../models/categorias.model';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
 import { BienExportService } from '../../../data-access/services/bien-export.service';
 import { InventarioFacade } from '../../../data-access/inventario.facade';
@@ -43,7 +44,7 @@ export class BienExportPageComponent {
     { id: 'csv', label: 'CSV', sub: 'Texto plano', icon: 'csv', iconColor: '#475569' },
   ];
 
-  readonly CATEGORIAS = ['Todas las categorías', 'Equipos de Cómputo', 'Mobiliario', 'Papelería', 'Cocina', 'Audiovisuales'];
+  readonly CATEGORIAS = ['Todas las categorías', ...CATEGORIAS_BIEN];
   readonly ALMACENES = ['Todos los almacenes', 'Almacén Central', 'Sede Norte', 'Sede Sur', 'Laboratorio 302'];
 
   readonly EXPORTACIONES_RECIENTES = [


### PR DESCRIPTION
## Resumen

- Crea `models/categorias.model.ts` con la constante `CATEGORIAS_BIEN` y el tipo `CategoriaBien`
- Reemplaza arrays hardcodeados en `bien-form` y `bien-export` por la fuente centralizada
- Categorías: Perecederos, Fruver, Abarrotes y Secos, Bebidas y Líquidos, Repostería y Congelados

## Test plan

- [ ] El dropdown de categoría en el formulario de nuevo bien muestra las 5 categorías gastronómicas
- [ ] El filtro de categoría en exportar incluye "Todas las categorías" + las 5 gastronómicas
- [ ] No aparecen categorías genéricas (Equipos de Cómputo, Mobiliario, etc.)