### PR TITLE
fix(inventario): corregir nombres de botones de confirmacion

### DIFF
--- a/libs/inventario/inventario/src/lib/components/confirmar-envio-solicitud-modal/confirmar-envio-solicitud-modal.component.html
+++ b/libs/inventario/inventario/src/lib/components/confirmar-envio-solicitud-modal/confirmar-envio-solicitud-modal.component.html
@@ -6,12 +6,12 @@
           <span class="material-symbols-outlined">send</span>
         </div>
         
-        <h2 class="modal-title">¿Confirmar envío?</h2>
+        <h2 class="modal-title">{{ isEdit ? 'Confirmar Edición' : 'Confirmar creación' }}</h2>
         <p class="modal-text">Una vez enviada no podrá editar la solicitud.</p>
         
         <div class="modal-actions">
           <button class="btn-cancel" type="button" (click)="cancelled.emit()">Cancelar</button>
-          <button class="btn-confirm" type="button" (click)="confirmed.emit()">Confirmar envío</button>
+          <button class="btn-confirm" type="button" (click)="confirmed.emit()">{{ isEdit ? 'Confirmar edición' : 'Confirmar creación' }}</button>
         </div>
       </div>
     </div>

--- a/libs/inventario/inventario/src/lib/components/confirmar-envio-solicitud-modal/confirmar-envio-solicitud-modal.component.ts
+++ b/libs/inventario/inventario/src/lib/components/confirmar-envio-solicitud-modal/confirmar-envio-solicitud-modal.component.ts
@@ -11,6 +11,7 @@ import { CommonModule } from '@angular/common';
 })
 export class ConfirmarEnvioSolicitudModalComponent {
   @Input() isOpen = false;
+  @Input() isEdit = false;
   @Output() confirmed = new EventEmitter<void>();
   @Output() cancelled = new EventEmitter<void>();
 }

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-form/solicitudes-insumos-form.component.html
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-form/solicitudes-insumos-form.component.html
@@ -176,6 +176,7 @@
 @if (isModalOpen()) {
   <restaurant-confirmar-envio-solicitud-modal
     [isOpen]="true"
+    [isEdit]="isEdit()"
     (cancelled)="cerrarModalConfirmacion()"
     (confirmed)="confirmarEnvio()">
   </restaurant-confirmar-envio-solicitud-modal>


### PR DESCRIPTION
## Descripción
se hace una corrección a los nombres de los botones de confirmación sobre algunas acciones del submodulo de solicitud de insumos.

## Tipo de cambio
- [ ] `fix` — corrección de bug


## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `inventario` · [


## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
se cambia el nombre confirmar envio por: "Confirmar creación" y "Confirmar edición"
-->
