### PR TITLE
fix(inventario): corregir flujo de eliminación de bien

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
@@ -2,7 +2,7 @@ import { inject, Injectable, signal, computed } from '@angular/core';
 import { Bien, BienFiltros, BienKpis, BienFormDto } from '../models/inventario.model';
 import { ExportacionProductosResponse } from './api/catalog.api';
 import { BienesService } from './services/bienes.service';
-import { finalize, catchError, of } from 'rxjs';
+import { finalize, catchError, of, switchMap } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -93,24 +93,24 @@ export class InventarioFacade {
   }
 
   /**
-   * Elimina un bien y refresca los datos.
+   * Elimina un bien: primero desactiva (PATCH /desactivar), luego elimina (DELETE).
+   * El backend requiere que el producto esté inactivo antes de aceptar el DELETE.
    */
   eliminarBien(id: string | number): void {
     this._loading.set(true);
-    this.bienesService.deleteBien(id)
-      .pipe(
-        catchError(() => {
-          this._error.set('Error al eliminar el bien');
-          return of(null);
-        }),
-        finalize(() => this._loading.set(false))
-      )
-      .subscribe((res) => {
-        if (res !== null) {
-          this.cargarBienes();
-          this.cargarKpis();
-        }
-      });
+    this.bienesService.desactivarBien(id).pipe(
+      switchMap(() => this.bienesService.deleteBien(id)),
+      catchError(() => {
+        this._error.set('Error al eliminar el bien');
+        return of(null);
+      }),
+      finalize(() => this._loading.set(false))
+    ).subscribe((res) => {
+      if (res !== null) {
+        this.cargarBienes();
+        this.cargarKpis();
+      }
+    });
   }
 
   /**

--- a/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
@@ -92,9 +92,9 @@ export class BienesService {
       );
   }
 
-  /** DELETE /catalog/productos/{id}?confirmacion={id} — @RequestParam requerido en backend */
+  /** DELETE /catalog/productos/{id}?confirmacion=ELIMINAR — @RequestParam requerido en backend */
   deleteBien(id: string | number): Observable<void> {
-    const params = new HttpParams().set('confirmacion', String(id));
+    const params = new HttpParams().set('confirmacion', 'ELIMINAR');
     return this.http
       .delete<void>(`${API}/catalog/productos/${id}`, { params })
       .pipe(catchError(err => throwError(() => err)));


### PR DESCRIPTION
## Resumen

Dos bugs en el flujo de eliminación de un bien:

- **Bug 1** — `bienes.service.ts`: el param `?confirmacion` enviaba el ID del bien (`String(id)`) en lugar del literal `'ELIMINAR'` que exige el backend
- **Bug 2** — `inventario.facade.ts`: `eliminarBien` llamaba directo al DELETE sin desactivar primero; el backend requiere que el producto esté inactivo antes de aceptar el DELETE

Flujo corregido:
```
PATCH /catalog/productos/{id}/desactivar  →  DELETE /catalog/productos/{id}?confirmacion=ELIMINAR
```

## Test plan

- [x] Abrir el modal de eliminación de un bien con stock 0, escribir ELIMINAR, confirmar
- [ ] Verificar en Network: primero sale el PATCH /desactivar, luego el DELETE con `?confirmacion=ELIMINAR`
- [ ] El bien desaparece del listado después de eliminar
- [ ] Si el PATCH falla, el DELETE no se ejecuta