### PR TITLE
feat(infra): add Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules/
+.git/
+.angular/
+.nx/
+coverage/
+*.log
+.env
+.env.*
+.claude/
+.atl/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# El build de Angular se corre localmente antes de construir la imagen:
+#   npx nx build restaurant-app --configuration=production
+#
+# Esta imagen solo toma el output ya compilado y lo sirve con nginx.
+FROM nginx:1.27-alpine
+
+COPY dist/apps/restaurant-app/browser /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 4200
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- Adds `Dockerfile` (nginx:1.27-alpine) to serve the Angular production build
- Adds `.dockerignore` to keep the image lean
- Works with the existing `docker-compose.yml` and `nginx.conf` already in the repo

## Test plan
- [ ] `npx nx build restaurant-app --configuration=production`
- [ ] `docker compose up -d --build frontend`
- [ ] Verify `http://localhost:4200` loads the app
- [ ] Verify API proxy routes work (inventario, cocina, restaurante, etc.)