### PR TITLE
feat(inventario): mejoras de UI en vistas de bienes

### DIFF
--- a/libs/inventario/inventario/src/lib/models/inventario.model.ts
+++ b/libs/inventario/inventario/src/lib/models/inventario.model.ts
@@ -158,4 +158,5 @@ export interface BienFormDto {
   descripcion?: string;
   categoria: string;
   unidadMedida: string;
+  imagenUrl?: string;
 }

--- a/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.html
+++ b/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.html
@@ -102,14 +102,17 @@
         </div>
 
         <div class="field-group">
-          <label class="field-label">URL DE IMAGEN</label>
-          <input class="field-input" formControlName="imagenUrl"
-                 placeholder="https://ejemplo.com/imagen.jpg" />
+          <label class="field-label">IMAGEN DEL BIEN</label>
+          <label class="file-upload-label">
+            <input type="file" accept="image/*" class="file-input-hidden"
+                   (change)="onImagenSeleccionada($event)" />
+            <span class="material-symbols-outlined">upload_file</span>
+            <span>{{ form.get('imagenUrl')?.value ? 'Cambiar imagen' : 'Seleccionar archivo' }}</span>
+          </label>
           @if (form.get('imagenUrl')?.value) {
             <img [src]="form.get('imagenUrl')?.value"
                  alt="Vista previa"
-                 class="imagen-preview"
-                 (error)="$any($event.target).style.display='none'" />
+                 class="imagen-preview" />
           }
         </div>
       </div>

--- a/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.html
+++ b/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.html
@@ -100,6 +100,18 @@
             </select>
           </div>
         </div>
+
+        <div class="field-group">
+          <label class="field-label">URL DE IMAGEN</label>
+          <input class="field-input" formControlName="imagenUrl"
+                 placeholder="https://ejemplo.com/imagen.jpg" />
+          @if (form.get('imagenUrl')?.value) {
+            <img [src]="form.get('imagenUrl')?.value"
+                 alt="Vista previa"
+                 class="imagen-preview"
+                 (error)="$any($event.target).style.display='none'" />
+          }
+        </div>
       </div>
 
     </div>

--- a/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.scss
+++ b/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.scss
@@ -406,3 +406,11 @@
 .filled {
   font-variation-settings: 'FILL' 1;
 }
+
+.imagen-preview {
+  margin-top: 0.5rem;
+  max-height: 120px;
+  border-radius: 0.5rem;
+  object-fit: contain;
+  border: 1px solid #e2e8f0;
+}

--- a/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.scss
+++ b/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.scss
@@ -407,10 +407,36 @@
   font-variation-settings: 'FILL' 1;
 }
 
+.file-input-hidden {
+  display: none;
+}
+
+.file-upload-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border: 1.5px dashed #cbd5e1;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  color: #64748b;
+  font-size: 0.875rem;
+  transition: border-color 0.2s, background 0.2s;
+
+  .material-symbols-outlined { font-size: 1.25rem; }
+
+  &:hover {
+    border-color: #22c55e;
+    background: #f0fdf4;
+    color: #16a34a;
+  }
+}
+
 .imagen-preview {
-  margin-top: 0.5rem;
-  max-height: 120px;
+  margin-top: 0.75rem;
+  max-height: 140px;
   border-radius: 0.5rem;
   object-fit: contain;
   border: 1px solid #e2e8f0;
+  display: block;
 }

--- a/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.ts
@@ -45,6 +45,7 @@ export class BienFormComponent implements OnInit {
         descripcion:     this.bien.descripcion ?? '',
         categoria:       this.bien.categoria,
         unidadMedida:    this.bien.unidadMedida,
+        imagenUrl:       this.bien.imagenUrl ?? '',
       });
       if (this.umBloqueada()) {
         this.form.get('unidadMedida')?.disable();
@@ -60,6 +61,7 @@ export class BienFormComponent implements OnInit {
       descripcion:     [''],
       categoria:       ['', Validators.required],
       unidadMedida:    ['', Validators.required],
+      imagenUrl:       [''],
     });
   }
 

--- a/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/modals/bien-form/bien-form.component.ts
@@ -77,6 +77,16 @@ export class BienFormComponent implements OnInit {
     this.cancel.emit();
   }
 
