### PR TITLE
fix(infra): corregir proxy auth, nginx SPA y healthcheck usuarios-db

### DIFF
--- a/apps/restaurant-app/proxy.conf.json
+++ b/apps/restaurant-app/proxy.conf.json
@@ -1,4 +1,12 @@
 {
+  "//": "MAPA DE PUERTOS — mantener sincronizado con docker-compose.yml",
+  "// restaurante": "8080 | inventario: 8081 | cocina: 8082 | barbarismo: 8086 | usuarios: 8087",
+
+  "/api/auth": {
+    "target": "http://localhost:8087",
+    "secure": false,
+    "changeOrigin": true
+  },
   "/api/barybarismo": {
     "target": "http://localhost:8086",
     "secure": false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
     volumes:
       - usuarios_db_data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "usuario_app", "-pclave_segura"]
       interval: 10s
       timeout: 5s
       retries: 6

--- a/nginx.conf
+++ b/nginx.conf
@@ -131,7 +131,8 @@ server {
     # ─── Usuarios (8081 interno) ──────────────────────────────────────────────
     # Host port es 8087 para evitar conflicto con inventario, pero dentro de
     # la red Docker el contenedor escucha en 8081.
-    location /auth {
+    # IMPORTANTE: /api/auth — no /auth — para que Angular maneje /auth/* como SPA.
+    location /api/auth {
         proxy_pass         http://usuarios:8081;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;


### PR DESCRIPTION
Closes #213

## Tipo de cambio
- [x] Bug fix

## Resumen
- Corrige `/api/auth` en `proxy.conf.json` que apuntaba a cocina (`:8082`) en vez de usuarios (`:8087`), causando `500` en login
- Corrige `location /auth` en `nginx.conf` a `location /api/auth` para que Angular maneje las rutas SPA sin recibir 404 en F5
- Agrega credenciales al healthcheck de `usuarios-db` en `docker-compose.yml` — MySQL 8 las requiere para que el contenedor `usuarios` arranque en producción

## Cambios

| Archivo | Cambio |
|---------|--------|
| `apps/restaurant-app/proxy.conf.json` | `/api/auth` target corregido a `:8087` + mapa de puertos documentado |
| `nginx.conf` | `location /auth` → `location /api/auth` |
| `docker-compose.yml` | healthcheck `usuarios-db` con credenciales MySQL 8 |

## Plan de pruebas
- [x] Login funciona sin error 500 en desarrollo (`ng serve`)
- [x] Proxy apunta a usuarios (`:8087`) verificado con `curl` directo al servicio
- [x] Lint pasa sin errores
- [x] Commits en formato Conventional Commits

## Checklist
- [x] Issue aprobado vinculado (`Closes #213`)
- [x] Exactamente un label `type:*` agregado
- [x] Sin `Co-Authored-By` en commits
- [x] Documentado mapa de puertos en proxy.conf.json