### PR TITLE
feat(inventario): campos resultado de aprendizaje y actividades en solicitudes

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/solicitudes.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/solicitudes.facade.ts
@@ -267,20 +267,17 @@ export class SolicitudesFacade {
   }
 
   /** POST /training/solicitudes — crea la solicitud y la deja seleccionada */
-  crearSolicitudSesion(data: CrearSolicitudSesionData): void {
+  crearSolicitudSesion(data: CrearSolicitudSesionData): Observable<SolicitudSesion | null> {
     this._loading.set(true);
     this._error.set(null);
-    this.solicitudesService.crearSolicitudSesion(data)
+    return this.solicitudesService.crearSolicitudSesion(data)
       .pipe(
         catchError(() => {
           this._error.set('Error al crear la solicitud de sesión');
           return of(null);
         }),
         finalize(() => this._loading.set(false))
-      )
-      .subscribe(res => {
-        if (res !== null) this._solicitudSesionSeleccionada.set(res);
-      });
+      );
   }
 
   /** PATCH /training/solicitudes/{id}/aprobar */

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-form/solicitudes-insumos-form.component.html
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-form/solicitudes-insumos-form.component.html
@@ -106,9 +106,37 @@
           <p class="field-hint">Cédula o número de identificación (opcional)</p>
         </div>
 
-
       </div>
     </div>
+
+    <div class="form-group">
+      <label class="form-label">Resultado de Aprendizaje <span class="required-mark">*</span></label>
+      <textarea
+        class="form-control"
+        rows="2"
+        placeholder="Ej. Preparar recetas de cocina colombiana aplicando técnicas culinarias básicas"
+        [value]="resultadoAprendizaje()"
+        (input)="resultadoAprendizaje.set($any($event.target).value)"
+      ></textarea>
+      @if (submitAttempted() && errores()['resultadoAprendizaje']) {
+        <p class="field-error">{{ errores()['resultadoAprendizaje'] }}</p>
+      }
+    </div>
+
+    <div class="form-group">
+      <label class="form-label">Actividades <span class="required-mark">*</span></label>
+      <textarea
+        class="form-control"
+        rows="2"
+        placeholder="Ej. Práctica de cocina en taller, elaboración de recetas y presentación de platos"
+        [value]="actividades()"
+        (input)="actividades.set($any($event.target).value)"
+      ></textarea>
+      @if (submitAttempted() && errores()['actividades']) {
+        <p class="field-error">{{ errores()['actividades'] }}</p>
+      }
+    </div>
+
   </div>
 
   <!-- ══════════════════════════════════════════════════════════════

--- a/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-form/solicitudes-insumos-form.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/solicitudes-insumos-page/solicitudes-insumos-form/solicitudes-insumos-form.component.ts
@@ -71,6 +71,10 @@ export class SolicitudesInsumosFormComponent implements OnInit {
       e['programaId'] = 'El programa de formación es requerido.';
     if (!this.instructorId().trim())
       e['instructorId'] = 'El ID del instructor es requerido.';
+    if (!this.resultadoAprendizaje().trim())
+      e['resultadoAprendizaje'] = 'El resultado de aprendizaje es requerido.';
+    if (!this.actividades().trim())
+      e['actividades'] = 'Las actividades son requeridas.';
     if (this.items().length === 0)
       e['items'] = 'Debe agregar al menos un ítem.';
     return e;
@@ -179,7 +183,10 @@ export class SolicitudesInsumosFormComponent implements OnInit {
       voceroId:                 this.voceroId(),
       valorTotalDeSolicitud:    this.valorTotalDeSolicitud(),
       items:                    this.items(),
+    }).subscribe(res => {
+      if (res !== null) {
+        this.router.navigate(['/app/inventario/solicitudes-insumos-page']);
+      }
     });
-    this.router.navigate(['/app/inventario/solicitudes-insumos-page']);
   }
 }


### PR DESCRIPTION
@
## Summary
- Agrega campos **Resultado de Aprendizaje** y **Actividades** (textarea con validación requerida) al formulario de solicitudes de insumos
- Refactoriza `crearSolicitudSesion` en la facade para retornar `Observable` en vez de subscribirse internamente, permitiendo al componente reaccionar al resultado
- Navega al listado solo después de respuesta exitosa del backend (antes navegaba inmediatamente)

## Test plan
- [ ] Verificar que los campos "Resultado de Aprendizaje" y "Actividades" aparecen en el formulario
- [ ] Verificar validación: submit sin llenar muestra error en ambos campos
- [ ] Verificar que al crear exitosamente navega al listado
- [ ] Verificar que si falla la creación NO navega
@