### PR TITLE
fix(inventario): alinear contratos Kardex con Swagger y agregar paginación

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/inventory.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/inventory.api.ts
@@ -22,27 +22,24 @@ export interface MovimientoResponse {
   estado: 'Completado' | 'Pendiente' | 'Cancelado';
 }
 
+/** RegistrarEntradaHttpRequest — POST /api/v1/inventory/movimientos/entrada */
 export interface EntradaRequest {
-  productoId: string;
-  cantidad: number;
-  fecha: string;
-  proveedorId?: string;
-  facturaId?: string;
-  ubicacion: string;
-  valorUnitario: number;
-  observaciones?: string;
+  productoId:      string;
+  cantidad:        number;
+  precioUnitario:  number;
+  facturaId?:      string;
+  proveedorNit?:   string;
+  gilId?:          string;
+  conciliacionId?: string;
 }
 
+/** RegistrarSalidaHttpRequest — POST /api/v1/inventory/movimientos/salida */
 export interface SalidaRequest {
-  productoId: string;
-  cantidad: number;
-  fecha: string;
-  areaDestino: string;
-  instructorId?: string;
-  fichaId?: string;
-  categoria: string;
-  proposito: string;
-  observaciones?: string;
+  productoId:    string;
+  cantidad:      number;
+  requisicionId: string;
+  instructorId:  string;
+  categoria:     string;
 }
 
 export interface ReservaRequest {

--- a/libs/inventario/inventario/src/lib/data-access/api/inventory.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/inventory.api.ts
@@ -1,3 +1,24 @@
+/**
+ * GET /inventory/movimientos/{productoId} — response paginado.
+ * El backend no documenta el schema en Swagger (type: object genérico).
+ * Se soportan ambas convenciones: inglés (content/totalElements) y
+ * español (contenido/totalElementos) para cubrir las variaciones del backend.
+ */
+export interface MovimientoPageResponse {
+  // Convención inglés (Spring Page<T> estándar — igual que PagedGilResponse)
+  content?:       MovimientoResponse[];
+  totalElements?: number;
+  totalPages?:    number;
+  number?:        number;
+  size?:          number;
+  // Convención español (patrón interno de otros módulos)
+  contenido?:       MovimientoResponse[];
+  totalElementos?:  number;
+  totalPaginas?:    number;
+  paginaActual?:    number;
+  tamano?:          number;
+}
+
 export interface ExistenciaResponse {
   productoId: string;
   stockFisico: number;

--- a/libs/inventario/inventario/src/lib/data-access/api/legalization.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/legalization.api.ts
@@ -57,25 +57,37 @@ export interface TrazabilidadRequest {
   cufeFuenteId?: string;
 }
 
+/** Categorías de insumo — enum Swagger (B-04) */
+export type CategoriaInsumo =
+  | 'ABARROTES'
+  | 'LACTEOS'
+  | 'FRUTAS_Y_VEGETALES'
+  | 'CARNES_PESCADOS_MARISCOS';
+
+/** RequisicionItemResponse — Swagger actualizado (B-02).
+ *  productoId = codigoSena del catálogo; usar como productoId en RegistrarSalidaHttpRequest. */
 export interface RequisicionItemResponse {
-  codigo: string;
-  descripcion: string;
-  cantidad: number;
-  unidad: string;
+  productoId?:     string;
+  productoNombre?: string;
+  cantidad?:       number;
+  unidadMedida?:   string;
+  categoria?:      CategoriaInsumo;
 }
 
+/** RequisicionResponse — Swagger actualizado (B-02, B-04).
+ *  ENVIADA   → habilitada para generar Salida de inventario.
+ *  DESPACHADA → salida ya registrada. */
 export interface RequisicionResponse {
-  id: string;
-  numero: string;
-  programa: string;
-  fichaId: string;
-  instructorId: string;
-  instructorNombre: string;
-  diaSemana: string;
-  horaSesion: string;
-  fecha: string;
-  estado: 'BORRADOR' | 'ENVIADA' | 'DESPACHADA' | 'FIRMADA' | 'LEGALIZADA';
-  items: RequisicionItemResponse[];
+  id?:               string;
+  numero?:           string;
+  fecha?:            string;
+  diaSemana?:        string;
+  horaSesion?:       string;
+  fichaId?:          string;
+  instructorId?:     string;
+  instructorNombre?: string;
+  estado?:           'BORRADOR' | 'ENVIADA' | 'DESPACHADA' | 'FIRMADA' | 'LEGALIZADA';
+  items?:            RequisicionItemResponse[];
 }
 
 export interface CrearRequisicionRequest {

--- a/libs/inventario/inventario/src/lib/data-access/api/procurement.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/procurement.api.ts
@@ -7,17 +7,15 @@ export interface CuentadanteResponse {
 }
 
 /** Ítem de un GIL — BienGilResponse (Swagger).
- *  NOTA: el backend aún no expone productoId en este DTO (ver tarea B-01 backend).
- *  Se agrega como opcional para cuando el backend lo incorpore. */
+ *  productoId implementado en backend (B-01): usar directamente en RegistrarEntradaHttpRequest. */
 export interface BienGilResponse {
+  productoId?:    string;
   codigoSena?:    string;
   descripcion?:   string;
   unidadMedida?:  string;
   cantidad?:      number;
   valorUnitario?: number;
   subtotal?:      number;
-  /** Pendiente backend B-01: agregar productoId a BienGilResponse */
-  productoId?:    string;
 }
 
 /** GilResponse — estado: BORRADOR | EMITIDO | ENVIADO_PROVEEDOR | CERRADO */

--- a/libs/inventario/inventario/src/lib/data-access/api/procurement.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/procurement.api.ts
@@ -1,0 +1,56 @@
+/** DTOs de la capa procurement — alineados con el Swagger (GET /api/v1/procurement/giles).
+ *  Solo lectura: el dominio inventario no crea ni modifica GILes. */
+
+export interface CuentadanteResponse {
+  nombre?: string;
+  cedula?: string;
+}
+
+/** Ítem de un GIL — BienGilResponse (Swagger).
+ *  NOTA: el backend aún no expone productoId en este DTO (ver tarea B-01 backend).
+ *  Se agrega como opcional para cuando el backend lo incorpore. */
+export interface BienGilResponse {
+  codigoSena?:    string;
+  descripcion?:   string;
+  unidadMedida?:  string;
+  cantidad?:      number;
+  valorUnitario?: number;
+  subtotal?:      number;
+  /** Pendiente backend B-01: agregar productoId a BienGilResponse */
+  productoId?:    string;
+}
+
+/** GilResponse — estado: BORRADOR | EMITIDO | ENVIADO_PROVEEDOR | CERRADO */
+export type EstadoGil = 'BORRADOR' | 'EMITIDO' | 'ENVIADO_PROVEEDOR' | 'CERRADO';
+
+export interface GilResponse {
+  id?:                      string;
+  numeroGil?:               string;
+  estado?:                  EstadoGil;
+  fechaSolicitud?:          string;
+  regionalCodigo?:          number;
+  regionalNombre?:          string;
+  centroCostosCodigo?:      number;
+  centroCostosNombre?:      string;
+  area?:                    string;
+  destinoBienes?:           string;
+  jefeOficinaCoordinador?:  string;
+  cuentadantes?:            CuentadanteResponse[];
+  solicitante?:             string;
+  codigoGrupo?:             string;
+  fichaCaracterizacion?:    string;
+  bienes?:                  BienGilResponse[];
+  observaciones?:           string;
+  creadoEn?:                string;
+  actualizadoEn?:           string;
+}
+
+/** PagedGilResponse — GET /api/v1/procurement/giles */
+export interface PagedGilResponse {
+  content?:       GilResponse[];
+  totalElements?: number;
+  totalPages?:    number;
+  /** Número de página actual (0-based) */
+  number?:        number;
+  size?:          number;
+}

--- a/libs/inventario/inventario/src/lib/data-access/giles.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/giles.facade.ts
@@ -3,59 +3,94 @@ import { catchError, finalize, of } from 'rxjs';
 import { GilResponse } from './api/procurement.api';
 import { GilesService } from './services/giles.service';
 
+export interface GilesPaginacion {
+  totalElements: number;
+  totalPages:    number;
+  page:          number;
+  size:          number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class GilesFacade {
-  private gilesService = inject(GilesService);
+  private gilesService    = inject(GilesService);
+  private readonly PAGE_SIZE = 10;
 
   // ── Estado ───────────────────────────────────────────────────────────────────
-  private _giles          = signal<GilResponse[]>([]);
+  /** Todos los GILes válidos cargados (combinación de 3 estados). */
+  private _gilesTodos      = signal<GilResponse[]>([]);
   private _gilSeleccionado = signal<GilResponse | null>(null);
-  private _totalElements  = signal<number>(0);
-  private _loading        = signal<boolean>(false);
-  private _error          = signal<string | null>(null);
+  private _paginaActual    = signal<number>(0);
+  private _loading         = signal<boolean>(false);
+  private _error           = signal<string | null>(null);
 
   // ── Lectura pública ──────────────────────────────────────────────────────────
-  public giles           = computed(() => this._giles());
+
+  /** GILes de la página actual (máx. 10). */
+  public giles = computed<GilResponse[]>(() => {
+    const start = this._paginaActual() * this.PAGE_SIZE;
+    return this._gilesTodos().slice(start, start + this.PAGE_SIZE);
+  });
+
+  /** Estado de paginación: totalElements, totalPages, page (0-based), size. */
+  public paginacion = computed<GilesPaginacion>(() => ({
+    totalElements: this._gilesTodos().length,
+    totalPages:    Math.max(1, Math.ceil(this._gilesTodos().length / this.PAGE_SIZE)),
+    page:          this._paginaActual(),
+    size:          this.PAGE_SIZE,
+  }));
+
   public gilSeleccionado = computed(() => this._gilSeleccionado());
-  public totalElements   = computed(() => this._totalElements());
   public loading         = computed(() => this._loading());
   public error           = computed(() => this._error());
 
   // ── Acciones ─────────────────────────────────────────────────────────────────
 
-  /** Carga los GILes que habilitan registro de entrada:
-   *  estados EMITIDO, ENVIADO_PROVEEDOR y CERRADO.
-   *  Pendiente backend B-05: confirmar cuáles estados son válidos. */
-  cargarGilesValidados(page = 0, size = 20): void {
+  /**
+   * Carga todos los GILes válidos para registrar entradas:
+   * estados EMITIDO, ENVIADO_PROVEEDOR y CERRADO en paralelo.
+   * Usa size=50 por estado para cubrir el volumen operativo normal.
+   * Los resultados se combinan y se paginan de a 10 en el cliente.
+   */
+  cargarGilesValidados(): void {
     this._loading.set(true);
     this._error.set(null);
+    this._paginaActual.set(0);
 
-    // Cargamos los tres estados válidos en paralelo y los combinamos.
-    // Cuando el backend exponga filtro multi-estado esto se simplifica a una sola llamada.
     const estados = ['EMITIDO', 'ENVIADO_PROVEEDOR', 'CERRADO'] as const;
-    const resultados: GilResponse[][] = [];
+    const buffer: GilResponse[][] = [[], [], []];
     let pendientes = estados.length;
 
-    estados.forEach(estado => {
-      this.gilesService.getGiles({ estado, page, size })
-        .pipe(
-          catchError(() => of({ content: [] })),
-        )
+    estados.forEach((estado, idx) => {
+      this.gilesService.getGiles({ estado, page: 0, size: 50 })
+        .pipe(catchError(() => of({ content: [] as GilResponse[] })))
         .subscribe(paged => {
-          resultados.push(paged.content ?? []);
+          buffer[idx] = paged.content ?? [];
           pendientes--;
           if (pendientes === 0) {
-            const todos = resultados.flat();
-            this._giles.set(todos);
-            this._totalElements.set(todos.length);
+            this._gilesTodos.set(buffer.flat());
             this._loading.set(false);
           }
         });
     });
   }
 
-  /** Carga un GIL específico por ID y lo establece como seleccionado. */
+  /**
+   * Navega a la página indicada (0-based).
+   * No tiene efecto si el índice está fuera de rango.
+   */
+  irAPagina(page: number): void {
+    const total = this.paginacion().totalPages;
+    if (page >= 0 && page < total) {
+      this._paginaActual.set(page);
+    }
+  }
+
+  /** Carga un GIL específico por ID con todos sus bienes y lo establece como seleccionado. */
   cargarGilById(id: string): void {
+    if (!id) {
+      this._gilSeleccionado.set(null);
+      return;
+    }
     this._loading.set(true);
     this._error.set(null);
     this.gilesService.getGilById(id)

--- a/libs/inventario/inventario/src/lib/data-access/giles.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/giles.facade.ts
@@ -1,0 +1,81 @@
+import { inject, Injectable, signal, computed } from '@angular/core';
+import { catchError, finalize, of } from 'rxjs';
+import { GilResponse } from './api/procurement.api';
+import { GilesService } from './services/giles.service';
+
+@Injectable({ providedIn: 'root' })
+export class GilesFacade {
+  private gilesService = inject(GilesService);
+
+  // ── Estado ───────────────────────────────────────────────────────────────────
+  private _giles          = signal<GilResponse[]>([]);
+  private _gilSeleccionado = signal<GilResponse | null>(null);
+  private _totalElements  = signal<number>(0);
+  private _loading        = signal<boolean>(false);
+  private _error          = signal<string | null>(null);
+
+  // ── Lectura pública ──────────────────────────────────────────────────────────
+  public giles           = computed(() => this._giles());
+  public gilSeleccionado = computed(() => this._gilSeleccionado());
+  public totalElements   = computed(() => this._totalElements());
+  public loading         = computed(() => this._loading());
+  public error           = computed(() => this._error());
+
+  // ── Acciones ─────────────────────────────────────────────────────────────────
+
+  /** Carga los GILes que habilitan registro de entrada:
+   *  estados EMITIDO, ENVIADO_PROVEEDOR y CERRADO.
+   *  Pendiente backend B-05: confirmar cuáles estados son válidos. */
+  cargarGilesValidados(page = 0, size = 20): void {
+    this._loading.set(true);
+    this._error.set(null);
+
+    // Cargamos los tres estados válidos en paralelo y los combinamos.
+    // Cuando el backend exponga filtro multi-estado esto se simplifica a una sola llamada.
+    const estados = ['EMITIDO', 'ENVIADO_PROVEEDOR', 'CERRADO'] as const;
+    const resultados: GilResponse[][] = [];
+    let pendientes = estados.length;
+
+    estados.forEach(estado => {
+      this.gilesService.getGiles({ estado, page, size })
+        .pipe(
+          catchError(() => of({ content: [] })),
+        )
+        .subscribe(paged => {
+          resultados.push(paged.content ?? []);
+          pendientes--;
+          if (pendientes === 0) {
+            const todos = resultados.flat();
+            this._giles.set(todos);
+            this._totalElements.set(todos.length);
+            this._loading.set(false);
+          }
+        });
+    });
+  }
+
+  /** Carga un GIL específico por ID y lo establece como seleccionado. */
+  cargarGilById(id: string): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.gilesService.getGilById(id)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar el GIL');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(gil => this._gilSeleccionado.set(gil));
+  }
+
+  /** Selecciona un GIL ya cargado en la lista (sin nueva llamada HTTP). */
+  seleccionarGil(gil: GilResponse | null): void {
+    this._gilSeleccionado.set(gil);
+  }
+
+  /** Limpia la selección actual. */
+  limpiarSeleccion(): void {
+    this._gilSeleccionado.set(null);
+  }
+}

--- a/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
@@ -128,7 +128,7 @@ export class KardexFacade {
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
+      .subscribe(res => { if (res) this.cargarKardex(data.productoId); });
   }
 
   registrarSalida(data: SalidaMovimientoData): void {
@@ -141,7 +141,7 @@ export class KardexFacade {
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
+      .subscribe(res => { if (res) this.cargarKardex(data.productoId); });
   }
 
   registrarReserva(data: ReservaMovimientoData): void {

--- a/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
-import { catchError, finalize, of } from 'rxjs';
+import { catchError, EMPTY, finalize, of } from 'rxjs';
 import {
   Movimiento,
   EntradaMovimientoData,
@@ -120,66 +120,71 @@ export class KardexFacade {
 
   registrarEntrada(data: EntradaMovimientoData): void {
     this._loading.set(true);
+    this._error.set(null);
     this.movimientosService.registrarEntrada(data)
       .pipe(
         catchError(() => {
           this._error.set('Error al registrar entrada');
-          return of(null);
+          return EMPTY;
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(res => { if (res) this.cargarKardex(data.productoId); });
+      .subscribe(() => this.cargarKardex(data.productoId));
   }
 
   registrarSalida(data: SalidaMovimientoData): void {
     this._loading.set(true);
+    this._error.set(null);
     this.movimientosService.registrarSalida(data)
       .pipe(
         catchError(() => {
           this._error.set('Error al registrar salida');
-          return of(null);
+          return EMPTY;
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(res => { if (res) this.cargarKardex(data.productoId); });
+      .subscribe(() => this.cargarKardex(data.productoId));
   }
 
   registrarReserva(data: ReservaMovimientoData): void {
     this._loading.set(true);
+    this._error.set(null);
     this.movimientosService.registrarReserva(data)
       .pipe(
         catchError(() => {
           this._error.set('Error al registrar reserva');
-          return of(null);
+          return EMPTY;
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
+      .subscribe(() => this.cargarKardex(data.producto));
   }
 
   registrarLiberacion(data: LiberacionMovimientoData): void {
     this._loading.set(true);
+    this._error.set(null);
     this.movimientosService.registrarLiberacion(data)
       .pipe(
         catchError(() => {
           this._error.set('Error al registrar liberación');
-          return of(null);
+          return EMPTY;
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
+      .subscribe(() => this.cargarKardex(data.producto));
   }
 
   registrarAjuste(data: AjusteMovimientoData): void {
     this._loading.set(true);
+    this._error.set(null);
     this.movimientosService.registrarAjuste(data)
       .pipe(
         catchError(() => {
           this._error.set('Error al registrar ajuste');
-          return of(null);
+          return EMPTY;
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(res => { if (res) this.cargarKardex(data.producto); });
+      .subscribe(() => this.cargarKardex(data.producto));
   }
 }

--- a/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
@@ -25,6 +25,13 @@ export class KardexFacade {
   private _loading                  = signal<boolean>(false);
   private _error                    = signal<string | null>(null);
 
+  /** Paginación del kardex (GET /inventory/movimientos/{productoId}) */
+  private _paginacion = signal<{ totalElementos: number; totalPaginas: number; page: number; size: number }>({
+    totalElementos: 0, totalPaginas: 0, page: 0, size: 10,
+  });
+  /** productoId activo para reutilizarlo al navegar páginas sin pasarlo de nuevo */
+  private _productoIdActual = signal<string>('');
+
   // ── Lectura pública ──────────────────────────────────────────────────────────
   public movimientos              = computed(() => this._movimientos());
   public movimientoSeleccionado   = computed(() => this._movimientoSeleccionado());
@@ -33,6 +40,7 @@ export class KardexFacade {
   public kardexValorizado         = computed(() => this._kardexValorizado());
   public loading                  = computed(() => this._loading());
   public error                    = computed(() => this._error());
+  public paginacion               = computed(() => this._paginacion());
 
   // ── Kardex ───────────────────────────────────────────────────────────────────
 
@@ -41,20 +49,39 @@ export class KardexFacade {
   loadAll(): void {
     this._movimientos.set([]);
     this._error.set(null);
+    this._paginacion.set({ totalElementos: 0, totalPaginas: 0, page: 0, size: 10 });
   }
 
-  cargarKardex(productoId: string): void {
+  /**
+   * Carga la página indicada del kardex de un producto.
+   * Los params `pagina`/`tamano` coinciden con el Swagger (español).
+   * El productoId se memoriza para reutilizarlo en `irAPaginaKardex`.
+   */
+  cargarKardex(productoId: string, pagina = 0, tamano = 10): void {
     this._loading.set(true);
     this._error.set(null);
-    this.movimientosService.getKardex(productoId)
+    this._productoIdActual.set(productoId);
+    this.movimientosService.getKardex(productoId, pagina, tamano)
       .pipe(
         catchError(() => {
           this._error.set('Error al cargar el kardex');
-          return of([]);
+          return of({ movimientos: [], totalPaginas: 0, totalElementos: 0 });
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(data => this._movimientos.set(data));
+      .subscribe(({ movimientos, totalPaginas, totalElementos }) => {
+        this._movimientos.set(movimientos);
+        this._paginacion.set({ totalElementos, totalPaginas, page: pagina, size: tamano });
+      });
+  }
+
+  /** Navega a la página indicada del kardex del producto actualmente cargado. */
+  irAPaginaKardex(page: number): void {
+    const { size } = this._paginacion();
+    const productoId = this._productoIdActual();
+    if (productoId) {
+      this.cargarKardex(productoId, page, size);
+    }
   }
 
   cargarMovimiento(id: string): void {
@@ -129,7 +156,10 @@ export class KardexFacade {
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(() => this.cargarKardex(data.productoId));
+      .subscribe(() => {
+        const { page, size } = this._paginacion();
+        this.cargarKardex(data.productoId, page, size);
+      });
   }
 
   registrarSalida(data: SalidaMovimientoData): void {
@@ -143,7 +173,10 @@ export class KardexFacade {
         }),
         finalize(() => this._loading.set(false))
       )
-      .subscribe(() => this.cargarKardex(data.productoId));
+      .subscribe(() => {
+        const { page, size } = this._paginacion();
+        this.cargarKardex(data.productoId, page, size);
+      });
   }
 
   registrarReserva(data: ReservaMovimientoData): void {

--- a/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
@@ -9,6 +9,7 @@ import {
 import { ExistenciaProducto } from '../../models/inventario.model';
 import {
   MovimientoResponse,
+  MovimientoPageResponse,
   ExistenciaResponse,
   EntradaRequest,
   SalidaRequest,
@@ -16,6 +17,25 @@ import {
   LiberacionRequest,
   AjusteRequest,
 } from '../api/inventory.api';
+
+/**
+ * Normaliza la respuesta paginada de GET /inventory/movimientos/{productoId}.
+ * El backend no documenta el schema en Swagger (type: object genérico) y puede
+ * usar convención inglés (content/totalElements) o español (contenido/totalElementos).
+ */
+export function movimientoPageFromApi(resp: MovimientoPageResponse): {
+  movimientos:    Movimiento[];
+  totalPaginas:   number;
+  totalElementos: number;
+} {
+  const dtos: MovimientoResponse[] =
+    resp.content ?? resp.contenido ?? [];
+  return {
+    movimientos:    dtos.map(movimientoFromApi),
+    totalPaginas:   resp.totalPages   ?? resp.totalPaginas   ?? 0,
+    totalElementos: resp.totalElements ?? resp.totalElementos ?? 0,
+  };
+}
 
 export function movimientoFromApi(dto: MovimientoResponse): Movimiento {
   return {

--- a/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
@@ -45,28 +45,23 @@ export function existenciaFromApi(dto: ExistenciaResponse): ExistenciaProducto {
 
 export function entradaToRequest(data: EntradaMovimientoData): EntradaRequest {
   return {
-    productoId: data.producto,
-    cantidad: data.cantidad,
-    fecha: data.fecha,
-    proveedorId: data.proveedor,
-    facturaId: data.factura,
-    ubicacion: data.ubicacion,
-    valorUnitario: data.valorUnitario,
-    observaciones: data.observaciones,
+    productoId:      data.productoId,
+    cantidad:        data.cantidad,
+    precioUnitario:  data.precioUnitario,
+    facturaId:       data.facturaId,
+    proveedorNit:    data.proveedorNit,
+    gilId:           data.gilId,
+    conciliacionId:  data.conciliacionId,
   };
 }
 
 export function salidaToRequest(data: SalidaMovimientoData): SalidaRequest {
   return {
-    productoId: data.producto,
-    cantidad: data.cantidad,
-    fecha: data.fecha,
-    areaDestino: data.areaDestino,
-    instructorId: data.instructor,
-    fichaId: data.ficha,
-    categoria: data.categoria,
-    proposito: data.proposito,
-    observaciones: data.observaciones,
+    productoId:    data.productoId,
+    cantidad:      data.cantidad,
+    requisicionId: data.requisicionId,
+    instructorId:  data.instructorId,
+    categoria:     data.categoria,
   };
 }
 

--- a/libs/inventario/inventario/src/lib/data-access/mappers/legalization.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/legalization.mapper.ts
@@ -41,21 +41,22 @@ export function paqueteFromApi(dto: PaqueteResponse): PaqueteProbatorio {
 
 export function requisicionFromApi(dto: RequisicionResponse): Requisicion {
   return {
-    id: dto.id,
-    numero: dto.numero,
-    programa: dto.programa,
-    fichaId: dto.fichaId,
-    instructorId: dto.instructorId,
-    instructorNombre: dto.instructorNombre,
-    diaSemana: dto.diaSemana,
-    horaSesion: dto.horaSesion,
-    fecha: dto.fecha,
-    estado: dto.estado,
-    items: dto.items.map((i): RequisicionItem => ({
-      codigo: i.codigo,
-      descripcion: i.descripcion,
-      cantidad: i.cantidad,
-      unidad: i.unidad,
+    id:               dto.id               ?? '',
+    numero:           dto.numero           ?? '',
+    programa:         '',
+    fichaId:          dto.fichaId          ?? '',
+    instructorId:     dto.instructorId     ?? '',
+    instructorNombre: dto.instructorNombre ?? '',
+    diaSemana:        dto.diaSemana        ?? '',
+    horaSesion:       dto.horaSesion       ?? '',
+    fecha:            dto.fecha            ?? '',
+    estado:           dto.estado           ?? 'BORRADOR',
+    items: (dto.items ?? []).map((i): RequisicionItem => ({
+      productoId:     i.productoId     ?? '',
+      productoNombre: i.productoNombre ?? '',
+      cantidad:       i.cantidad       ?? 0,
+      unidadMedida:   i.unidadMedida   ?? '',
+      categoria:      i.categoria      ?? 'ABARROTES',
     })),
   };
 }

--- a/libs/inventario/inventario/src/lib/data-access/requisiciones.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/requisiciones.facade.ts
@@ -47,6 +47,21 @@ export class RequisicionesFacade {
       .subscribe(data => this._requisiciones.set(data));
   }
 
+  /** Carga requisiciones filtradas por estado (ej: 'DESPACHADA' para habilitar salidas). */
+  cargarPorEstado(estado: string): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.requisicionesService.getRequisicionesByEstado(estado)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al cargar requisiciones');
+          return of([]);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(data => this._requisiciones.set(data));
+  }
+
   /** Carga una requisición específica por ID. */
   cargarRequisicion(id: string): void {
     this._loading.set(true);

--- a/libs/inventario/inventario/src/lib/data-access/services/giles.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/giles.service.ts
@@ -1,0 +1,40 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { GilResponse, PagedGilResponse, EstadoGil } from '../api/procurement.api';
+
+const API = '/api/v1';
+
+export interface GilesParams {
+  estado?:               EstadoGil;
+  fichaCaracterizacion?: string;
+  page?:                 number;
+  size?:                 number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class GilesService {
+  private http = inject(HttpClient);
+
+  /** GET /api/v1/procurement/giles
+   *  Para entradas de Kardex usar estado: 'EMITIDO' | 'ENVIADO_PROVEEDOR' | 'CERRADO' */
+  getGiles(params: GilesParams = {}): Observable<PagedGilResponse> {
+    let httpParams = new HttpParams();
+    if (params.estado)               httpParams = httpParams.set('estado',               params.estado);
+    if (params.fichaCaracterizacion) httpParams = httpParams.set('fichaCaracterizacion', params.fichaCaracterizacion);
+    if (params.page != null)         httpParams = httpParams.set('page',                 String(params.page));
+    if (params.size != null)         httpParams = httpParams.set('size',                 String(params.size));
+
+    return this.http
+      .get<PagedGilResponse>(`${API}/procurement/giles`, { params: httpParams })
+      .pipe(catchError(err => throwError(() => err)));
+  }
+
+  /** GET /api/v1/procurement/giles/{id} */
+  getGilById(id: string): Observable<GilResponse> {
+    return this.http
+      .get<GilResponse>(`${API}/procurement/giles/${id}`)
+      .pipe(catchError(err => throwError(() => err)));
+  }
+}

--- a/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
@@ -76,35 +76,37 @@ export class MovimientosService {
 
   // ── Movimientos de entrada / salida ─────────────────────────────────────────
 
-  registrarEntrada(data: EntradaMovimientoData): Observable<{ success: boolean }> {
+  /** POST /inventory/movimientos/entrada — 201 No Content */
+  registrarEntrada(data: EntradaMovimientoData): Observable<void> {
     return this.http
-      .post<{ success: boolean }>(`${API}/inventory/movimientos/entrada`, entradaToRequest(data))
+      .post<void>(`${API}/inventory/movimientos/entrada`, entradaToRequest(data))
       .pipe(catchError(err => throwError(() => err)));
   }
 
-  registrarSalida(data: SalidaMovimientoData): Observable<{ success: boolean }> {
+  /** POST /inventory/movimientos/salida — 201 No Content */
+  registrarSalida(data: SalidaMovimientoData): Observable<void> {
     return this.http
-      .post<{ success: boolean }>(`${API}/inventory/movimientos/salida`, salidaToRequest(data))
+      .post<void>(`${API}/inventory/movimientos/salida`, salidaToRequest(data))
       .pipe(catchError(err => throwError(() => err)));
   }
 
   // ── Reserva / Liberación / Ajuste ───────────────────────────────────────────
 
-  registrarReserva(data: ReservaMovimientoData): Observable<{ success: boolean }> {
+  registrarReserva(data: ReservaMovimientoData): Observable<void> {
     return this.http
-      .post<{ success: boolean }>(`${API}/inventory/movimientos/reserva`, reservaToRequest(data))
+      .post<void>(`${API}/inventory/movimientos/reserva`, reservaToRequest(data))
       .pipe(catchError(err => throwError(() => err)));
   }
 
-  registrarLiberacion(data: LiberacionMovimientoData): Observable<{ success: boolean }> {
+  registrarLiberacion(data: LiberacionMovimientoData): Observable<void> {
     return this.http
-      .post<{ success: boolean }>(`${API}/inventory/movimientos/liberacion`, liberacionToRequest(data))
+      .post<void>(`${API}/inventory/movimientos/liberacion`, liberacionToRequest(data))
       .pipe(catchError(err => throwError(() => err)));
   }
 
-  registrarAjuste(data: AjusteMovimientoData): Observable<{ success: boolean }> {
+  registrarAjuste(data: AjusteMovimientoData): Observable<void> {
     return this.http
-      .post<{ success: boolean }>(`${API}/inventory/movimientos/ajuste`, ajusteToRequest(data))
+      .post<void>(`${API}/inventory/movimientos/ajuste`, ajusteToRequest(data))
       .pipe(catchError(err => throwError(() => err)));
   }
 

--- a/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/movimientos.service.ts
@@ -11,7 +11,7 @@ import {
   AjusteMovimientoData,
 } from '../../models/movimiento.model';
 import { ExistenciaProducto } from '../../models/inventario.model';
-import { MovimientoResponse, ExistenciaResponse } from '../api/inventory.api';
+import { MovimientoResponse, MovimientoPageResponse, ExistenciaResponse } from '../api/inventory.api';
 import { KardexValorizadoItemResponse } from '../api/reporting.api';
 import { KardexValorizadoItem } from '../../models/reporting.model';
 import {
@@ -22,6 +22,7 @@ import {
   reservaToRequest,
   liberacionToRequest,
   ajusteToRequest,
+  movimientoPageFromApi,
 } from '../mappers/inventory.mapper';
 import { kardexValorizadoFromApi } from '../mappers/reporting.mapper';
 
@@ -33,12 +34,23 @@ export class MovimientosService {
 
   // ── Kardex ──────────────────────────────────────────────────────────────────
 
-  /** Historial de movimientos de un producto (GET /inventory/movimientos/{productoId}) */
-  getKardex(productoId: string): Observable<Movimiento[]> {
+  /**
+   * GET /inventory/movimientos/{productoId}?pagina=0&tamano=10
+   * El Swagger declara params `pagina`/`tamano` (español) y respuesta genérica `object`.
+   * El mapper `movimientoPageFromApi` normaliza ambas convenciones de campo.
+   */
+  getKardex(
+    productoId: string,
+    pagina = 0,
+    tamano = 10,
+  ): Observable<{ movimientos: Movimiento[]; totalPaginas: number; totalElementos: number }> {
+    const params = new HttpParams()
+      .set('pagina', String(pagina))
+      .set('tamano', String(tamano));
     return this.http
-      .get<MovimientoResponse[]>(`${API}/inventory/movimientos/${productoId}`)
+      .get<MovimientoPageResponse>(`${API}/inventory/movimientos/${productoId}`, { params })
       .pipe(
-        map(list => list.map(movimientoFromApi)),
+        map(resp => movimientoPageFromApi(resp)),
         catchError(err => throwError(() => err))
       );
   }

--- a/libs/inventario/inventario/src/lib/data-access/services/requisiciones.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/requisiciones.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { Requisicion } from '../../models/requisicion.model';
@@ -15,6 +15,19 @@ export class RequisicionesService {
   getRequisiciones(): Observable<Requisicion[]> {
     return this.http
       .get<RequisicionResponse[]>(`${API}/legalization/requisiciones`)
+      .pipe(
+        map(list => list.map(requisicionFromApi)),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** GET /legalization/requisiciones?estado=X
+   *  Para salidas de Kardex usar estado 'DESPACHADA'.
+   *  Pendiente backend B-04: confirmar el enum de estados válidos. */
+  getRequisicionesByEstado(estado: string): Observable<Requisicion[]> {
+    const params = new HttpParams().set('estado', estado);
+    return this.http
+      .get<RequisicionResponse[]>(`${API}/legalization/requisiciones`, { params })
       .pipe(
         map(list => list.map(requisicionFromApi)),
         catchError(err => throwError(() => err))

--- a/libs/inventario/inventario/src/lib/models/movimiento.model.ts
+++ b/libs/inventario/inventario/src/lib/models/movimiento.model.ts
@@ -13,29 +13,28 @@ export interface Movimiento {
   estado: 'Completado' | 'Pendiente' | 'Cancelado';
 }
 
-/** Payload del formulario de registro de entrada */
+/** Payload del formulario de registro de entrada.
+ *  Alineado con RegistrarEntradaHttpRequest (Swagger).
+ *  Las entradas deben originarse desde un GIL validado → gilId obligatorio en ese flujo. */
 export interface EntradaMovimientoData {
-  producto: string;
-  cantidad: number;
-  fecha: string;
-  proveedor: string;
-  factura?: string;
-  ubicacion: string;
-  valorUnitario: number;
-  observaciones?: string;
+  productoId:      string;
+  cantidad:        number;
+  precioUnitario:  number;
+  facturaId?:      string;
+  proveedorNit?:   string;
+  gilId?:          string;
+  conciliacionId?: string;
 }
 
-/** Payload del formulario de registro de salida */
+/** Payload del formulario de registro de salida.
+ *  Alineado con RegistrarSalidaHttpRequest (Swagger).
+ *  Las salidas DEBEN referenciar una requisición válida → requisicionId obligatorio. */
 export interface SalidaMovimientoData {
-  producto: string;
-  cantidad: number;
-  fecha: string;
-  areaDestino: string;
-  instructor?: string;
-  ficha?: string;
-  categoria: string;
-  proposito: string;
-  observaciones?: string;
+  productoId:    string;
+  cantidad:      number;
+  requisicionId: string;
+  instructorId:  string;
+  categoria:     string;
 }
 
 /** Payload para reservar stock de un producto */

--- a/libs/inventario/inventario/src/lib/models/requisicion.model.ts
+++ b/libs/inventario/inventario/src/lib/models/requisicion.model.ts
@@ -10,11 +10,21 @@ export type RequisicionEstado =
   | 'FIRMADA'
   | 'LEGALIZADA';
 
+/** Categorías de insumo — enum Swagger (B-04) */
+export type CategoriaInsumo =
+  | 'ABARROTES'
+  | 'LACTEOS'
+  | 'FRUTAS_Y_VEGETALES'
+  | 'CARNES_PESCADOS_MARISCOS';
+
+/** Ítem de requisición — Swagger actualizado (B-02).
+ *  productoId = codigoSena del catálogo; usar como productoId en RegistrarSalidaHttpRequest. */
 export interface RequisicionItem {
-  codigo:      string;
-  descripcion: string;
-  cantidad:    number;
-  unidad:      string;
+  productoId:     string;
+  productoNombre: string;
+  cantidad:       number;
+  unidadMedida:   string;
+  categoria:      CategoriaInsumo;
 }
 
 export interface Requisicion {
@@ -46,8 +56,8 @@ export const MOCK_REQUISICIONES: Requisicion[] = [
     fecha: '10/04/2026',
     estado: 'BORRADOR',
     items: [
-      { codigo: 'INS-001', descripcion: 'Harina de Trigo', cantidad: 5, unidad: 'kg' },
-      { codigo: 'INS-002', descripcion: 'Aceite de Oliva', cantidad: 2, unidad: 'L' },
+      { productoId: 'SENA-INS-001', productoNombre: 'Harina de Trigo', cantidad: 5, unidadMedida: 'kg', categoria: 'ABARROTES' },
+      { productoId: 'SENA-INS-002', productoNombre: 'Aceite de Oliva', cantidad: 2, unidadMedida: 'L', categoria: 'ABARROTES' },
     ],
   },
   {
@@ -62,7 +72,7 @@ export const MOCK_REQUISICIONES: Requisicion[] = [
     fecha: '08/04/2026',
     estado: 'ENVIADA',
     items: [
-      { codigo: 'INS-003', descripcion: 'Mantequilla sin sal', cantidad: 3, unidad: 'kg' },
+      { productoId: 'SENA-INS-003', productoNombre: 'Mantequilla sin sal', cantidad: 3, unidadMedida: 'kg', categoria: 'LACTEOS' },
     ],
   },
   {
@@ -77,7 +87,7 @@ export const MOCK_REQUISICIONES: Requisicion[] = [
     fecha: '05/04/2026',
     estado: 'DESPACHADA',
     items: [
-      { codigo: 'INS-004', descripcion: 'Azúcar Glass', cantidad: 4, unidad: 'kg' },
+      { productoId: 'SENA-INS-004', productoNombre: 'Azúcar Glass', cantidad: 4, unidadMedida: 'kg', categoria: 'ABARROTES' },
     ],
   },
   {
@@ -92,7 +102,7 @@ export const MOCK_REQUISICIONES: Requisicion[] = [
     fecha: '01/04/2026',
     estado: 'FIRMADA',
     items: [
-      { codigo: 'INS-005', descripcion: 'Vino Tinto Selección', cantidad: 2, unidad: 'botella' },
+      { productoId: 'SENA-INS-005', productoNombre: 'Vino Tinto Selección', cantidad: 2, unidadMedida: 'botella', categoria: 'ABARROTES' },
     ],
   },
 ];

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.html
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.html
@@ -36,6 +36,34 @@
             }
             <lucide-icon name="chevron-down" [size]="18" class="icon-right"></lucide-icon>
           </div>
+
+          <!-- Paginación del selector de GIL -->
+          @if (!gilesFacade.loading() && gilesFacade.paginacion().totalPages > 1) {
+            <div class="pagination-row">
+              <button
+                class="page-btn"
+                type="button"
+                [disabled]="gilesFacade.paginacion().page === 0"
+                (click)="gilesFacade.irAPagina(gilesFacade.paginacion().page - 1)">
+                <lucide-icon name="chevron-left" [size]="14"></lucide-icon>
+                Anterior
+              </button>
+              <span class="page-info">
+                Página {{ gilesFacade.paginacion().page + 1 }}
+                de {{ gilesFacade.paginacion().totalPages }}
+                <span class="page-total">({{ gilesFacade.paginacion().totalElements }} GILes)</span>
+              </span>
+              <button
+                class="page-btn"
+                type="button"
+                [disabled]="gilesFacade.paginacion().page >= gilesFacade.paginacion().totalPages - 1"
+                (click)="gilesFacade.irAPagina(gilesFacade.paginacion().page + 1)">
+                Siguiente
+                <lucide-icon name="chevron-right" [size]="14"></lucide-icon>
+              </button>
+            </div>
+          }
+
           <p class="hint-text">
             <lucide-icon name="info" [size]="14"></lucide-icon>
             Solo GILes en estado EMITIDO, ENVIADO_PROVEEDOR o CERRADO.

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.html
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.html
@@ -65,20 +65,6 @@
           @if (bienesActuales().length === 0) {
             <p class="hint-text">Este GIL no tiene bienes registrados.</p>
           } @else {
-            <!-- Aviso backend pendiente B-01 -->
-            @if (hayBienSinProducto()) {
-              <div class="error-summary">
-                <lucide-icon name="alert-triangle" [size]="20" class="error-icon"></lucide-icon>
-                <div>
-                  <h4>Ítems sin productoId en el catálogo</h4>
-                  <p>
-                    Uno o más ítems de este GIL no tienen productoId en el backend (tarea B-01 pendiente).
-                    Solo se registrarán los ítems que sí tienen producto vinculado.
-                  </p>
-                </div>
-              </div>
-            }
-
             <div class="items-table-container">
               <div style="overflow-x: auto;">
                 <table class="items-table">
@@ -89,23 +75,18 @@
                       <th class="text-center">Cant. GIL</th>
                       <th class="text-center" style="width: 8rem;">Cant. Recibida</th>
                       <th class="text-right" style="width: 9rem;">Precio Unitario</th>
-                      <th class="text-right">Estado</th>
                     </tr>
                   </thead>
                   <tbody>
                     @for (bien of bienesActuales(); track bien.codigoSena; let i = $index) {
-                      <tr class="table-row" [class.table-row--error]="!bien.productoId">
+                      <tr class="table-row">
                         <td>
-                          <div class="item-name" [class.item-name--error]="!bien.productoId">
-                            @if (!bien.productoId) {
-                              <lucide-icon name="alert-circle" [size]="16" class="error-icon"></lucide-icon>
-                            }
-                            {{ bien.descripcion ?? '—' }}
+                          <div class="item-name">{{ bien.descripcion ?? '—' }}</div>
+                          <div class="item-desc" style="font-family: monospace; font-size: 0.7rem;">
+                            {{ bien.productoId }}
                           </div>
                         </td>
-                        <td class="code-text" [class.code-text--error]="!bien.productoId">
-                          {{ bien.codigoSena ?? '—' }}
-                        </td>
+                        <td class="code-text">{{ bien.codigoSena ?? '—' }}</td>
                         <td class="text-center">{{ bien.cantidad ?? 0 }}</td>
                         <td>
                           <input
@@ -113,28 +94,14 @@
                             class="qty-input"
                             [formControl]="getBienGroup(i).get('cantidadRecibida')!"
                             [max]="bien.cantidad ?? 9999"
-                            min="0"
-                            [disabled]="!bien.productoId">
+                            min="0">
                         </td>
                         <td>
                           <input
                             type="number"
                             class="qty-input"
                             [formControl]="getBienGroup(i).get('precioUnitario')!"
-                            min="0"
-                            [disabled]="!bien.productoId">
-                        </td>
-                        <td class="text-right">
-                          @if (bien.productoId) {
-                            <span class="status-ok">
-                              <span class="dot"></span> OK
-                            </span>
-                          } @else {
-                            <span class="status-error">
-                              <span class="err-title">SIN PRODUCTO ID</span>
-                              <span class="err-link">Pendiente backend B-01</span>
-                            </span>
-                          }
+                            min="0">
                         </td>
                       </tr>
                     }

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.html
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.html
@@ -1,159 +1,168 @@
 <div class="modal-overlay">
-  <!-- Modal Container -->
   <div class="modal-content">
-    
-    <!-- Modal Header -->
+
+    <!-- Header -->
     <div class="modal-header">
       <div>
-        <h2 class="modal-title">Registrar Entrada</h2>
-        <p class="modal-subtitle">Basado en Formulario GIL-F-014</p>
+        <h2 class="modal-title">Registrar Entrada por GIL</h2>
+        <p class="modal-subtitle">Formulario GIL-F-014 — solo GILes en estado Emitido, Enviado o Cerrado</p>
       </div>
       <button class="close-btn" (click)="closeModal()" aria-label="Cerrar modal">
         <lucide-icon name="x" [size]="20"></lucide-icon>
       </button>
     </div>
 
-    <!-- Modal Body -->
+    <!-- Body -->
     <div class="modal-body">
-      
-      <!-- Form Info Section -->
+
+      <!-- Selector de GIL -->
       <section class="info-section">
-        <!-- GIL Selector -->
         <div class="form-group">
-          <label>CÓDIGO DE GIL-F-014 ORIGEN</label>
+          <label>GIL ORIGEN</label>
           <div class="select-wrapper">
-            <select class="form-select">
-              <option value="" disabled>Seleccione un formulario aprobado...</option>
-              <option value="GIL-2023-089" selected>GIL-2023-089 - Traslado Sede Central (Aprobado)</option>
-              <option value="GIL-2023-091">GIL-2023-091 - Dotación Laboratorio (Procesado)</option>
-              <option value="GIL-2023-095">GIL-2023-095 - Equipos Cómputo (Aprobado)</option>
-            </select>
+            @if (gilesFacade.loading()) {
+              <select class="form-select" disabled>
+                <option>Cargando GILes...</option>
+              </select>
+            } @else {
+              <select class="form-select" (change)="onGilChange($event)">
+                <option value="">Seleccione un GIL validado...</option>
+                @for (gil of gilesFacade.giles(); track gil.id) {
+                  <option [value]="gil.id">
+                    {{ gil.numeroGil ?? gil.id }} — {{ gil.destinoBienes ?? gil.area }} ({{ gil.estado }})
+                  </option>
+                }
+              </select>
+            }
             <lucide-icon name="chevron-down" [size]="18" class="icon-right"></lucide-icon>
           </div>
           <p class="hint-text">
             <lucide-icon name="info" [size]="14"></lucide-icon>
-            Solo se listan formularios en estado Aprobado o Procesado.
+            Solo GILes en estado EMITIDO, ENVIADO_PROVEEDOR o CERRADO.
           </p>
         </div>
 
-        <!-- Date -->
-        <div class="form-group">
-          <label>FECHA DE ENTRADA</label>
-          <input type="date" class="form-input">
-        </div>
-
-        <!-- Receiver -->
-        <div class="form-group">
-          <label>RESPONSABLE DE RECEPCIÓN</label>
-          <input type="text" class="form-input" placeholder="Nombre completo">
-        </div>
+        @if (gilSeleccionado(); as gil) {
+          <div class="form-group">
+            <label>SOLICITANTE</label>
+            <input type="text" class="form-input" [value]="gil.solicitante ?? '—'" readonly>
+          </div>
+          <div class="form-group">
+            <label>FICHA</label>
+            <input type="text" class="form-input" [value]="gil.fichaCaracterizacion ?? '—'" readonly>
+          </div>
+        }
       </section>
 
-      <!-- Items Table Section -->
-      <section>
-        <div class="items-header">
-          <h3>Ítems a Ingresar</h3>
-          <span class="items-badge">3 Ítems Encontrados</span>
-        </div>
-
-        <div class="items-table-container">
-          <div style="overflow-x: auto;">
-            <table class="items-table">
-              <thead>
-                <tr>
-                  <th>Nombre del Bien</th>
-                  <th>Código SENA</th>
-                  <th class="text-center">Cant. Solicitada</th>
-                  <th class="text-center" style="width: 10rem;">Cant. Recibida</th>
-                  <th class="text-right">Estado</th>
-                </tr>
-              </thead>
-              <tbody>
-                <!-- Valid Row 1 -->
-                <tr class="table-row">
-                  <td>
-                    <div class="item-name">Monitor Dell 24"</div>
-                    <div class="item-desc">P2419H</div>
-                  </td>
-                  <td class="code-text">SENA-EQ-1042</td>
-                  <td class="text-center">15</td>
-                  <td>
-                    <input type="number" class="qty-input" value="15" min="0" max="15">
-                  </td>
-                  <td class="text-right">
-                    <span class="status-ok">
-                      <span class="dot"></span> OK
-                    </span>
-                  </td>
-                </tr>
-
-                <!-- Invalid Row -->
-                <tr class="table-row table-row--error">
-                  <td>
-                    <div class="item-name item-name--error">
-                      <lucide-icon name="alert-circle" [size]="18" class="error-icon"></lucide-icon>
-                      Teclado Mecánico RGB
-                    </div>
-                    <div class="item-desc item-desc--error">K95 Platinum</div>
-                  </td>
-                  <td class="code-text code-text--error">--</td>
-                  <td class="text-center" style="color: #ba1a1a;">5</td>
-                  <td>
-                    <input type="number" class="qty-input" value="0" disabled>
-                  </td>
-                  <td class="text-right">
-                    <span class="status-error">
-                      <span class="err-title">NO EXISTE EN CATÁLOGO</span>
-                      <a href="javascript:void(0)" class="err-link">Crear producto faltante &rarr;</a>
-                    </span>
-                  </td>
-                </tr>
-
-                <!-- Valid Row 2 -->
-                <tr class="table-row">
-                  <td>
-                    <div class="item-name">Mouse Inalámbrico Logitech</div>
-                    <div class="item-desc">M330 Silent</div>
-                  </td>
-                  <td class="code-text">SENA-AC-4091</td>
-                  <td class="text-center">20</td>
-                  <td>
-                    <input type="number" class="qty-input" value="20" min="0" max="20">
-                  </td>
-                  <td class="text-right">
-                    <span class="status-ok">
-                      <span class="dot"></span> OK
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+      <!-- Tabla de bienes -->
+      @if (gilIdSeleccionado() !== '') {
+        <section>
+          <div class="items-header">
+            <h3>Ítems del GIL</h3>
+            <span class="items-badge">{{ bienesActuales().length }} ítems</span>
           </div>
-        </div>
 
-        <!-- Error Summary -->
+          @if (bienesActuales().length === 0) {
+            <p class="hint-text">Este GIL no tiene bienes registrados.</p>
+          } @else {
+            <!-- Aviso backend pendiente B-01 -->
+            @if (hayBienSinProducto()) {
+              <div class="error-summary">
+                <lucide-icon name="alert-triangle" [size]="20" class="error-icon"></lucide-icon>
+                <div>
+                  <h4>Ítems sin productoId en el catálogo</h4>
+                  <p>
+                    Uno o más ítems de este GIL no tienen productoId en el backend (tarea B-01 pendiente).
+                    Solo se registrarán los ítems que sí tienen producto vinculado.
+                  </p>
+                </div>
+              </div>
+            }
+
+            <div class="items-table-container">
+              <div style="overflow-x: auto;">
+                <table class="items-table">
+                  <thead>
+                    <tr>
+                      <th>Descripción</th>
+                      <th>Código SENA</th>
+                      <th class="text-center">Cant. GIL</th>
+                      <th class="text-center" style="width: 8rem;">Cant. Recibida</th>
+                      <th class="text-right" style="width: 9rem;">Precio Unitario</th>
+                      <th class="text-right">Estado</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @for (bien of bienesActuales(); track bien.codigoSena; let i = $index) {
+                      <tr class="table-row" [class.table-row--error]="!bien.productoId">
+                        <td>
+                          <div class="item-name" [class.item-name--error]="!bien.productoId">
+                            @if (!bien.productoId) {
+                              <lucide-icon name="alert-circle" [size]="16" class="error-icon"></lucide-icon>
+                            }
+                            {{ bien.descripcion ?? '—' }}
+                          </div>
+                        </td>
+                        <td class="code-text" [class.code-text--error]="!bien.productoId">
+                          {{ bien.codigoSena ?? '—' }}
+                        </td>
+                        <td class="text-center">{{ bien.cantidad ?? 0 }}</td>
+                        <td>
+                          <input
+                            type="number"
+                            class="qty-input"
+                            [formControl]="getBienGroup(i).get('cantidadRecibida')!"
+                            [max]="bien.cantidad ?? 9999"
+                            min="0"
+                            [disabled]="!bien.productoId">
+                        </td>
+                        <td>
+                          <input
+                            type="number"
+                            class="qty-input"
+                            [formControl]="getBienGroup(i).get('precioUnitario')!"
+                            min="0"
+                            [disabled]="!bien.productoId">
+                        </td>
+                        <td class="text-right">
+                          @if (bien.productoId) {
+                            <span class="status-ok">
+                              <span class="dot"></span> OK
+                            </span>
+                          } @else {
+                            <span class="status-error">
+                              <span class="err-title">SIN PRODUCTO ID</span>
+                              <span class="err-link">Pendiente backend B-01</span>
+                            </span>
+                          }
+                        </td>
+                      </tr>
+                    }
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          }
+        </section>
+      }
+
+      <!-- Error de facade -->
+      @if (kardexFacade.error()) {
         <div class="error-summary">
           <lucide-icon name="alert-triangle" [size]="20" class="error-icon"></lucide-icon>
-          <div>
-            <h4>Errores en la validación del catálogo</h4>
-            <p>Existen ítems en el formulario GIL que no están registrados en el catálogo maestro. Debe solicitar la creación de estos bienes antes de poder procesar la entrada.</p>
-          </div>
+          <p>{{ kardexFacade.error() }}</p>
         </div>
-      </section>
-
-      <!-- Observations -->
-      <section class="form-group">
-        <label>OBSERVACIONES DE ENTRADA (OPCIONAL)</label>
-        <textarea class="form-textarea" rows="2" placeholder="Añada notas sobre el estado físico de los bienes recibidos..."></textarea>
-      </section>
+      }
 
     </div>
 
-    <!-- Modal Footer -->
+    <!-- Footer -->
     <div class="modal-footer">
       <restaurant-button variant="surface" (click)="closeModal()">Cancelar</restaurant-button>
-      <!-- Disabled Primary CTA -->
-      <restaurant-button variant="surface" [disabled]="true" style="opacity: 0.6;">
+      <restaurant-button
+        variant="primary"
+        (click)="onSubmit()"
+        [disabled]="!puedeRegistrar()">
         <div style="display: flex; align-items: center; gap: 0.5rem; font-weight: bold;">
           <lucide-icon name="save" [size]="18"></lucide-icon>
           Registrar Entrada por GIL

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.scss
@@ -341,6 +341,54 @@
   }
 }
 
+/* ── Paginación del selector GIL ── */
+.pagination-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.page-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.875rem;
+  background-color: #f3f4f5;
+  border: 1px solid rgba(189, 202, 185, 0.4);
+  border-radius: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #3e4a3c;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+
+  &:hover:not(:disabled) {
+    background-color: #e7e8e9;
+    border-color: rgba(0, 110, 37, 0.3);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.page-info {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #575f67;
+  flex: 1;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.page-total {
+  color: #9ea3a8;
+  font-weight: 400;
+}
+
 /* ── Modal Footer ── */
 .modal-footer {
   padding: 1.25rem 2rem;

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.ts
@@ -1,20 +1,114 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
-
+import { Component, inject, ChangeDetectionStrategy, computed, signal, effect } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, FormArray, FormGroup, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { LucideIconComponent, ButtonComponent } from '@restaurant/shared/ui';
+import { GilesFacade } from '../../../data-access/giles.facade';
+import { KardexFacade } from '../../../data-access/kardex.facade';
+import { BienGilResponse, GilResponse } from '../../../data-access/api/procurement.api';
+import { EntradaMovimientoData } from '../../../models/movimiento.model';
 
 @Component({
   selector: 'restaurant-movimiento-entrada-gil',
   standalone: true,
-  imports: [RouterModule, LucideIconComponent, ButtonComponent],
+  imports: [ReactiveFormsModule, RouterModule, LucideIconComponent, ButtonComponent],
   templateUrl: './movimiento-entrada-gil.component.html',
   styleUrl: './movimiento-entrada-gil.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MovimientoEntradaGilComponent {
-  private router = inject(Router);
+  private fb            = inject(FormBuilder);
+  private router        = inject(Router);
+  readonly gilesFacade  = inject(GilesFacade);
+  readonly kardexFacade = inject(KardexFacade);
+
+  // ── Estado del selector ───────────────────────────────────────────────────
+  gilIdSeleccionado = signal<string>('');
+
+  // ── Computed ──────────────────────────────────────────────────────────────
+  gilSeleccionado    = computed(() => this.gilesFacade.gilSeleccionado());
+  bienesActuales     = computed(() => this.gilSeleccionado()?.bienes ?? []);
+  bienesConProducto  = computed(() => this.bienesActuales().filter(b => !!b.productoId));
+  hayBienSinProducto = computed(() => this.bienesActuales().some(b => !b.productoId));
+  puedeRegistrar     = computed(() =>
+    this.gilIdSeleccionado() !== '' &&
+    this.bienesConProducto().length > 0 &&
+    this.bienesForm.valid &&
+    !this.kardexFacade.loading()
+  );
+
+  // ── FormArray: un FormGroup por bien ──────────────────────────────────────
+  bienesForm: FormArray = this.fb.array([]);
+
+  constructor() {
+    this.gilesFacade.cargarGilesValidados();
+
+    // Reconstruye el FormArray cada vez que cambia el GIL seleccionado
+    effect(() => {
+      this.reconstruirFormArray(this.bienesActuales());
+    });
+  }
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
+
+  onGilChange(event: Event): void {
+    const id = (event.target as HTMLSelectElement).value;
+    this.gilIdSeleccionado.set(id);
+    const gil: GilResponse | null = this.gilesFacade.giles().find(g => g.id === id) ?? null;
+    this.gilesFacade.seleccionarGil(gil);
+  }
+
+  onSubmit(): void {
+    if (!this.puedeRegistrar()) return;
+
+    const gil = this.gilSeleccionado();
+    if (!gil?.id) return;
+
+    this.bienesActuales().forEach((bien, i) => {
+      if (!bien.productoId) return; // pendiente backend B-01
+
+      const grupo = this.getBienGroup(i);
+      if (!grupo.valid) return;
+
+      const cantidadRecibida: number = grupo.get('cantidadRecibida')?.value ?? 0;
+      if (cantidadRecibida <= 0) return;
+
+      const entrada: EntradaMovimientoData = {
+        productoId:     bien.productoId,
+        cantidad:       cantidadRecibida,
+        precioUnitario: grupo.get('precioUnitario')?.value ?? 0,
+        gilId:          gil.id,
+      };
+
+      this.kardexFacade.registrarEntrada(entrada);
+    });
+
+    this.closeModal();
+  }
 
   closeModal(): void {
+    this.gilesFacade.limpiarSeleccion();
     this.router.navigate(['/app/inventario/movimientos']);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  getBienGroup(index: number): FormGroup {
+    return this.bienesForm.at(index) as FormGroup;
+  }
+
+  private reconstruirFormArray(bienes: BienGilResponse[]): void {
+    const grupos = bienes.map(bien =>
+      this.fb.group({
+        cantidadRecibida: [
+          bien.cantidad ?? 0,
+          [Validators.required, Validators.min(0), Validators.max(bien.cantidad ?? 9999)],
+        ],
+        precioUnitario: [
+          bien.valorUnitario ?? 0,
+          [Validators.required, Validators.min(0)],
+        ],
+      })
+    );
+    this.bienesForm = this.fb.array(grupos);
   }
 }

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.ts
@@ -4,7 +4,7 @@ import { Router, RouterModule } from '@angular/router';
 import { LucideIconComponent, ButtonComponent } from '@restaurant/shared/ui';
 import { GilesFacade } from '../../../data-access/giles.facade';
 import { KardexFacade } from '../../../data-access/kardex.facade';
-import { BienGilResponse, GilResponse } from '../../../data-access/api/procurement.api';
+import { BienGilResponse } from '../../../data-access/api/procurement.api';
 import { EntradaMovimientoData } from '../../../models/movimiento.model';
 
 @Component({
@@ -51,8 +51,9 @@ export class MovimientoEntradaGilComponent {
   onGilChange(event: Event): void {
     const id = (event.target as HTMLSelectElement).value;
     this.gilIdSeleccionado.set(id);
-    const gil: GilResponse | null = this.gilesFacade.giles().find(g => g.id === id) ?? null;
-    this.gilesFacade.seleccionarGil(gil);
+    // Cargamos por ID para garantizar que bienes esté completo
+    // (el endpoint de lista puede omitir subarrays por rendimiento)
+    this.gilesFacade.cargarGilById(id);
   }
 
   onSubmit(): void {

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada-gil/movimiento-entrada-gil.component.ts
@@ -25,13 +25,11 @@ export class MovimientoEntradaGilComponent {
   gilIdSeleccionado = signal<string>('');
 
   // ── Computed ──────────────────────────────────────────────────────────────
-  gilSeleccionado    = computed(() => this.gilesFacade.gilSeleccionado());
-  bienesActuales     = computed(() => this.gilSeleccionado()?.bienes ?? []);
-  bienesConProducto  = computed(() => this.bienesActuales().filter(b => !!b.productoId));
-  hayBienSinProducto = computed(() => this.bienesActuales().some(b => !b.productoId));
-  puedeRegistrar     = computed(() =>
+  gilSeleccionado = computed(() => this.gilesFacade.gilSeleccionado());
+  bienesActuales  = computed(() => this.gilSeleccionado()?.bienes ?? []);
+  puedeRegistrar  = computed(() =>
     this.gilIdSeleccionado() !== '' &&
-    this.bienesConProducto().length > 0 &&
+    this.bienesActuales().length > 0 &&
     this.bienesForm.valid &&
     !this.kardexFacade.loading()
   );
@@ -64,8 +62,6 @@ export class MovimientoEntradaGilComponent {
     if (!gil?.id) return;
 
     this.bienesActuales().forEach((bien, i) => {
-      if (!bien.productoId) return; // pendiente backend B-01
-
       const grupo = this.getBienGroup(i);
       if (!grupo.valid) return;
 
@@ -73,7 +69,7 @@ export class MovimientoEntradaGilComponent {
       if (cantidadRecibida <= 0) return;
 
       const entrada: EntradaMovimientoData = {
-        productoId:     bien.productoId,
+        productoId:     bien.productoId ?? '',
         cantidad:       cantidadRecibida,
         precioUnitario: grupo.get('precioUnitario')?.value ?? 0,
         gilId:          gil.id,

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada/movimiento-entrada.component.html
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada/movimiento-entrada.component.html
@@ -1,15 +1,15 @@
 <div class="modal-overlay">
-  <!-- Modal Content -->
   <div class="modal-content">
-    <!-- Modal Header -->
+
+    <!-- Header -->
     <div class="modal-header">
       <div class="header-info">
         <div class="header-icon">
           <lucide-icon name="plus-circle" [size]="28"></lucide-icon>
         </div>
         <div>
-          <h3 class="modal-title">Registrar Entrada de Producto</h3>
-          <p class="modal-subtitle">Complete la información para actualizar el stock.</p>
+          <h3 class="modal-title">Registrar Entrada Directa</h3>
+          <p class="modal-subtitle">Para entradas desde GIL use el formulario específico.</p>
         </div>
       </div>
       <button class="close-btn" (click)="closeModal()">
@@ -17,92 +17,116 @@
       </button>
     </div>
 
-    <!-- Modal Body -->
+    <!-- Aviso de uso -->
+    <div class="notice-banner">
+      <lucide-icon name="info" [size]="16"></lucide-icon>
+      <span>
+        Este formulario es para entradas excepcionales. Si la entrada corresponde a un GIL aprobado,
+        <a routerLink="/app/inventario/movimientos/entrada-gil" (click)="closeModal()">use el formulario de GIL</a>.
+      </span>
+    </div>
+
+    <!-- Body -->
     <form [formGroup]="entradaForm" (ngSubmit)="onSubmit()" class="modal-body">
       <div class="form-grid">
-        <!-- Product Search -->
+
+        <!-- Producto ID (UUID) -->
         <div class="form-group full-width">
-          <label>Código o Nombre del Producto</label>
+          <label>ID DEL PRODUCTO <span class="required">*</span></label>
           <div class="input-wrapper">
             <lucide-icon name="barcode" class="input-icon" [size]="18"></lucide-icon>
-            <input type="text" formControlName="producto" placeholder="Buscar por código o nombre..." class="form-input">
+            <input
+              type="text"
+              formControlName="productoId"
+              placeholder="UUID del producto del catálogo"
+              class="form-input"
+              style="font-family: monospace;">
           </div>
+          @if (entradaForm.get('productoId')?.invalid && entradaForm.get('productoId')?.touched) {
+            <p class="error-hint">El ID del producto es obligatorio.</p>
+          }
         </div>
 
-        <!-- Quantity -->
+        <!-- Cantidad -->
         <div class="form-group">
-          <label>CANTIDAD</label>
+          <label>CANTIDAD <span class="required">*</span></label>
           <div class="input-wrapper">
             <lucide-icon name="package-plus" class="input-icon" [size]="18"></lucide-icon>
             <input type="number" formControlName="cantidad" placeholder="0" class="form-input">
           </div>
         </div>
 
-        <!-- Date -->
+        <!-- Precio Unitario -->
         <div class="form-group">
-          <label>FECHA</label>
-          <div class="input-wrapper">
-            <lucide-icon name="calendar" class="input-icon" [size]="18"></lucide-icon>
-            <input type="date" formControlName="fecha" class="form-input">
-          </div>
-        </div>
-
-        <!-- Provider -->
-        <div class="form-group">
-          <label>PROVEEDOR</label>
-          <div class="input-wrapper">
-            <lucide-icon name="building-2" class="input-icon" [size]="18"></lucide-icon>
-            <select formControlName="proveedor" class="form-select">
-              <option value="">Seleccione proveedor...</option>
-              <option value="tech">TechSupply Global S.A.</option>
-              <option value="infrared">InfraRed Mayoristas</option>
-            </select>
-          </div>
-        </div>
-
-        <!-- Invoice Number (FEL) -->
-        <div class="form-group">
-          <label>NÚMERO DE FACTURA (FEL)</label>
-          <div class="input-wrapper">
-            <lucide-icon name="receipt" class="input-icon" [size]="18"></lucide-icon>
-            <select formControlName="factura" class="form-select">
-              <option value="">Seleccionar factura registrada...</option>
-              <option value="FAC-2026-045">FAC-2026-045 (Registrada)</option>
-              <option value="FAC-2026-046">FAC-2026-046 (Verificada)</option>
-            </select>
-          </div>
-          <span class="field-hint">Solo facturas en estado Registrada o Verificada</span>
-        </div>
-
-        <!-- Warehouse Location -->
-        <div class="form-group">
-          <label>UBICACIÓN</label>
-          <div class="input-wrapper">
-            <lucide-icon name="map-pin" class="input-icon" [size]="18"></lucide-icon>
-            <input type="text" formControlName="ubicacion" placeholder="Pasillo A - Estante 4" class="form-input">
-          </div>
-        </div>
-
-        <!-- Unit Price -->
-        <div class="form-group">
-          <label>VALOR UNITARIO</label>
+          <label>PRECIO UNITARIO <span class="required">*</span></label>
           <div class="input-wrapper">
             <lucide-icon name="banknote" class="input-icon" [size]="18"></lucide-icon>
-            <input type="number" formControlName="valorUnitario" placeholder="0.00" class="form-input">
+            <input type="number" formControlName="precioUnitario" placeholder="0.00" class="form-input">
           </div>
         </div>
 
-        <!-- Observations -->
-        <div class="form-group full-width">
-          <label>OBSERVACIONES</label>
-          <textarea formControlName="observaciones" rows="3" placeholder="Detalles adicionales sobre el envío o estado del producto..." class="form-textarea"></textarea>
+        <!-- NIT Proveedor -->
+        <div class="form-group">
+          <label>NIT DEL PROVEEDOR</label>
+          <div class="input-wrapper">
+            <lucide-icon name="building-2" class="input-icon" [size]="18"></lucide-icon>
+            <input
+              type="text"
+              formControlName="proveedorNit"
+              placeholder="900123456-1"
+              class="form-input"
+              style="font-family: monospace;">
+          </div>
         </div>
+
+        <!-- Factura ID -->
+        <div class="form-group">
+          <label>ID DE FACTURA</label>
+          <div class="input-wrapper">
+            <lucide-icon name="receipt" class="input-icon" [size]="18"></lucide-icon>
+            <input
+              type="text"
+              formControlName="facturaId"
+              placeholder="UUID de la factura registrada"
+              class="form-input"
+              style="font-family: monospace;">
+          </div>
+        </div>
+
+        <!-- GIL ID (opcional para trazabilidad) -->
+        <div class="form-group">
+          <label>GIL ID <span class="optional">(opcional)</span></label>
+          <div class="input-wrapper">
+            <lucide-icon name="link" class="input-icon" [size]="18"></lucide-icon>
+            <input
+              type="text"
+              formControlName="gilId"
+              placeholder="UUID del GIL vinculado"
+              class="form-input"
+              style="font-family: monospace;">
+          </div>
+        </div>
+
+        <!-- Conciliación ID (opcional) -->
+        <div class="form-group">
+          <label>ID DE CONCILIACIÓN <span class="optional">(opcional)</span></label>
+          <div class="input-wrapper">
+            <lucide-icon name="git-merge" class="input-icon" [size]="18"></lucide-icon>
+            <input
+              type="text"
+              formControlName="conciliacionId"
+              placeholder="UUID de la conciliación"
+              class="form-input"
+              style="font-family: monospace;">
+          </div>
+        </div>
+
       </div>
 
-      <!-- Modal Footer -->
+      <!-- Footer -->
       <div class="modal-footer">
-        <restaurant-button variant="surface" (click)="closeModal()">Cancelar</restaurant-button>
-        <restaurant-button variant="primary" type="submit" [disabled]="entradaForm.invalid">
+        <restaurant-button variant="surface" (click)="closeModal()" type="button">Cancelar</restaurant-button>
+        <restaurant-button variant="primary" type="submit" [disabled]="entradaForm.invalid || facade.loading()">
           <lucide-icon name="check-circle" [size]="18" style="margin-right: 0.5rem;"></lucide-icon>
           Registrar Entrada
         </restaurant-button>

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada/movimiento-entrada.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada/movimiento-entrada.component.scss
@@ -174,3 +174,42 @@
   justify-content: flex-end;
   gap: 1rem;
 }
+
+/* ── Aviso de uso ── */
+.notice-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: #3e4a3c;
+  padding: 0.75rem 2rem;
+  background-color: rgba(0, 110, 37, 0.06);
+  border-bottom: 1px solid rgba(0, 110, 37, 0.12);
+
+  a {
+    color: #006e25;
+    font-weight: 600;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}
+
+.required {
+  color: #ba1a1a;
+  margin-left: 0.125rem;
+}
+
+.optional {
+  color: #94a3b8;
+  font-weight: 400;
+  font-style: italic;
+  font-size: 0.75em;
+}
+
+.error-hint {
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: #ba1a1a;
+  margin-top: 0.25rem;
+  padding-left: 0.25rem;
+}

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada/movimiento-entrada.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-entrada/movimiento-entrada.component.ts
@@ -1,33 +1,36 @@
 import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
-
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { LucideIconComponent, ButtonComponent } from '@restaurant/shared/ui';
 import { KardexFacade } from '../../../data-access/kardex.facade';
 import { EntradaMovimientoData } from '../../../models/movimiento.model';
 
+/**
+ * Entrada directa sin GIL — para casos excepcionales (ajustes de stock, devoluciones, etc.).
+ * Para entradas desde GIL usar la ruta /entrada-gil.
+ * Alineado con RegistrarEntradaHttpRequest (Swagger).
+ */
 @Component({
   selector: 'restaurant-movimiento-entrada',
   standalone: true,
   imports: [ReactiveFormsModule, RouterModule, LucideIconComponent, ButtonComponent],
   templateUrl: './movimiento-entrada.component.html',
   styleUrl: './movimiento-entrada.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MovimientoEntradaComponent {
   private fb     = inject(FormBuilder);
   private router = inject(Router);
-  private facade = inject(KardexFacade);
+  readonly facade = inject(KardexFacade);
 
   entradaForm: FormGroup = this.fb.group({
-    producto:      ['', Validators.required],
-    cantidad:      [null, [Validators.required, Validators.min(1)]],
-    fecha:         ['', Validators.required],
-    proveedor:     ['', Validators.required],
-    factura:       [''],
-    ubicacion:     ['', Validators.required],
-    valorUnitario: [null, [Validators.required, Validators.min(0)]],
-    observaciones: [''],
+    productoId:      ['', Validators.required],
+    cantidad:        [null, [Validators.required, Validators.min(1)]],
+    precioUnitario:  [null, [Validators.required, Validators.min(0)]],
+    proveedorNit:    [''],
+    facturaId:       [''],
+    gilId:           [''],
+    conciliacionId:  [''],
   });
 
   onSubmit(): void {

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.html
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.html
@@ -12,7 +12,7 @@
             <h3 class="modal-title">Registrar Salida de Producto</h3>
             <span class="req-badge">REQ-45-S</span>
           </div>
-          <p class="modal-subtitle">La salida debe estar vinculada a una Requisición DESPACHADA.</p>
+          <p class="modal-subtitle">Solo requisiciones en estado ENVIADA habilitan salida.</p>
         </div>
       </div>
       <button class="close-btn" (click)="closeModal()">
@@ -21,7 +21,7 @@
     </div>
 
     <!-- Body -->
-    <form [formGroup]="salidaForm" (ngSubmit)="onSubmit()" class="modal-body">
+    <form (ngSubmit)="onSubmit()" class="modal-body">
       <div class="form-grid">
 
         <!-- Selector de requisición -->
@@ -31,17 +31,17 @@
             <select class="form-select full-select" disabled>
               <option>Cargando requisiciones...</option>
             </select>
-          } @else if (requisicionesDespachadas().length === 0) {
+          } @else if (requisicionesEnviadas().length === 0) {
             <div class="empty-notice">
               <lucide-icon name="inbox" [size]="16"></lucide-icon>
-              No hay requisiciones en estado DESPACHADA disponibles.
+              No hay requisiciones en estado ENVIADA disponibles.
             </div>
           } @else {
             <select class="form-select full-select" (change)="onRequisicionChange($event)">
-              <option value="">Seleccione una requisición despachada...</option>
-              @for (req of requisicionesDespachadas(); track req.id) {
+              <option value="">Seleccione una requisición enviada...</option>
+              @for (req of requisicionesEnviadas(); track req.id) {
                 <option [value]="req.id">
-                  {{ req.numero }} — {{ req.instructorNombre }} — {{ req.fecha }} ({{ req.programa }})
+                  {{ req.numero }} — {{ req.instructorNombre }} — {{ req.fecha }}
                 </option>
               }
             </select>
@@ -65,71 +65,68 @@
             </div>
           </div>
 
-          <!-- Ítems de la requisición (referencia visual) -->
-          @if (req.items.length > 0) {
-            <div class="items-ref full-width">
-              <p class="items-ref-title">
-                <lucide-icon name="list" [size]="14"></lucide-icon>
-                Ítems de la requisición (referencia):
-              </p>
-              <ul class="items-ref-list">
-                @for (item of req.items; track item.codigo) {
-                  <li>
-                    <span class="item-code">{{ item.codigo }}</span>
-                    {{ item.descripcion }} — {{ item.cantidad }} {{ item.unidad }}
-                  </li>
-                }
-              </ul>
-              <p class="hint-text">
-                <lucide-icon name="info" [size]="13"></lucide-icon>
-                Pendiente backend B-02: cuando los ítems expongan productoId, el formulario se pre-llenará automáticamente.
-              </p>
+          <!-- Tabla de ítems pre-llenada -->
+          @if (itemsActuales().length > 0) {
+            <div class="full-width">
+              <div class="items-header">
+                <h3 class="items-title">Ítems de la Requisición</h3>
+                <span class="items-badge">{{ itemsActuales().length }} ítems</span>
+              </div>
+
+              <div class="items-table-container">
+                <div style="overflow-x: auto;">
+                  <table class="items-table">
+                    <thead>
+                      <tr>
+                        <th>Producto</th>
+                        <th>Unidad</th>
+                        <th class="text-center" style="width: 8rem;">Cantidad</th>
+                        <th style="width: 12rem;">Categoría</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      @for (item of itemsActuales(); track item.productoId; let i = $index) {
+                        <tr class="table-row">
+                          <td>
+                            <div class="item-name">{{ item.productoNombre }}</div>
+                            <div class="item-desc" style="font-family: monospace; font-size: 0.7rem;">
+                              {{ item.productoId }}
+                            </div>
+                          </td>
+                          <td class="code-text">{{ item.unidadMedida }}</td>
+                          <td>
+                            <input
+                              type="number"
+                              class="qty-input"
+                              [formControl]="getItemGroup(i).get('cantidad')!"
+                              [max]="item.cantidad"
+                              min="1">
+                          </td>
+                          <td>
+                            <select
+                              class="form-select"
+                              style="font-size: 0.8rem; padding: 0.4rem 0.75rem;"
+                              [formControl]="getItemGroup(i).get('categoria')!">
+                              <option value="ABARROTES">Abarrotes</option>
+                              <option value="LACTEOS">Lácteos</option>
+                              <option value="FRUTAS_Y_VEGETALES">Frutas y Vegetales</option>
+                              <option value="CARNES_PESCADOS_MARISCOS">Carnes / Pescados</option>
+                            </select>
+                          </td>
+                        </tr>
+                      }
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          } @else {
+            <div class="empty-notice full-width">
+              <lucide-icon name="inbox" [size]="16"></lucide-icon>
+              Esta requisición no tiene ítems registrados.
             </div>
           }
         }
-
-        <!-- Separador -->
-        <div class="separator full-width"></div>
-
-        <!-- Producto + Cantidad -->
-        <div class="form-group product-col">
-          <label>ID DEL PRODUCTO <span class="required">*</span></label>
-          <div class="input-wrapper">
-            <lucide-icon name="scan-barcode" class="input-icon" [size]="18"></lucide-icon>
-            <input
-              type="text"
-              formControlName="productoId"
-              placeholder="UUID del producto"
-              class="form-input"
-              style="font-family: monospace;">
-          </div>
-          @if (salidaForm.get('productoId')?.invalid && salidaForm.get('productoId')?.touched) {
-            <p class="error-hint">El ID del producto es obligatorio.</p>
-          }
-        </div>
-
-        <div class="form-group qty-col">
-          <label>CANTIDAD <span class="required">*</span></label>
-          <div class="input-wrapper">
-            <input type="number" formControlName="cantidad" placeholder="0" class="form-input qty-input">
-            <span class="suffix">uds</span>
-          </div>
-        </div>
-
-        <!-- Categoría -->
-        <div class="form-group full-width">
-          <label>CATEGORÍA <span class="required">*</span></label>
-          <select formControlName="categoria" class="form-select full-select">
-            <option value="" disabled selected>Seleccione una categoría</option>
-            <option value="abarrotes">Abarrotes</option>
-            <option value="lacteos">Lácteos</option>
-            <option value="frutas">Frutas y Vegetales</option>
-            <option value="carnes">Carnes y Pescados</option>
-            <option value="bebidas">Bebidas</option>
-            <option value="condimentos">Condimentos y Especias</option>
-            <option value="otros">Otros</option>
-          </select>
-        </div>
 
         <!-- Error de facade -->
         @if (kardexFacade.error()) {
@@ -147,7 +144,7 @@
         <restaurant-button
           variant="primary"
           type="submit"
-          [disabled]="salidaForm.invalid || kardexFacade.loading()">
+          [disabled]="!puedeRegistrar()">
           <div style="display: flex; align-items: center; gap: 0.5rem; font-weight: bold;">
             <lucide-icon name="check-circle" [size]="18"></lucide-icon>
             Registrar Salida

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.html
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.html
@@ -1,7 +1,7 @@
 <div class="modal-overlay">
-  <!-- Modal Container -->
   <div class="modal-content">
-    <!-- Modal Header -->
+
+    <!-- Header -->
     <div class="modal-header">
       <div class="header-info">
         <div class="header-icon">
@@ -12,7 +12,7 @@
             <h3 class="modal-title">Registrar Salida de Producto</h3>
             <span class="req-badge">REQ-45-S</span>
           </div>
-          <p class="modal-subtitle">Control de Inventario</p>
+          <p class="modal-subtitle">La salida debe estar vinculada a una Requisición DESPACHADA.</p>
         </div>
       </div>
       <button class="close-btn" (click)="closeModal()">
@@ -20,107 +20,134 @@
       </button>
     </div>
 
-    <!-- Modal Body -->
+    <!-- Body -->
     <form [formGroup]="salidaForm" (ngSubmit)="onSubmit()" class="modal-body">
       <div class="form-grid">
-        
-        <!-- Two Column Row: Product & Qty -->
-        <div class="product-qty-row">
-          <div class="form-group product-col">
-            <label>Producto o Código</label>
-            <div class="input-wrapper">
-              <lucide-icon name="scan-barcode" class="input-icon" [size]="18"></lucide-icon>
-              <input type="text" formControlName="producto" placeholder="Busque por nombre o escanee código" class="form-input" style="padding-left: 2.5rem; font-family: monospace;">
+
+        <!-- Selector de requisición -->
+        <div class="form-group full-width">
+          <label>REQUISICIÓN ORIGEN <span class="required">*</span></label>
+          @if (requisicionesFacade.loading()) {
+            <select class="form-select full-select" disabled>
+              <option>Cargando requisiciones...</option>
+            </select>
+          } @else if (requisicionesDespachadas().length === 0) {
+            <div class="empty-notice">
+              <lucide-icon name="inbox" [size]="16"></lucide-icon>
+              No hay requisiciones en estado DESPACHADA disponibles.
+            </div>
+          } @else {
+            <select class="form-select full-select" (change)="onRequisicionChange($event)">
+              <option value="">Seleccione una requisición despachada...</option>
+              @for (req of requisicionesDespachadas(); track req.id) {
+                <option [value]="req.id">
+                  {{ req.numero }} — {{ req.instructorNombre }} — {{ req.fecha }} ({{ req.programa }})
+                </option>
+              }
+            </select>
+          }
+        </div>
+
+        <!-- Detalle de la requisición seleccionada -->
+        @if (requisicionSeleccionada(); as req) {
+          <div class="requisicion-detail full-width">
+            <div class="detail-row">
+              <span class="detail-label">Instructor ID</span>
+              <span class="detail-value" style="font-family: monospace;">{{ req.instructorId }}</span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-label">Ficha</span>
+              <span class="detail-value">{{ req.fichaId }}</span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-label">Sesión</span>
+              <span class="detail-value">{{ req.diaSemana }} {{ req.horaSesion }}</span>
             </div>
           </div>
-          
-          <div class="form-group qty-col">
-            <label>Cantidad</label>
-            <div class="input-wrapper">
-              <input type="number" formControlName="cantidad" placeholder="0" class="form-input qty-input" [class.error]="salidaForm.get('cantidad')?.value > stockDisponible()">
-              <span class="suffix">uds</span>
+
+          <!-- Ítems de la requisición (referencia visual) -->
+          @if (req.items.length > 0) {
+            <div class="items-ref full-width">
+              <p class="items-ref-title">
+                <lucide-icon name="list" [size]="14"></lucide-icon>
+                Ítems de la requisición (referencia):
+              </p>
+              <ul class="items-ref-list">
+                @for (item of req.items; track item.codigo) {
+                  <li>
+                    <span class="item-code">{{ item.codigo }}</span>
+                    {{ item.descripcion }} — {{ item.cantidad }} {{ item.unidad }}
+                  </li>
+                }
+              </ul>
+              <p class="hint-text">
+                <lucide-icon name="info" [size]="13"></lucide-icon>
+                Pendiente backend B-02: cuando los ítems expongan productoId, el formulario se pre-llenará automáticamente.
+              </p>
             </div>
-            @if (salidaForm.get('cantidad')?.value > stockDisponible()) {
-<p class="error-hint">
-              La cantidad excede el stock disponible ({{stockDisponible()}})
-            </p>
-}
+          }
+        }
+
+        <!-- Separador -->
+        <div class="separator full-width"></div>
+
+        <!-- Producto + Cantidad -->
+        <div class="form-group product-col">
+          <label>ID DEL PRODUCTO <span class="required">*</span></label>
+          <div class="input-wrapper">
+            <lucide-icon name="scan-barcode" class="input-icon" [size]="18"></lucide-icon>
+            <input
+              type="text"
+              formControlName="productoId"
+              placeholder="UUID del producto"
+              class="form-input"
+              style="font-family: monospace;">
+          </div>
+          @if (salidaForm.get('productoId')?.invalid && salidaForm.get('productoId')?.touched) {
+            <p class="error-hint">El ID del producto es obligatorio.</p>
+          }
+        </div>
+
+        <div class="form-group qty-col">
+          <label>CANTIDAD <span class="required">*</span></label>
+          <div class="input-wrapper">
+            <input type="number" formControlName="cantidad" placeholder="0" class="form-input qty-input">
+            <span class="suffix">uds</span>
           </div>
         </div>
 
-        <!-- Two Column Row: Date & Area -->
-        <div class="form-row-2">
-          <div class="form-group">
-            <label>Fecha</label>
-            <div class="input-wrapper">
-              <lucide-icon name="calendar" class="input-icon" [size]="18"></lucide-icon>
-              <input type="date" formControlName="fecha" class="form-input">
-            </div>
-          </div>
-          
-          <div class="form-group">
-            <label>Área de Destino</label>
-            <div class="input-wrapper">
-              <select formControlName="areaDestino" class="form-select">
-                <option value="">Seleccione un área</option>
-                <option value="sistemas">Sistemas y Desarrollo</option>
-                <option value="administracion">Administración</option>
-                <option value="mantenimiento">Mantenimiento</option>
-                <option value="bienestar">Bienestar Estudiantil</option>
-              </select>
-            </div>
-          </div>
-        </div>
-
-        <!-- Instructor & Ficha -->
-        <div class="form-row-2">
-          <div class="form-group">
-            <label>Instructor</label>
-            <div class="input-wrapper">
-              <lucide-icon name="user" class="input-icon" [size]="18"></lucide-icon>
-              <input type="text" formControlName="instructor" placeholder="Nombre completo del instructor" class="form-input">
-            </div>
-          </div>
-          
-          <div class="form-group">
-            <label>Ficha</label>
-            <div class="input-wrapper">
-              <lucide-icon name="hash" class="input-icon" [size]="18"></lucide-icon>
-              <input type="text" formControlName="ficha" placeholder="1234567" maxlength="7" class="form-input" style="font-family: monospace;">
-            </div>
-          </div>
-        </div>
-
-        <!-- Category -->
-        <div class="form-group">
-          <label>Categoría de Alimento</label>
+        <!-- Categoría -->
+        <div class="form-group full-width">
+          <label>CATEGORÍA <span class="required">*</span></label>
           <select formControlName="categoria" class="form-select full-select">
             <option value="" disabled selected>Seleccione una categoría</option>
             <option value="abarrotes">Abarrotes</option>
             <option value="lacteos">Lácteos</option>
             <option value="frutas">Frutas y Vegetales</option>
             <option value="carnes">Carnes y Pescados</option>
+            <option value="bebidas">Bebidas</option>
+            <option value="condimentos">Condimentos y Especias</option>
+            <option value="otros">Otros</option>
           </select>
         </div>
 
-        <!-- Purpose -->
-        <div class="form-group">
-          <label>Propósito</label>
-          <input type="text" formControlName="proposito" placeholder="Motivo de la salida (ej: Mantenimiento, Dotación)" class="form-input">
-        </div>
-
-        <!-- Observations -->
-        <div class="form-group">
-          <label>Observaciones</label>
-          <textarea formControlName="observaciones" rows="3" placeholder="Detalles adicionales del movimiento..." class="form-textarea"></textarea>
-        </div>
+        <!-- Error de facade -->
+        @if (kardexFacade.error()) {
+          <div class="error-inline full-width">
+            <lucide-icon name="alert-triangle" [size]="16"></lucide-icon>
+            {{ kardexFacade.error() }}
+          </div>
+        }
 
       </div>
 
-      <!-- Modal Footer -->
+      <!-- Footer -->
       <div class="modal-footer">
         <restaurant-button variant="surface" (click)="closeModal()" type="button">Cancelar</restaurant-button>
-        <restaurant-button variant="primary" type="submit" [disabled]="salidaForm.invalid || salidaForm.get('cantidad')?.value > stockDisponible">
+        <restaurant-button
+          variant="primary"
+          type="submit"
+          [disabled]="salidaForm.invalid || kardexFacade.loading()">
           <div style="display: flex; align-items: center; gap: 0.5rem; font-weight: bold;">
             <lucide-icon name="check-circle" [size]="18"></lucide-icon>
             Registrar Salida

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.scss
@@ -250,3 +250,114 @@
   gap: 1rem;
   align-items: center;
 }
+
+/* ── Detalle de requisición seleccionada ── */
+.requisicion-detail {
+  background-color: rgba(0, 110, 37, 0.06);
+  border: 1px solid rgba(0, 110, 37, 0.15);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.detail-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.detail-label {
+  font-weight: 700;
+  color: #475569;
+  min-width: 8rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.detail-value {
+  color: #191c1d;
+  font-weight: 500;
+}
+
+/* ── Ítems de referencia ── */
+.items-ref {
+  background-color: #f8f9fa;
+  border: 1px dashed #bdcab9;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+}
+
+.items-ref-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin: 0 0 0.625rem;
+}
+
+.items-ref-list {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  li {
+    font-size: 0.8125rem;
+    color: #3e4a3c;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}
+
+.item-code {
+  background-color: #e7e8e9;
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: #191c1d;
+  font-weight: 600;
+}
+
+/* ── Separador ── */
+.separator {
+  height: 1px;
+  background-color: #e1e3e4;
+}
+
+/* ── Aviso vacío ── */
+.empty-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #3e4a3c;
+  padding: 0.75rem 1rem;
+  background-color: #f3f4f5;
+  border-radius: 0.75rem;
+  border: 1px dashed #bdcab9;
+}
+
+/* ── Error inline ── */
+.error-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #ba1a1a;
+  padding: 0.75rem 1rem;
+  background-color: rgba(255, 218, 214, 0.4);
+  border-radius: 0.5rem;
+  border: 1px solid rgba(186, 26, 26, 0.2);
+}

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.scss
@@ -349,6 +349,98 @@
   border: 1px dashed #bdcab9;
 }
 
+/* ── Tabla de ítems ── */
+.items-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.items-title {
+  font-family: 'Manrope', sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #191c1d;
+  margin: 0;
+}
+
+.items-badge {
+  background-color: rgba(40, 167, 69, 0.15);
+  color: #00330d;
+  padding: 0.2rem 0.625rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.items-table-container {
+  background-color: #ffffff;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(189, 202, 185, 0.2);
+  overflow: hidden;
+}
+
+.items-table {
+  width: 100%;
+  text-align: left;
+  border-collapse: collapse;
+
+  th {
+    padding: 0.75rem 1.25rem;
+    background-color: #edeeef;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #3e4a3c;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  td {
+    padding: 0.75rem 1.25rem;
+    font-size: 0.875rem;
+  }
+
+  .text-center { text-align: center; }
+}
+
+.table-row {
+  border-top: 1px solid #edeeef;
+  transition: background-color 0.15s;
+  &:hover { background-color: #f8f9fa; }
+}
+
+.item-name {
+  font-weight: 500;
+  color: #191c1d;
+}
+
+.item-desc { color: #3e4a3c; }
+
+.code-text {
+  font-size: 0.875rem;
+  color: #3e4a3c;
+}
+
+.qty-input {
+  width: 5rem;
+  display: block;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border: 1px solid rgba(189, 202, 185, 0.4);
+  border-radius: 0.5rem;
+  padding: 0.3rem 0.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: #191c1d;
+
+  &:focus {
+    outline: none;
+    border-color: #006e25;
+    box-shadow: 0 0 0 2px rgba(0, 110, 37, 0.2);
+  }
+}
+
 /* ── Error inline ── */
 .error-inline {
   display: flex;

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.ts
@@ -1,18 +1,18 @@
-import { Component, inject, ChangeDetectionStrategy, computed } from '@angular/core';
-import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Component, inject, ChangeDetectionStrategy, computed, signal, effect } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, FormArray, FormGroup, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { LucideIconComponent, ButtonComponent } from '@restaurant/shared/ui';
 import { KardexFacade } from '../../../data-access/kardex.facade';
 import { RequisicionesFacade } from '../../../data-access/requisiciones.facade';
-import { Requisicion } from '../../../models/requisicion.model';
+import { Requisicion, RequisicionItem } from '../../../models/requisicion.model';
 import { SalidaMovimientoData } from '../../../models/movimiento.model';
 
 /**
  * Registro de salida de inventario.
- * REGLA DE NEGOCIO: toda salida debe estar vinculada a una Requisición DESPACHADA.
- * requisicionId e instructorId se auto-rellenan al seleccionar la requisición.
- * Pendiente backend B-02/B-03: cuando el backend exponga items en RequisicionResponse,
- * la tabla de ítems pre-llenará productoId y cantidad automáticamente.
+ * REGLA DE NEGOCIO: toda salida debe estar vinculada a una Requisición en estado ENVIADA.
+ *   ENVIADA   → habilita registrar Salida (B-04).
+ *   DESPACHADA → salida ya registrada, no aparece en este selector.
+ * Los ítems de la requisición pre-llenan productoId, cantidad y categoria (B-02).
  */
 @Component({
   selector: 'restaurant-movimiento-salida',
@@ -23,66 +23,102 @@ import { SalidaMovimientoData } from '../../../models/movimiento.model';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MovimientoSalidaComponent {
-  private fb                    = inject(FormBuilder);
-  private router                = inject(Router);
-  readonly kardexFacade         = inject(KardexFacade);
-  readonly requisicionesFacade  = inject(RequisicionesFacade);
+  private fb                   = inject(FormBuilder);
+  private router               = inject(Router);
+  readonly kardexFacade        = inject(KardexFacade);
+  readonly requisicionesFacade = inject(RequisicionesFacade);
 
-  // Requisiciones en estado DESPACHADA (habilitadas para generar salida)
-  requisicionesDespachadas = computed(() =>
-    this.requisicionesFacade.requisiciones().filter(r => r.estado === 'DESPACHADA')
+  // ── Estado del selector ───────────────────────────────────────────────────
+  requisicionIdSeleccionada = signal<string>('');
+
+  // ── Computed ──────────────────────────────────────────────────────────────
+  /** Solo requisiciones ENVIADA habilitan salida (B-04). */
+  requisicionesEnviadas = computed(() =>
+    this.requisicionesFacade.requisiciones().filter(r => r.estado === 'ENVIADA')
   );
 
   requisicionSeleccionada = computed<Requisicion | null>(() => {
-    const id = this.salidaForm.get('requisicionId')?.value;
+    const id = this.requisicionIdSeleccionada();
     if (!id) return null;
-    return this.requisicionesDespachadas().find(r => r.id === id) ?? null;
+    return this.requisicionesEnviadas().find(r => r.id === id) ?? null;
   });
 
-  salidaForm: FormGroup = this.fb.group({
-    // Auto-rellenados al seleccionar la requisición
-    requisicionId: ['', Validators.required],
-    instructorId:  ['', Validators.required],
-    // Ingresados manualmente (pendiente B-02: vendrán pre-llenados desde los items)
-    productoId:    ['', Validators.required],
-    cantidad:      [null, [Validators.required, Validators.min(1)]],
-    categoria:     ['', Validators.required],
-  });
+  itemsActuales = computed(() => this.requisicionSeleccionada()?.items ?? []);
+
+  puedeRegistrar = computed(() =>
+    this.requisicionIdSeleccionada() !== '' &&
+    this.itemsActuales().length > 0 &&
+    this.itemsForm.valid &&
+    !this.kardexFacade.loading()
+  );
+
+  // ── FormArray: un FormGroup por ítem ──────────────────────────────────────
+  itemsForm: FormArray = this.fb.array([]);
 
   constructor() {
-    // Carga solo requisiciones DESPACHADA al abrir el modal
-    this.requisicionesFacade.cargarPorEstado('DESPACHADA');
+    // Carga solo requisiciones ENVIADA al abrir el modal
+    this.requisicionesFacade.cargarPorEstado('ENVIADA');
+
+    // Reconstruye el FormArray cada vez que cambia la requisición seleccionada
+    effect(() => {
+      this.reconstruirFormArray(this.itemsActuales());
+    });
   }
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
 
   onRequisicionChange(event: Event): void {
     const id = (event.target as HTMLSelectElement).value;
-    const req = this.requisicionesDespachadas().find(r => r.id === id);
-    if (req) {
-      this.salidaForm.patchValue({
-        requisicionId: req.id,
-        instructorId:  req.instructorId,
-      });
-    } else {
-      this.salidaForm.patchValue({ requisicionId: '', instructorId: '' });
-    }
+    this.requisicionIdSeleccionada.set(id);
   }
 
   onSubmit(): void {
-    if (this.salidaForm.invalid) return;
+    if (!this.puedeRegistrar()) return;
 
-    const payload: SalidaMovimientoData = {
-      productoId:    this.salidaForm.get('productoId')!.value,
-      cantidad:      this.salidaForm.get('cantidad')!.value,
-      requisicionId: this.salidaForm.get('requisicionId')!.value,
-      instructorId:  this.salidaForm.get('instructorId')!.value,
-      categoria:     this.salidaForm.get('categoria')!.value,
-    };
+    const req = this.requisicionSeleccionada();
+    if (!req?.id) return;
 
-    this.kardexFacade.registrarSalida(payload);
+    this.itemsActuales().forEach((item, i) => {
+      const grupo = this.getItemGroup(i);
+      if (!grupo.valid) return;
+
+      const cantidad: number = grupo.get('cantidad')?.value ?? 0;
+      if (cantidad <= 0) return;
+
+      const payload: SalidaMovimientoData = {
+        productoId:    item.productoId,
+        cantidad,
+        requisicionId: req.id,
+        instructorId:  req.instructorId,
+        categoria:     grupo.get('categoria')?.value ?? item.categoria,
+      };
+
+      this.kardexFacade.registrarSalida(payload);
+    });
+
     this.closeModal();
   }
 
   closeModal(): void {
     this.router.navigate(['/app/inventario/movimientos']);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  getItemGroup(index: number): FormGroup {
+    return this.itemsForm.at(index) as FormGroup;
+  }
+
+  private reconstruirFormArray(items: RequisicionItem[]): void {
+    const grupos = items.map(item =>
+      this.fb.group({
+        cantidad: [
+          item.cantidad,
+          [Validators.required, Validators.min(1), Validators.max(item.cantidad)],
+        ],
+        categoria: [item.categoria, Validators.required],
+      })
+    );
+    this.itemsForm = this.fb.array(grupos);
   }
 }

--- a/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/kardex-page/movimiento-salida/movimiento-salida.component.ts
@@ -1,44 +1,85 @@
-import { Component, inject, ChangeDetectionStrategy, signal } from '@angular/core';
-
-import { Router, RouterModule } from '@angular/router';
+import { Component, inject, ChangeDetectionStrategy, computed } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
 import { LucideIconComponent, ButtonComponent } from '@restaurant/shared/ui';
 import { KardexFacade } from '../../../data-access/kardex.facade';
+import { RequisicionesFacade } from '../../../data-access/requisiciones.facade';
+import { Requisicion } from '../../../models/requisicion.model';
 import { SalidaMovimientoData } from '../../../models/movimiento.model';
 
+/**
+ * Registro de salida de inventario.
+ * REGLA DE NEGOCIO: toda salida debe estar vinculada a una Requisición DESPACHADA.
+ * requisicionId e instructorId se auto-rellenan al seleccionar la requisición.
+ * Pendiente backend B-02/B-03: cuando el backend exponga items en RequisicionResponse,
+ * la tabla de ítems pre-llenará productoId y cantidad automáticamente.
+ */
 @Component({
   selector: 'restaurant-movimiento-salida',
   standalone: true,
   imports: [RouterModule, ReactiveFormsModule, LucideIconComponent, ButtonComponent],
   templateUrl: './movimiento-salida.component.html',
   styleUrl: './movimiento-salida.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MovimientoSalidaComponent {
-  private fb     = inject(FormBuilder);
-  private router = inject(Router);
-  private facade = inject(KardexFacade);
+  private fb                    = inject(FormBuilder);
+  private router                = inject(Router);
+  readonly kardexFacade         = inject(KardexFacade);
+  readonly requisicionesFacade  = inject(RequisicionesFacade);
 
-  /** Stock en tiempo real; se actualizará cuando el backend esté integrado */
-  stockDisponible = signal<number>(0);
+  // Requisiciones en estado DESPACHADA (habilitadas para generar salida)
+  requisicionesDespachadas = computed(() =>
+    this.requisicionesFacade.requisiciones().filter(r => r.estado === 'DESPACHADA')
+  );
 
-  salidaForm: FormGroup = this.fb.group({
-    producto:      ['', Validators.required],
-    cantidad:      [null, [Validators.required, Validators.min(1)]],
-    fecha:         ['', Validators.required],
-    areaDestino:   ['', Validators.required],
-    instructor:    [''],
-    ficha:         ['', [Validators.pattern('^[0-9]{7}$')]],
-    categoria:     ['', Validators.required],
-    proposito:     ['', Validators.required],
-    observaciones: [''],
+  requisicionSeleccionada = computed<Requisicion | null>(() => {
+    const id = this.salidaForm.get('requisicionId')?.value;
+    if (!id) return null;
+    return this.requisicionesDespachadas().find(r => r.id === id) ?? null;
   });
 
-  onSubmit(): void {
-    if (this.salidaForm.valid) {
-      this.facade.registrarSalida(this.salidaForm.getRawValue() as SalidaMovimientoData);
-      this.closeModal();
+  salidaForm: FormGroup = this.fb.group({
+    // Auto-rellenados al seleccionar la requisición
+    requisicionId: ['', Validators.required],
+    instructorId:  ['', Validators.required],
+    // Ingresados manualmente (pendiente B-02: vendrán pre-llenados desde los items)
+    productoId:    ['', Validators.required],
+    cantidad:      [null, [Validators.required, Validators.min(1)]],
+    categoria:     ['', Validators.required],
+  });
+
+  constructor() {
+    // Carga solo requisiciones DESPACHADA al abrir el modal
+    this.requisicionesFacade.cargarPorEstado('DESPACHADA');
+  }
+
+  onRequisicionChange(event: Event): void {
+    const id = (event.target as HTMLSelectElement).value;
+    const req = this.requisicionesDespachadas().find(r => r.id === id);
+    if (req) {
+      this.salidaForm.patchValue({
+        requisicionId: req.id,
+        instructorId:  req.instructorId,
+      });
+    } else {
+      this.salidaForm.patchValue({ requisicionId: '', instructorId: '' });
     }
+  }
+
+  onSubmit(): void {
+    if (this.salidaForm.invalid) return;
+
+    const payload: SalidaMovimientoData = {
+      productoId:    this.salidaForm.get('productoId')!.value,
+      cantidad:      this.salidaForm.get('cantidad')!.value,
+      requisicionId: this.salidaForm.get('requisicionId')!.value,
+      instructorId:  this.salidaForm.get('instructorId')!.value,
+      categoria:     this.salidaForm.get('categoria')!.value,
+    };
+
+    this.kardexFacade.registrarSalida(payload);
+    this.closeModal();
   }
 
   closeModal(): void {

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-list/solicitudes-insumos-list.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-list/solicitudes-insumos-list.component.ts
@@ -6,7 +6,6 @@ import {
   DataTableComponent,
   KpiCardComponent,
   StatusBadgeComponent,
-  LucideIconComponent
 } from '@restaurant/shared/ui';
 import { AprobarSolicitudModalComponent } from '../../../components/aprobar-solicitud-modal/aprobar-solicitud-modal.component';
 
@@ -31,7 +30,6 @@ interface SolicitudInsumo {
     DataTableComponent,
     KpiCardComponent,
     StatusBadgeComponent,
-    LucideIconComponent,
     AprobarSolicitudModalComponent
   ],
   templateUrl: './solicitudes-insumos-list.component.html',
@@ -118,17 +116,17 @@ export class SolicitudesInsumosListComponent {
 
   // ─── KPIs calculados (4 tarjetas del prototipo) ────────────────────
   totalEnviadasPendientes = computed(() => this.solicitudes().filter(s => s.estado === 'ENVIADA').length);
-  totalAprobadasHoy       = computed(() => this.solicitudes().filter(s => s.estado === 'APROBADA').length);
-  totalCerradas           = computed(() => this.solicitudes().filter(s => s.estado === 'CERRADA').length);
-  totalLibres             = computed(() => 3); // Valor estático por el momento, según la imagen
+  totalAprobadasHoy = computed(() => this.solicitudes().filter(s => s.estado === 'APROBADA').length);
+  totalCerradas = computed(() => this.solicitudes().filter(s => s.estado === 'CERRADA').length);
+  totalLibres = computed(() => 3); // Valor estático por el momento, según la imagen
 
   // ─── Opciones filtros ──────────────────────────────────────────────
   estadoOptions = [
     { value: '', label: 'Todos los estados' },
-    { value: 'ENVIADA',  label: 'Enviada'  },
+    { value: 'ENVIADA', label: 'Enviada' },
     { value: 'APROBADA', label: 'Aprobada' },
-    { value: 'CERRADA',  label: 'Cerrada'  },
-    { value: 'BORRADOR',  label: 'Borrador' },
+    { value: 'CERRADA', label: 'Cerrada' },
+    { value: 'BORRADOR', label: 'Borrador' },
   ];
 
   fechaOptions = [
@@ -159,16 +157,16 @@ export class SolicitudesInsumosListComponent {
 
   solicitudSeleccionada = signal<SolicitudInsumo | null>(null);
 
-  onSearch(term: string): void    { console.log('Buscar:', term);    }
-  onFilterEstado(v: string): void { console.log('Estado:', v);       }
-  onFilterFecha(v: string): void  { console.log('Fecha:', v);        }
-  onClearFilters(): void          { console.log('Limpiar filtros');  }
+  onSearch(term: string): void { console.log('Buscar:', term); }
+  onFilterEstado(v: string): void { console.log('Estado:', v); }
+  onFilterFecha(v: string): void { console.log('Fecha:', v); }
+  onClearFilters(): void { console.log('Limpiar filtros'); }
 
   getSolicitudVariant(estado: string): 'warning' | 'success' | 'neutral' {
     const map: Record<string, 'warning' | 'success' | 'neutral'> = {
-      'ENVIADA':  'warning',
+      'ENVIADA': 'warning',
       'APROBADA': 'success',
-      'CERRADA':  'neutral',
+      'CERRADA': 'neutral',
       'BORRADOR': 'neutral'
     };
     return map[estado] ?? 'neutral';
@@ -181,7 +179,7 @@ export class SolicitudesInsumosListComponent {
   onEdit(id: string | number): void {
     this.router.navigate(['/app/inventario/solicitudes-insumos-page', id, 'editar']);
   }
-  
+
   onApprove(id: number): void {
     const sol = this.solicitudes().find(s => s.id === id);
     if (sol) {


### PR DESCRIPTION
## Resumen

Alineación completa del módulo Kardex con los contratos del backend (Swagger) y corrección de bugs que impedían el registro y visualización de movimientos.

---

## ¿Qué cambió?

### 1. Contratos de entrada/salida alineados con Swagger

- `EntradaRequest` / `SalidaRequest` en `inventory.api.ts` — corregidos para coincidir exactamente con los schemas `RegistrarEntradaHttpRequest` y `RegistrarSalidaHttpRequest` del Swagger
- `EntradaMovimientoData` / `SalidaMovimientoData` en `movimiento.model.ts` — campos actualizados
- Mapper `entradaToRequest` / `salidaToRequest` — reescritos para reflejar los nuevos campos

### 2. Integración de cambios backend B-01 a B-05

- `BienGilResponse.productoId` — campo añadido tras confirmación del backend (B-01)
- `RequisicionItemResponse` — nuevo DTO con `productoId`, `productoNombre`, `unidadMedida`, `categoria` (B-02)
- `GilesService` y `GilesFacade` — nuevos archivos para gestión de GILes desde el módulo Kardex
- `RequisicionesFacade.cargarPorEstado(estado)` — método añadido para filtrar por estado (B-04)
- Regla de negocio B-04: `ENVIADA` habilita la salida; `DESPACHADA` ya fue despachada. Filtro corregido en `movimiento-salida.component.ts`.

### 3. Bug crítico: Kardex no se refrescaba tras registrar movimiento

- **Raíz:** `movimientosService.registrarEntrada/Salida` estaba tipado como `Observable<{ success: boolean }>` pero el backend devuelve HTTP 201 con body vacío
- `res` era `null` en el subscribe → `if (res)` nunca ejecutaba `cargarKardex()`
- **Fix:** tipos cambiados a `Observable<void>`, `of(null)` reemplazado por `EMPTY`, callbacks sin condicional

### 4. Paginación estándar en GilesFacade y KardexFacade

- `GilesFacade`: client-side pagination de 10 ítems por página; 3 llamadas paralelas (EMITIDO, ENVIADO_PROVEEDOR, CERRADO) con `size=50` combinadas; expone `giles()`, `paginacion()`, `irAPagina()`
- `movimiento-entrada-gil`: selector GIL con controles Anterior/Siguiente; `onGilChange` ahora llama `cargarGilById()` para garantizar bienes completos
- `KardexFacade`: `cargarKardex()` recibe `pagina`/`tamano` (params del Swagger en español), expone `paginacion()` e `irAPaginaKardex()`
- `MovimientoPageResponse` normaliza respuesta en dos convenciones (inglés/español) ya que el Swagger no documenta el schema (`type: object`)

---

## Archivos fuera de scope NO incluidos

- `libs/shell/shell/src/lib/shell.routes.ts` — tiene un `roleGuard` comentado de desarrollo; queda pendiente de restaurar y no forma parte de este PR

---

## Cómo revisar

1. Verificar que los campos de `EntradaRequest` y `SalidaRequest` coinciden con el Swagger en `POST /inventory/movimientos/entrada` y `POST /inventory/movimientos/salida`
2. Abrir el modal "Registrar Entrada por GIL" — el selector debe paginar de a 10 GILes con botones Anterior/Siguiente cuando hay más de una página
3. Abrir el modal "Registrar Salida" — debe mostrar solo requisiciones en estado `ENVIADA`
4. Registrar un movimiento (con backend activo) — el Kardex debe recargarse automáticamente al cerrar el modal