### PR TITLE
fix(inventario): conectar DELETE GIL al endpoint real del backend

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/services/solicitudes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/solicitudes.service.ts
@@ -133,10 +133,13 @@ export class SolicitudesService {
       );
   }
 
-  /** DELETE — endpoint NO disponible en backend */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  deleteSolicitud(_codigo: string): Observable<boolean> {
-    return throwError(() => new Error('deleteSolicitud: endpoint DELETE no disponible en backend'));
+  /** DELETE /procurement/giles/{id} — elimina un GIL en estado BORRADOR */
+  deleteSolicitud(id: string): Observable<void> {
+    return this.http
+      .delete<void>(`${API}/procurement/giles/${id}`)
+      .pipe(
+        catchError(err => throwError(() => err))
+      );
   }
 
   /** Generar GILs desde solicitudes aprobadas — endpoint NO disponible en backend */

--- a/libs/inventario/inventario/src/lib/data-access/solicitudes.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/solicitudes.facade.ts
@@ -9,7 +9,7 @@ import {
 } from '../models/solicitud-sesion.model';
 import { SolicitudesService } from './services/solicitudes.service';
 import { EnviarProveedorRequest } from './api/sourcing.api';
-import { finalize, catchError, of, map } from 'rxjs';
+import { finalize, catchError, of, map, EMPTY } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -186,23 +186,28 @@ export class SolicitudesFacade {
   }
 
   /**
-   * Elimina una solicitud y refresca los datos.
+   * Elimina un GIL por su UUID y refresca el listado.
+   * Solo GILes en estado BORRADOR pueden eliminarse (backend devuelve 409 si no).
    */
-  eliminarSolicitud(codigo: string): void {
+  eliminarSolicitud(id: string): void {
     this._loading.set(true);
-    this.solicitudesService.deleteSolicitud(codigo)
+    this._error.set(null);
+    this.solicitudesService.deleteSolicitud(id)
       .pipe(
-        catchError(() => {
-          this._error.set('Error al eliminar la solicitud');
-          return of(false);
+        catchError((err: unknown) => {
+          const httpErr = err as { status?: number };
+          if (httpErr.status === 404) {
+            this._error.set('GIL no encontrado');
+          } else if (httpErr.status === 409) {
+            this._error.set('Solo se pueden eliminar GILes en estado Borrador');
+          } else {
+            this._error.set('Error al eliminar la solicitud');
+          }
+          return EMPTY;
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe((success) => {
-        if (success) {
-          this.cargarSolicitudes();
-        }
-      });
+      .subscribe(() => this.cargarSolicitudes());
   }
 
   /** PUT /procurement/giles/{id}/enviar-proveedor con proveedorDestinatarioId y fechaEnvio */

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-page/solicitudes-list/solicitudes-list.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-page/solicitudes-list/solicitudes-list.component.ts
@@ -122,9 +122,9 @@ export class SolicitudesListComponent implements OnInit {
   }
 
   confirmDelete(): void {
-    const id = this.itemToDelete()?.numeroGil;
+    const id = this.itemToDelete()?.id;
     if (id) {
-      this.facade.eliminarSolicitud(id);
+      this.facade.eliminarSolicitud(String(id));
     }
     this.closeDeleteModal();
   }


### PR DESCRIPTION
Cierra #4

## ¿Qué cambió y por qué?

El método `deleteSolicitud()` era un stub que lanzaba un error hardcodeado. El endpoint `DELETE /api/v1/procurement/giles/{id}` ya está activo en el backend. Este PR conecta las tres capas: servicio, facade y componente.

Se detectó además un **bug crítico** en el componente: se estaba pasando `numeroGil` ("GIL-0007") como identificador al endpoint, cuando el backend espera el **UUID** del campo `id`.

## Tipo de cambio

- [x] Corrección de bug (cambio no disruptivo que soluciona un problema)

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `data-access/services/solicitudes.service.ts` | Reemplaza stub con `http.delete<void>` real; parámetro `_codigo` → `id`; retorno `Observable<boolean>` → `Observable<void>` |
| `data-access/solicitudes.facade.ts` | Renombra `codigo` → `id`; agrega `_error.set(null)`; usa `EMPTY` en catchError; manejo explícito de 404 y 409; suscripción corregida para `Observable<void>` |
| `pages/solicitudes-page/solicitudes-list/solicitudes-list.component.ts` | Corrige bug: `confirmDelete()` pasaba `numeroGil` al endpoint DELETE en lugar del UUID (`id`) |

## Detalle técnico de cada cambio

**Servicio**
```typescript
// Antes — stub inútil
deleteSolicitud(_codigo: string): Observable<boolean> {
  return throwError(() => new Error('endpoint DELETE no disponible en backend'));
}

// Después — llamada real al backend
deleteSolicitud(id: string): Observable<void> {
  return this.http.delete<void>(`${API}/procurement/giles/${id}`)
    .pipe(catchError(err => throwError(() => err)));
}
```

**Facade** — error handling consistente con `actualizarSolicitud`
```typescript
eliminarSolicitud(id: string): void {
  this._loading.set(true);
  this._error.set(null);
  this.solicitudesService.deleteSolicitud(id)
    .pipe(
      catchError((err: unknown) => {
        const httpErr = err as { status?: number };
        if (httpErr.status === 404) this._error.set('GIL no encontrado');
        else if (httpErr.status === 409) this._error.set('Solo se pueden eliminar GILes en estado Borrador');
        else this._error.set('Error al eliminar la solicitud');
        return EMPTY;
      }),
      finalize(() => this._loading.set(false))
    )
    .subscribe(() => this.cargarSolicitudes());
}
```

**Componente** — bug crítico corregido
```typescript
// Antes — enviaba "GIL-0007" (numeroGil) como ID
const id = this.itemToDelete()?.numeroGil;

// Después — envía el UUID real
const id = this.itemToDelete()?.id;
if (id) this.facade.eliminarSolicitud(String(id));
```

## Plan de pruebas

- [ ] Seleccionar un GIL en estado **BORRADOR** → hacer clic en eliminar → confirmar → el GIL desaparece de la lista
- [ ] Verificar que la red muestra `DELETE /api/v1/procurement/giles/{uuid}` (no `GIL-0007`)
- [ ] Intentar eliminar un GIL en estado **EMITIDO** → el backend devuelve 409 → el error se muestra correctamente
- [ ] Intentar eliminar un UUID inexistente → 404 → mensaje de error legible
- [x] `nx run inventario:lint` pasa sin errores

## Checklist del contribuidor

- [x] Issue aprobado vinculado (#4)
- [x] Formato de Conventional Commits
- [x] Sin trazas de `Co-Authored-By`
- [x] Solo toca `libs/inventario/`
- [x] Solo capa de data-access + corrección de bug en componente