### PR TITLE
feat(inventario): paginación real con backend y fix duplicados en exportar

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
-import { Bien, BienFiltros, BienKpis, BienFormDto } from '../models/inventario.model';
+import { Bien, BienFiltros, BienKpis, BienFormDto, BienPaginacion } from '../models/inventario.model';
 import { ExportacionProductosResponse } from './api/catalog.api';
 import { BienesService } from './services/bienes.service';
 import { finalize, catchError, of, switchMap } from 'rxjs';
@@ -14,7 +14,8 @@ export class InventarioFacade {
   private _bienes              = signal<Bien[]>([]);
   private _kpis                = signal<BienKpis | null>(null);
   private _loading             = signal<boolean>(false);
-  private _filtros             = signal<BienFiltros>({});
+  private _filtros             = signal<BienFiltros>({ page: 0, size: 10 });
+  private _paginacion          = signal<BienPaginacion>({ totalElements: 0, totalPages: 1, page: 0, size: 10 });
   private _bienSeleccionado    = signal<Bien | undefined>(undefined);
   private _exportacionPendiente = signal<ExportacionProductosResponse | null>(null);
   private _error               = signal<string | null>(null);
@@ -24,6 +25,7 @@ export class InventarioFacade {
   public kpis                 = computed(() => this._kpis());
   public loading              = computed(() => this._loading());
   public filtros              = computed(() => this._filtros());
+  public paginacion           = computed(() => this._paginacion());
   public bienSeleccionado     = computed(() => this._bienSeleccionado());
   public exportacionPendiente = computed(() => this._exportacionPendiente());
   public error                = computed(() => this._error());
@@ -38,20 +40,42 @@ export class InventarioFacade {
 
   /**
    * Carga el listado de bienes aplicando los filtros actuales.
+   * Al cambiar filtros de búsqueda/categoría vuelve a página 0.
    */
   cargarBienes(filtros?: BienFiltros): void {
-    if (filtros) this._filtros.set(filtros);
-    
+    if (filtros) this._filtros.set({ ...this._filtros(), ...filtros, page: 0 });
+
     this._loading.set(true);
     this.bienesService.getBienes(this._filtros())
       .pipe(
         catchError(() => {
           this._error.set('Error al cargar la lista de bienes');
-          return of([]);
+          return of({ bienes: [], paginacion: { totalElements: 0, totalPages: 1, page: 0, size: 10 } });
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(data => this._bienes.set(data));
+      .subscribe(({ bienes, paginacion }) => {
+        this._bienes.set(bienes);
+        this._paginacion.set(paginacion);
+      });
+  }
+
+  /** Navega a una página específica sin resetear los filtros. */
+  irAPagina(page: number): void {
+    this._filtros.update(f => ({ ...f, page }));
+    this._loading.set(true);
+    this.bienesService.getBienes(this._filtros())
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar la página');
+          return of({ bienes: [], paginacion: this._paginacion() });
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(({ bienes, paginacion }) => {
+        this._bienes.set(bienes);
+        this._paginacion.set(paginacion);
+      });
   }
 
   /**

--- a/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, of, throwError, forkJoin } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { Bien, BienFiltros, BienKpis, BienFormDto } from '../../models/inventario.model';
+import { Bien, BienFiltros, BienKpis, BienFormDto, BienPaginacion } from '../../models/inventario.model';
 import {
   PagedResponse,
   ProductoResponse,
@@ -27,18 +27,27 @@ export class BienesService {
 
   // ── Listado ──────────────────────────────────────────────────────────────────
 
-  /** GET /catalog/productos — lista paginada.
-   *  Estado derivado de `activo`; valor = 0 (sin endpoint de precio). */
-  getBienes(filtros?: BienFiltros): Observable<Bien[]> {
+  /** GET /catalog/productos — lista paginada (page 0-based, size por defecto 10). */
+  getBienes(filtros?: BienFiltros): Observable<{ bienes: Bien[]; paginacion: BienPaginacion }> {
     let params = new HttpParams();
     if (filtros?.busqueda)  params = params.set('q', filtros.busqueda);
     if (filtros?.categoria) params = params.set('categoria', filtros.categoria);
     if (filtros?.estado)    params = params.set('estado', filtros.estado);
+    params = params.set('page', String(filtros?.page ?? 0));
+    params = params.set('size', String(filtros?.size ?? 10));
 
     return this.http
       .get<PagedResponse<ProductoResponse>>(`${API}/catalog/productos`, { params })
       .pipe(
-        map(res => res.content.map(bienFromCatalogo)),
+        map(res => ({
+          bienes: res.content.map(bienFromCatalogo),
+          paginacion: {
+            totalElements: res.totalElements,
+            totalPages:    res.totalPages,
+            page:          res.page,
+            size:          res.size,
+          },
+        })),
         catchError(err => throwError(() => err))
       );
   }

--- a/libs/inventario/inventario/src/lib/models/inventario.model.ts
+++ b/libs/inventario/inventario/src/lib/models/inventario.model.ts
@@ -76,6 +76,15 @@ export interface BienFiltros {
   busqueda?: string;
   categoria?: string;
   estado?: EstadoBien;
+  page?: number;
+  size?: number;
+}
+
+export interface BienPaginacion {
+  totalElements: number;
+  totalPages: number;
+  page: number;
+  size: number;
 }
 
 /**

--- a/libs/inventario/inventario/src/lib/ui/pages/bien-export/bien-export.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/pages/bien-export/bien-export.component.ts
@@ -44,8 +44,8 @@ export class BienExportPageComponent {
     { id: 'csv', label: 'CSV', sub: 'Texto plano', icon: 'csv', iconColor: '#475569' },
   ];
 
-  readonly CATEGORIAS = ['Todas las categorías', ...CATEGORIAS_BIEN];
-  readonly ALMACENES = ['Todos los almacenes', 'Almacén Central', 'Sede Norte', 'Sede Sur', 'Laboratorio 302'];
+  readonly CATEGORIAS = CATEGORIAS_BIEN;
+  readonly ALMACENES = ['Almacén Central', 'Sede Norte', 'Sede Sur', 'Laboratorio 302'];
 
   readonly EXPORTACIONES_RECIENTES = [
     { nombre: 'Inv_Bienes_Oct.xlsx', tiempo: 'Hace 2 horas', tamano: '4.2 MB', icono: 'table_chart', color: '#217346' },

--- a/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.html
+++ b/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.html
@@ -144,13 +144,25 @@
 
     <!-- Pagination Footer -->
     <div class="pagination-footer">
-      <p class="pagination-info">MOSTRANDO {{ bienes().length }} DE {{ bienes().length }} BIENES</p>
+      <p class="pagination-info">
+        MOSTRANDO {{ bienes().length }} DE {{ paginacion().totalElements }} BIENES
+      </p>
       <div class="pagination-controls">
-        <button class="page-btn" disabled>
+        <button class="page-btn"
+          [disabled]="paginacion().page === 0"
+          (click)="onIrAPagina(paginacion().page - 1)">
           <span class="material-symbols-outlined">chevron_left</span>
         </button>
-        <button class="page-btn page-btn--active">1</button>
-        <button class="page-btn" disabled>
+        @for (p of paginas(); track p) {
+          <button class="page-btn"
+            [class.page-btn--active]="p === paginacion().page"
+            (click)="onIrAPagina(p)">
+            {{ p + 1 }}
+          </button>
+        }
+        <button class="page-btn"
+          [disabled]="paginacion().page >= paginacion().totalPages - 1"
+          (click)="onIrAPagina(paginacion().page + 1)">
           <span class="material-symbols-outlined">chevron_right</span>
         </button>
       </div>

--- a/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.ts
+++ b/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { ButtonComponent, KpiCardComponent, LoadingSkeletonComponent } from '@restaurant/shared/ui';
@@ -29,9 +29,14 @@ export class BienesListPageComponent implements OnInit {
   private router = inject(Router);
 
   // State signals
-  bienes = this.facade.bienes;
-  kpis = this.facade.kpis;
-  loading = this.facade.loading;
+  bienes      = this.facade.bienes;
+  kpis        = this.facade.kpis;
+  loading     = this.facade.loading;
+  paginacion  = this.facade.paginacion;
+
+  paginas = computed(() =>
+    Array.from({ length: this.paginacion().totalPages }, (_, i) => i)
+  );
 
   // Modal controls
   showFormModal = signal(false);
@@ -45,7 +50,11 @@ export class BienesListPageComponent implements OnInit {
   }
 
   onSearch(query: string): void {
-    this.facade.setFiltros({ busqueda: query });
+    this.facade.cargarBienes({ busqueda: query });
+  }
+
+  onIrAPagina(page: number): void {
+    this.facade.irAPagina(page);
   }
 
   onImportBienes(): void {


### PR DESCRIPTION
## Resumen

### Fix — Opciones duplicadas en exportar
- `bien-export.component.ts`: las opciones "Todas las categorías" y "Todos los almacenes" aparecían dos veces porque el array TS las incluía Y el HTML tenía el `<option value="">` hardcodeado. Se eliminan del array, quedan solo en el template.

### Feat — Paginación conectada al backend
Hasta ahora la paginación era decorativa (botones deshabilitados, siempre página 1). Ahora:

- **`BienFiltros`** — agrega `page` y `size` opcionales
- **`BienPaginacion`** — nuevo tipo con `totalElements`, `totalPages`, `page`, `size`
- **`BienesService.getBienes`** — manda `page` y `size` al backend; devuelve `{ bienes, paginacion }` en lugar de solo `Bien[]`
- **`InventarioFacade`** — señal `_paginacion` expuesta como `paginacion`; método `irAPagina(page)` para navegar sin resetear filtros; al aplicar filtros de búsqueda vuelve a página 0 automáticamente
- **`BienesList`** — pagination footer conectado: muestra `X de N bienes`, botones prev/next habilitados según página actual, números de página dinámicos

Tamaño de página por defecto: **10 items**.

## Test plan

- [ ] Exportar: seleccionar "Todas las categorías" aparece una sola vez en el dropdown
- [ ] Exportar: seleccionar "Todos los almacenes" aparece una sola vez
- [ ] Bienes: el footer muestra `MOSTRANDO X DE N BIENES` con el total real del backend
- [ ] Bienes: navegar a página 2 carga los siguientes 10 registros
- [ ] Bienes: el botón "anterior" se deshabilita en página 1; "siguiente" en la última
- [ ] Bienes: al buscar un término, la tabla vuelve a página 1 con los resultados filtrados