+  onImagenSeleccionada(event: Event): void {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.form.patchValue({ imagenUrl: reader.result as string });
+    };
+    reader.readAsDataURL(file);
+  }
+
   hasError(field: string): boolean {
     const ctrl = this.form.get(field);
     return !!(ctrl?.invalid && ctrl?.touched);

--- a/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.html
+++ b/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.html
@@ -24,10 +24,10 @@
         <span class="material-symbols-outlined">history</span>
         Exportar Historial
       </button>
-      <button class="btn-gradient" (click)="onEditarActivo()">
+      <restaurant-button variant="primary" (click)="onEditarActivo()">
         <span class="material-symbols-outlined">edit</span>
-        Editar Activo
-      </button>
+        Editar Bien
+      </restaurant-button>
     </div>
   </div>
 

--- a/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.html
+++ b/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.html
@@ -121,41 +121,49 @@
       <button class="link-btn">Ver todo el historial</button>
     </div>
 
-    <div class="movements-table-wrap">
-      <table class="movements-table">
-        <thead>
-          <tr>
-            <th>FECHA</th>
-            <th>TIPO</th>
-            <th>RESPONSABLE</th>
-            <th>UBICACIÓN</th>
-            <th>CANTIDAD</th>
-            <th>OBSERVACIÓN</th>
-          </tr>
-        </thead>
-        <tbody>
-          @for (m of movimientos(); track m) {
-<tr>
-            <td class="mov-fecha">{{ m.fecha | date:'dd/MM/yyyy' }}</td>
-            <td>
-              <restaurant-status-badge
-                [label]="m.tipo"
-                [variant]="getTipoVariant(m.tipo)">
-              </restaurant-status-badge>
-            </td>
-            <td class="mov-responsable">{{ m.responsable }}</td>
-            <td class="mov-ubicacion">{{ m.ubicacion }}</td>
-            <td>
-              <span class="cantidad-text" [ngClass]="getCantidadClass(m.cantidad)">
-                {{ getCantidadPrefix(m.cantidad) }}
-              </span>
-            </td>
-            <td class="mov-obs">{{ m.observacion }}</td>
-          </tr>
-}
-        </tbody>
-      </table>
-    </div>
+    @if (movimientos().length > 0) {
+      <div class="movements-table-wrap">
+        <table class="movements-table">
+          <thead>
+            <tr>
+              <th>FECHA</th>
+              <th>TIPO</th>
+              <th>RESPONSABLE</th>
+              <th>UBICACIÓN</th>
+              <th>CANTIDAD</th>
+              <th>OBSERVACIÓN</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (m of movimientos(); track m) {
+              <tr>
+                <td class="mov-fecha">{{ m.fecha | date:'dd/MM/yyyy' }}</td>
+                <td>
+                  <restaurant-status-badge
+                    [label]="m.tipo"
+                    [variant]="getTipoVariant(m.tipo)">
+                  </restaurant-status-badge>
+                </td>
+                <td class="mov-responsable">{{ m.responsable }}</td>
+                <td class="mov-ubicacion">{{ m.ubicacion }}</td>
+                <td>
+                  <span class="cantidad-text" [ngClass]="getCantidadClass(m.cantidad)">
+                    {{ getCantidadPrefix(m.cantidad) }}
+                  </span>
+                </td>
+                <td class="mov-obs">{{ m.observacion }}</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    } @else {
+      <div class="empty-state">
+        <span class="material-symbols-outlined">sync</span>
+        <p>Sin movimientos registrados</p>
+        <small>Este bien aún no tiene movimientos de inventario.</small>
+      </div>
+    }
   </section>
 
   <!-- Facturas de Abastecimiento -->

--- a/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.ts
@@ -6,7 +6,6 @@ import { InventarioFacade } from '../../../data-access/inventario.facade';
 import { ButtonComponent, StatusBadgeComponent } from '@restaurant/shared/ui';
 import { BienFormComponent } from '../../modals/bien-form/bien-form.component';
 import { BienFormDto, EstadoBien } from '../../../models/inventario.model';
-import { MOVIMIENTOS_MOCK } from '../../../models/inventario.mock';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
 
 @Component({
@@ -48,7 +47,7 @@ export class BienDetailPageComponent implements OnInit {
 
   private loadData(id: string): void {
     this.facade.cargarBienPorId(id);
-    this.movimientos.set(MOVIMIENTOS_MOCK);
+    this.movimientos.set([]);
   }
 
   onVolver(): void {

--- a/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/pages/bien-detail/bien-detail.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MovimientoBien } from '../../../models/inventario.model';
 import { InventarioFacade } from '../../../data-access/inventario.facade';
-import { StatusBadgeComponent } from '@restaurant/shared/ui';
+import { ButtonComponent, StatusBadgeComponent } from '@restaurant/shared/ui';
 import { BienFormComponent } from '../../modals/bien-form/bien-form.component';
 import { BienFormDto, EstadoBien } from '../../../models/inventario.model';
 import { MOVIMIENTOS_MOCK } from '../../../models/inventario.mock';
@@ -12,7 +12,7 @@ import { BackButtonComponent } from '../../../components/back-button/back-button
 @Component({
   selector: 'restaurant-bien-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, BienFormComponent, BackButtonComponent, StatusBadgeComponent],
+  imports: [CommonModule, RouterModule, BienFormComponent, BackButtonComponent, StatusBadgeComponent, ButtonComponent],
   templateUrl: './bien-detail.component.html',
   styleUrl: './bien-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/inventario/inventario/src/lib/ui/pages/bien-export/bien-export.component.html
+++ b/libs/inventario/inventario/src/lib/ui/pages/bien-export/bien-export.component.html
@@ -125,7 +125,7 @@
         <div class="summary-stats">
           <div class="stat-row">
             <span class="stat-label">Registros totales</span>
-            <span class="stat-value highlight-green">{{ resumenReporte().registros | number }}</span>
+            <span class="stat-value text-white">{{ resumenReporte().registros | number }}</span>
           </div>
           <div class="stat-row">
             <span class="stat-label">Valor estimado</span>


### PR DESCRIPTION
## Resumen

- **bien-detail**: botón "Editar Activo" reemplazado por `<restaurant-button variant="primary">` y renombrado a "Editar Bien"
- **bien-detail**: historial de movimientos arranca vacío (elimina datos quemados de `MOVIMIENTOS_MOCK`); muestra empty-state cuando no hay registros
- **bien-export**: número de "Registros totales" cambiado a `text-white` (igual que el resto de valores del resumen)
- **bien-form**: nuevo campo opcional "URL de imagen" con preview en tiempo real; `imagenUrl` agregado a `BienFormDto`

## Test plan

- [ ] Vista detalle: el botón "Editar Bien" usa el estilo compartido (no `btn-gradient` local)
- [ ] Vista detalle: al abrir un bien recién creado el historial muestra "Sin movimientos registrados"
- [ ] Vista exportar: el número de registros totales aparece en blanco (igual que los demás)
- [ ] Formulario nuevo bien: el campo URL de imagen es visible y opcional; al pegar una URL válida aparece la preview
- [ ] Formulario editar bien: si el bien tiene `imagenUrl`, el campo se rellena con el valor existente