### PR TITLE
feat(restaurante): ajustar flujos visuales, roles de cobro y solucion…

### DIFF
--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
@@ -11,13 +11,17 @@
           <span class="category">{{ item.observaciones || 'Sin observaciones' }}</span>
           
           <div class="quantity-controls">
-            <button class="btn-minus" (click)="decrementar(i)">
-              <lucide-icon name="minus" [size]="14"></lucide-icon>
-            </button>
+            @if (!esPedidoSoloLectura()) {
+              <button class="btn-minus" (click)="decrementar(i)">
+                <lucide-icon name="minus" [size]="14"></lucide-icon>
+              </button>
+            }
             <span class="qty">{{ item.cantidad }}</span>
-            <button class="btn-plus" (click)="incrementar(i)">
-              <lucide-icon name="plus" [size]="14"></lucide-icon>
-            </button>
+            @if (!esPedidoSoloLectura()) {
+              <button class="btn-plus" (click)="incrementar(i)">
+                <lucide-icon name="plus" [size]="14"></lucide-icon>
+              </button>
+            }
           </div>
         </div>
         
@@ -25,9 +29,11 @@
           <div class="prices">
             <span class="current">{{ item.precioUnitario | currencyCop }}</span>
           </div>
-          <button class="btn-delete" (click)="eliminarItem(i)" title="Eliminar producto">
-            <lucide-icon name="trash-2" [size]="16"></lucide-icon>
-          </button>
+          @if (!esPedidoSoloLectura()) {
+            <button class="btn-delete" (click)="eliminarItem(i)" title="Eliminar producto">
+              <lucide-icon name="trash-2" [size]="16"></lucide-icon>
+            </button>
+          }
         </div>
       </div>
     } @empty {
@@ -46,6 +52,7 @@
     placeholder="Ej: Para llevar, sin sal..."
     [ngModel]="observacionesGenerales()"
     (ngModelChange)="observacionesGenerales.set($event)"
+    [readonly]="esPedidoSoloLectura()"
   ></textarea>
 </div>
 
@@ -59,22 +66,36 @@
 </div>
 
 <div class="cart-actions">
-  <restaurant-button 
-    class="action-btn" 
-    variant="ghost" 
-    [disabled]="!pedidoActivo()" 
-    (click)="iniciarCancelacion()">
-    <lucide-icon name="trash-2" [size]="18" class="text-error"></lucide-icon>
-    <span>Cancelar</span>
-  </restaurant-button>
-  
-  <restaurant-button 
-    class="action-btn flex-1" 
-    variant="primary" 
-    [disabled]="!pedidoActivo()?.detalles?.length" 
-    (click)="iniciarConfirmacion()">
-    <span>Confirmar Pedido</span>
-  </restaurant-button>
+  @if (estadoPedido() === 'BORRADOR') {
+    <restaurant-button 
+      class="action-btn" 
+      variant="ghost" 
+      [disabled]="!pedidoActivo()" 
+      (click)="iniciarCancelacion()">
+      <lucide-icon name="trash-2" [size]="18" class="text-error"></lucide-icon>
+      <span>Cancelar</span>
+    </restaurant-button>
+    
+    <restaurant-button 
+      class="action-btn flex-1" 
+      variant="primary" 
+      [disabled]="!pedidoActivo()?.detalles?.length" 
+      (click)="iniciarConfirmacion()">
+      <span>Confirmar Pedido</span>
+    </restaurant-button>
+  } @else if (estadoPedido() === 'ENVIADO_COCINA') {
+    <restaurant-button 
+      class="action-btn flex-1 btn-anular" 
+      variant="primary" 
+      (click)="iniciarAnulacionBackend()">
+      <lucide-icon name="alert-triangle" [size]="18" class="text-white"></lucide-icon>
+      <span>Anular Pedido</span>
+    </restaurant-button>
+  } @else {
+    <div class="status-badge" style="width: 100%; text-align: center; padding: 12px; background: var(--bg-neutral); border-radius: var(--radius-md); color: var(--text-secondary); font-weight: 500;">
+      No se puede anular (Pedido {{ estadoPedido().replace('_', ' ') | titlecase }})
+    </div>
+  }
 </div>
 
 <restaurant-confirm-dialog
@@ -86,6 +107,17 @@
   [showCancel]="true"
   (confirm)="ejecutarCancelacion()"
   (cancel)="showCancelModal.set(false)"
+></restaurant-confirm-dialog>
+
+<restaurant-confirm-dialog
+  [open]="showAnularBackendModal()"
+  title="Anular Pedido"
+  message="¿Estás seguro de que quieres anular esta comanda? Esto cancelará su preparación en cocina y liberará la mesa."
+  confirmText="Sí, anular pedido"
+  cancelText="No, volver"
+  [showCancel]="true"
+  (confirm)="ejecutarAnulacionBackend()"
+  (cancel)="showAnularBackendModal.set(false)"
 ></restaurant-confirm-dialog>
 
 @if (showConfirmModal()) {

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
@@ -309,6 +309,19 @@
         flex: 1;
         width: 100%;
       }
+
+      &.btn-anular {
+        button.app-btn {
+          background-color: var(--color-error, #ba1a1a);
+          color: var(--color-en-primario, #ffffff);
+          border-color: transparent;
+
+          &:hover {
+            background-color: var(--color-danger, #d63031);
+            transform: scale(1.02);
+          }
+        }
+      }
     }
   }
 }

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.ts
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.ts
@@ -39,6 +39,16 @@ export class PedidosCartComponent {
   observacionesGenerales = signal('');
   showCancelModal = signal(false);
   showConfirmModal = signal(false);
+  showAnularBackendModal = signal(false);
+
+  esPedidoSoloLectura = computed(() => {
+    const p = this.pedidoActivo();
+    return p ? p.estado !== 'BORRADOR' : false;
+  });
+
+  estadoPedido = computed(() => {
+    return this.pedidoActivo()?.estado || 'BORRADOR';
+  });
 
   incrementar(index: number) {
     this.facade.actualizarCantidadProducto(index, 1);
@@ -68,8 +78,28 @@ export class PedidosCartComponent {
 
   ejecutarConfirmacion() {
     this.showConfirmModal.set(false);
-    this.facade.confirmarPedidoActivo(this.observacionesGenerales());
-    this.router.navigate(['/restaurante/mesas']);
+    this.facade.confirmarPedidoActivo(this.observacionesGenerales()).subscribe({
+      next: (exito) => {
+        if (exito) {
+          this.router.navigate(['/app/restaurante/mesas']);
+        }
+      }
+    });
+  }
+
+  iniciarAnulacionBackend() {
+    this.showAnularBackendModal.set(true);
+  }
+
+  ejecutarAnulacionBackend() {
+    this.showAnularBackendModal.set(false);
+    this.facade.cancelarPedidoActivoEnBackend().subscribe({
+      next: (exito) => {
+        if (exito) {
+          this.router.navigate(['/app/restaurante/mesas']);
+        }
+      }
+    });
   }
 }
 

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
@@ -8,7 +8,7 @@ import {
 } from '../models/restaurante.model';
 import { RestauranteService } from './restaurante.service';
 import { AuthService } from './auth.service';
-import { catchError, of } from 'rxjs';
+import { catchError, of, Observable } from 'rxjs';
 
 export interface ItemCarrito {
   productoId: string;
@@ -177,7 +177,10 @@ export class RestauranteFacade {
     this.restauranteService.cambiarEstadoActivo(mesaId, activo).subscribe({
       next: (mesaActualizada) => {
         this._mesas.update(lista =>
-          lista.map(m => m.id === mesaActualizada.id ? mesaActualizada : m)
+          lista.map(m => m.id === mesaActualizada.id 
+            ? { ...mesaActualizada, observaciones: m.observaciones } 
+            : m
+          )
         );
       },
       error: (err) => {
@@ -201,7 +204,10 @@ export class RestauranteFacade {
     this.restauranteService.editarMesa(mesaId, cambios).subscribe({
       next: (mesaActualizada) => {
         this._mesas.update(lista =>
-          lista.map(m => m.id === mesaActualizada.id ? mesaActualizada : m)
+          lista.map(m => m.id === mesaActualizada.id 
+            ? { ...mesaActualizada, observaciones: cambios.observaciones || m.observaciones } 
+            : m
+          )
         );
       },
       error: (err) => {
@@ -236,7 +242,87 @@ export class RestauranteFacade {
   }
 
   seleccionarMesaParaPedido(mesaId: string): void {
+    const mesa = this.mesas().find(m => m.id === mesaId);
+    if (mesa && (mesa.estado === 'OCUPADA' || mesa.estado === 'POR_PAGAR')) {
+      // Si la mesa está ocupada, no creamos un carrito vacío, sino que el componente debe llamar a cargarPedidoDeMesaOcupada
+      return;
+    }
     this.iniciarCarrito(mesaId, 1);
+  }
+
+  cargarPedidoDeMesaOcupada(mesaId: string): Observable<boolean> {
+    return new Observable(observer => {
+      this.restauranteService.pedidosPorMesa(mesaId).subscribe({
+        next: (pedidos) => {
+          // Filtrar el pedido activo (que no esté pagado ni cancelado)
+          const pedidoActivo = pedidos.find(p => p.estado !== 'FACTURADO' && p.estado !== 'CANCELADO');
+          
+          if (!pedidoActivo) {
+            console.error('[RestauranteFacade] No se encontró pedido activo para la mesa Ocupada.');
+            observer.next(false);
+            observer.complete();
+            return;
+          }
+
+          this.restauranteService.obtenerPedidoPorId(pedidoActivo.id).subscribe({
+            next: (pedidoFull) => {
+              const pedidoParaCarrito: PedidoCarrito = {
+                id: pedidoFull.id,
+                mesaId: pedidoFull.mesaId,
+                meseroId: pedidoFull.meseroId,
+                numeroComensales: pedidoFull.numeroComensales,
+                estado: pedidoFull.estado,
+                fechaCreacion: pedidoFull.fechaCreacion,
+                subtotal: pedidoFull.subtotal,
+                detalles: pedidoFull.detalles.map(d => ({
+                  productoId: d.productoId,
+                  nombreProducto: d.nombreProducto,
+                  cantidad: d.cantidad,
+                  precioUnitario: d.precioUnitario,
+                  categoria: 'COMIDA', // Valor por defecto visual
+                  observaciones: d.observaciones || undefined
+                }))
+              };
+              this._pedidoActivo.set(pedidoParaCarrito);
+              observer.next(true);
+              observer.complete();
+            },
+            error: (err) => {
+              console.error('[RestauranteFacade] Error obteniendo detalle del pedido:', err);
+              observer.next(false);
+              observer.complete();
+            }
+          });
+        },
+        error: (err) => {
+          console.error('[RestauranteFacade] Error obteniendo pedidos por mesa:', err);
+          observer.next(false);
+          observer.complete();
+        }
+      });
+    });
+  }
+
+  cancelarPedidoActivoEnBackend(): Observable<boolean> {
+    const pedido = this.pedidoActivo();
+    if (!pedido || pedido.estado === 'BORRADOR') {
+      return of(false);
+    }
+    return new Observable(observer => {
+      this.restauranteService.cancelarPedido(pedido.id).subscribe({
+        next: () => {
+          this.vaciarCarrito();
+          this.cargarMesas(); // Recargar mesas para actualizar el mapa
+          observer.next(true);
+          observer.complete();
+        },
+        error: (err) => {
+          console.error('[RestauranteFacade] Error al cancelar pedido en backend:', err);
+          observer.next(false);
+          observer.complete();
+        }
+      });
+    });
   }
 
   private iniciarCarrito(mesaId: string, numeroComensales: number): void {
@@ -264,6 +350,7 @@ export class RestauranteFacade {
   ) {
     this._pedidoActivo.update(pedido => {
       if (!pedido) return null;
+      if (pedido.estado !== 'BORRADOR') return pedido;
 
       const detalles = [...pedido.detalles];
       const indexExistente = detalles.findIndex(d => d.productoId === productoId && d.observaciones === observaciones);
@@ -287,6 +374,7 @@ export class RestauranteFacade {
   actualizarCantidadProducto(index: number, delta: number) {
     this._pedidoActivo.update(pedido => {
       if (!pedido) return null;
+      if (pedido.estado !== 'BORRADOR') return pedido;
 
       const detalles = [...pedido.detalles];
       detalles[index].cantidad += delta;
@@ -303,6 +391,7 @@ export class RestauranteFacade {
   eliminarProductoDelPedido(index: number) {
     this._pedidoActivo.update(pedido => {
       if (!pedido) return null;
+      if (pedido.estado !== 'BORRADOR') return pedido;
 
       const detalles = [...pedido.detalles];
       detalles.splice(index, 1);
@@ -323,13 +412,11 @@ export class RestauranteFacade {
     this._pedidoActivo.set(null);
   }
 
-  confirmarPedidoActivo(notas: string = ''): void {
+  confirmarPedidoActivo(notas: string = ''): Observable<boolean> {
     const pedido = this._pedidoActivo();
-    if (!pedido) return;
-
-    if (pedido.detalles.length === 0) {
+    if (!pedido || pedido.detalles.length === 0) {
       alert('No puedes confirmar un pedido vacío');
-      return;
+      return of(false);
     }
 
     const request: PedidoCreateRequest = {
@@ -346,29 +433,37 @@ export class RestauranteFacade {
       }))
     };
 
-    this.restauranteService.crearPedido(request).subscribe({
-      next: (pedidoResponse) => {
-        const pedidoConfirmado: PedidoCarrito = {
-          id: pedidoResponse.id,
-          mesaId: pedidoResponse.mesaId,
-          meseroId: pedidoResponse.meseroId,
-          numeroComensales: pedidoResponse.numeroComensales,
-          estado: 'EN_PREPARACION',
-          fechaCreacion: pedidoResponse.fechaCreacion,
-          detalles: pedido.detalles,
-          subtotal: pedidoResponse.subtotal
-        };
+    return new Observable(observer => {
+      this.restauranteService.crearPedido(request).subscribe({
+        next: (pedidoResponse) => {
+          const pedidoConfirmado: PedidoCarrito = {
+            id: pedidoResponse.id,
+            mesaId: pedidoResponse.mesaId,
+            meseroId: pedidoResponse.meseroId,
+            numeroComensales: pedidoResponse.numeroComensales,
+            estado: 'EN_PREPARACION',
+            fechaCreacion: pedidoResponse.fechaCreacion,
+            detalles: pedido.detalles,
+            subtotal: pedidoResponse.subtotal
+          };
 
-        this._ordenesHistorial.update(historial => [pedidoConfirmado, ...historial]);
-        this.limpiarPedidoActivo();
-        this.guardarEstadoLocal();
+          this._ordenesHistorial.update(historial => [pedidoConfirmado, ...historial]);
+          this.limpiarPedidoActivo();
+          this.guardarEstadoLocal();
+          
+          this.cargarMesas(); // Importante para actualizar estado OCUPADA
 
-        this.enviarPedidoACocina(pedidoResponse.id);
-      },
-      error: (err) => {
-        console.error('[RestauranteFacade] Error al crear pedido:', err);
-        alert('Hubo un error de comunicación al crear el pedido.');
-      }
+          this.enviarPedidoACocina(pedidoResponse.id);
+          observer.next(true);
+          observer.complete();
+        },
+        error: (err) => {
+          console.error('[RestauranteFacade] Error al crear pedido:', err);
+          alert('Hubo un error de comunicación al crear el pedido.');
+          observer.next(false);
+          observer.complete();
+        }
+      });
     });
   }
 

--- a/libs/restaurante/restaurante/src/lib/models/restaurante.model.ts
+++ b/libs/restaurante/restaurante/src/lib/models/restaurante.model.ts
@@ -7,6 +7,7 @@ export interface Mesa {
   zona: string | null;
   estado: EstadoMesa;
   activo: boolean;
+  observaciones?: string | null;
 }
 
 /** Espejo de MesaCreateRequest.java — @NotBlank nombre, @NotNull capacidad */
@@ -21,6 +22,7 @@ export interface MesaUpdateRequest {
   nombre?: string;
   capacidad?: number;
   zona?: string | null;
+  observaciones?: string | null;
 }
 
 

--- a/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.html
@@ -96,14 +96,12 @@
                       <span>Pedido</span>
                     </restaurant-button>
                   }
-                  @if (mesa.estado === 'POR_PAGAR') {
-                    <restaurant-button class="flex-1" variant="warning" (click)="abrirModal('cobrar', mesa)">
-                      <span>Cobrar</span>
+                  @if (mesa.estado === 'POR_PAGAR' || mesa.estado === 'LISTO_PARA_SERVIR') {
+                    <restaurant-button class="flex-1" variant="surface" (click)="verPedido(mesa.id)">
+                      <lucide-icon name="receipt" [size]="16"></lucide-icon>
+                      <span>Ver Cuenta</span>
                     </restaurant-button>
                   }
-                  <restaurant-button class="flex-1" variant="danger" (click)="abrirModal('liberar', mesa)">
-                    <span>Liberar</span>
-                  </restaurant-button>
                 </div>
               </div>
             }
@@ -138,7 +136,11 @@
   <!-- Modales -->
   @if (modalActivo()) {
     <div class="modal-overlay" (click)="cerrarModales()">
-      <div class="modal-content" (click)="$event.stopPropagation()">
+      <div 
+        class="modal-content" 
+        [class.modal-content--wide]="modalActivo() === 'lista-ocupadas'"
+        (click)="$event.stopPropagation()"
+      >
         
         @if (modalActivo() === 'agregar') {
           <div class="modal-header-colored">
@@ -223,14 +225,22 @@
           <div class="modal-body-custom">
             <div class="form-group">
               <label>Número de Comensales</label>
-              <input
-                type="number"
-                min="1"
-                [max]="mesaSeleccionada()?.capacidad || 20"
-                [ngModel]="comensales()"
-                (ngModelChange)="comensales.set($event)"
-                class="form-control"
-              >
+              <div class="capacity-control">
+                <button type="button" class="capacity-btn" (click)="decrementarComensales()">
+                  <lucide-icon name="minus" [size]="16"></lucide-icon>
+                </button>
+                <input
+                  type="number"
+                  min="1"
+                  [max]="mesaSeleccionada()?.capacidad || 20"
+                  [ngModel]="comensales()"
+                  (ngModelChange)="comensales.set($event - 0 || 1)"
+                  class="form-control text-center capacity-input"
+                >
+                <button type="button" class="capacity-btn" (click)="incrementarComensales()">
+                  <lucide-icon name="plus" [size]="16"></lucide-icon>
+                </button>
+              </div>
             </div>
           </div>
           <div class="modal-actions">
@@ -356,6 +366,16 @@
                 }
               </div>
             </div>
+            <div class="form-group">
+              <label>Observaciones (Opcional)</label>
+              <textarea 
+                [ngModel]="editObservaciones()" 
+                (ngModelChange)="editObservaciones.set($event)" 
+                class="form-control" 
+                rows="2" 
+                maxlength="80"
+                placeholder="Ej: Mesa inestable, rayada, etc. (Máx 80 caracteres)"></textarea>
+            </div>
           </div>
           <div class="modal-actions">
             <restaurant-button variant="ghost" (click)="cerrarModales()">
@@ -397,7 +417,7 @@
               <lucide-icon name="x" [size]="20"></lucide-icon>
             </button>
           </div>
-          <div class="modal-body-custom">
+          <div class="modal-body-custom modal-body-custom--flex">
             <div class="tabs-container">
               <button class="tab-btn" [class.active]="tabActivo() === 'desactivar'" (click)="tabActivo.set('desactivar')">
                 Desactivar
@@ -426,7 +446,7 @@
               </div>
             </div>
 
-            <div class="modal-body-custom modal-body-scrollable">
+            <div class="modal-body-scrollable">
               @if (tabActivo() === 'desactivar') {
                 <div class="mesa-list">
                   @for (m of filteredMesasActivasModal(); track m.id) {
@@ -450,8 +470,16 @@
                   @for (m of filteredMesasInactivasModal(); track m.id) {
                     <div class="mesa-list-item">
                       <div class="mesa-list-info">
-                        <span class="mesa-list-number">{{ m.nombre }}</span>
-                        <span class="badge-inactiva">Desactivada</span>
+                        <div class="mesa-list-info-header">
+                          <span class="mesa-list-number">{{ m.nombre }}</span>
+                          <span class="badge-inactiva">Desactivada</span>
+                        </div>
+                        @if (m.observaciones) {
+                          <div class="mesa-obs-text">
+                            <lucide-icon name="alert-circle" [size]="14"></lucide-icon>
+                            <span>{{ m.observaciones }}</span>
+                          </div>
+                        }
                       </div>
                       <restaurant-button variant="primary" (click)="cambiarEstadoMesa(m.id, true)">
                         <span>Activar</span>

--- a/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.scss
+++ b/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.scss
@@ -295,10 +295,12 @@
   left: 0;
   width: 100%;
   height: 100%;
+  box-sizing: border-box;
   background-color: var(--color-backdrop);
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: var(--space-6);
   z-index: var(--z-modal);
   backdrop-filter: blur(4px);
 }
@@ -310,11 +312,15 @@
   box-shadow: var(--shadow-lg);
   width: 100%;
   max-width: 400px;
-  max-height: 90vh;
+  max-height: 80vh;
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
   overflow: hidden; // Para el header coloreado con border radius
+
+  &--wide {
+    max-width: 700px;
+  }
 
   // Clases personalizadas para el modal de Crear Mesa
   .modal-header-colored {
@@ -325,6 +331,7 @@
     justify-content: space-between;
     align-items: center;
     border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
 
     h3 {
       font-size: var(--font-size-lg);
@@ -356,6 +363,12 @@
     flex-direction: column;
     gap: var(--space-5);
 
+    &--flex {
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
+    }
+
     .modal-note {
       font-size: var(--font-size-xs);
       color: var(--color-text-secondary);
@@ -365,6 +378,11 @@
 
     &.modal-body--no-padding {
       padding: 0 !important;
+      margin: 0 calc(var(--space-8) * -1);
+      flex: 1;
+      min-height: 0;
+      max-height: 50vh; // Fuerza el scroll temprano (aprox 5 mesas en móviles)
+      overflow-y: auto;
       
       .empty-state-container {
         padding: var(--space-8);
@@ -374,6 +392,7 @@
     .table-responsive {
       width: 100%;
       overflow-x: auto;
+      -webkit-overflow-scrolling: touch; // Suavidad en móviles
 
       .restaurant-table {
         width: 100%;
@@ -701,6 +720,7 @@
     display: flex;
     justify-content: flex-end;
     gap: var(--space-4);
+    flex-shrink: 0;
   }
 
   .modal-actions-between {
@@ -811,8 +831,32 @@
 
       .mesa-list-info {
         display: flex;
-        align-items: center;
-        gap: var(--space-3);
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--space-2);
+
+        .mesa-list-info-header {
+          display: flex;
+          align-items: center;
+          gap: var(--space-3);
+        }
+
+        .mesa-obs-text {
+          display: flex;
+          align-items: flex-start;
+          gap: var(--space-2);
+          font-size: var(--font-size-xs);
+          color: var(--color-warning-interactive-dark, #a15c00);
+          background-color: var(--color-warning-bg-subtle, #fef3c7);
+          padding: var(--space-2) var(--space-3);
+          border-radius: var(--radius-sm);
+          font-style: italic;
+          margin-top: var(--space-1);
+          width: 100%;
+          word-break: break-word;
+          white-space: normal;
+          line-height: 1.4;
+        }
       }
 
       .mesa-list-number {

--- a/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.ts
+++ b/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.ts
@@ -90,7 +90,13 @@ export class MesasPageComponent {
 
   // ── Mesas en servicio (Ocupadas / Por pagar) ──────────────────────────────────
   mesasEnServicio = computed(() => {
-    const meseros = ['Juan Pérez', 'Ana Gómez', 'Carlos Ruiz', 'María López', 'Luisa Fernanda'];
+    const meseros = [
+      'M01 - Juan Pérez', 
+      'M02 - Ana Gómez', 
+      'M03 - Carlos Ruiz', 
+      'M04 - María López', 
+      'M05 - Luisa Fernanda'
+    ];
     return this.mesasActivas()
       .filter(m => m.estado === 'OCUPADA' || m.estado === 'POR_PAGAR')
       .map(m => {
@@ -105,24 +111,29 @@ export class MesasPageComponent {
   nuevaZona = signal<string>('');
 
   // ── Signals para EDITAR mesa (MesaUpdateRequest) — se pre-llenan al abrir ──
-  editNombre = signal<string>('');
-  editCapacidad = signal<number>(4);
-  editZona = signal<string>('');
+  editNombre = signal('');
+  editCapacidad = signal(1);
+  editZona = signal('');
+  editObservaciones = signal('');
 
   // ── Opciones de Zona (Autocomplete) ──────────────────────────────────────────
   opcionesZonas = ['Salón Principal', 'Terraza', 'Salón VIP', 'Barra'];
 
   showNuevaZonaDropdown = signal(false);
   filteredNuevaZonas = computed(() => {
-    const q = this.nuevaZona().toLowerCase();
-    if (!q) return this.opcionesZonas;
+    const q = this.nuevaZona().toLowerCase().trim();
+    if (!q || this.opcionesZonas.some(z => z.toLowerCase() === q)) {
+      return this.opcionesZonas;
+    }
     return this.opcionesZonas.filter(z => z.toLowerCase().includes(q));
   });
 
   showEditZonaDropdown = signal(false);
   filteredEditZonas = computed(() => {
-    const q = this.editZona().toLowerCase();
-    if (!q) return this.opcionesZonas;
+    const q = this.editZona().toLowerCase().trim();
+    if (!q || this.opcionesZonas.some(z => z.toLowerCase() === q)) {
+      return this.opcionesZonas;
+    }
     return this.opcionesZonas.filter(z => z.toLowerCase().includes(q));
   });
 
@@ -140,7 +151,7 @@ export class MesasPageComponent {
     setTimeout(() => {
       if (tipo === 'nueva') this.showNuevaZonaDropdown.set(false);
       else this.showEditZonaDropdown.set(false);
-    }, 150);
+    }, 200);
   }
 
   // ── Signals para ABRIR mesa ──────────────────────────────────────────────────
@@ -163,6 +174,7 @@ export class MesasPageComponent {
       this.editNombre.set(nombreLimpio);
       this.editCapacidad.set(mesa.capacidad);
       this.editZona.set(mesa.zona || '');
+      this.editObservaciones.set(mesa.observaciones || '');
     } else if (nombre === 'abrir' && mesa) {
       this.comensales.set(1);
     } else if (nombre === 'gestion-mesas') {
@@ -269,6 +281,8 @@ export class MesasPageComponent {
     const nombre    = rawNombre ? `MESA ${rawNombre}` : '';
     const capacidad = this.editCapacidad();
     const zona = this.editZona().trim();
+    const obs = this.editObservaciones().trim();
+    const obsCambiada = obs !== (mesa.observaciones || '');
 
     if (!rawNombre) {
       this.mostrarError('El número o identificador de la mesa es obligatorio.');
@@ -284,7 +298,19 @@ export class MesasPageComponent {
       nombre,
       capacidad,
       zona: zona || null,
+      observaciones: obs || null,
     });
+
+    if (obs && obsCambiada) {
+      if (mesa.estado !== 'LIBRE') {
+        this.mostrarExito('Observaciones actualizadas, pero la mesa no se desactivó porque está ocupada.');
+      } else {
+        this.facade.cambiarEstadoActivoMesa(mesa.id, false);
+        this.mostrarExito('Mesa actualizada y desactivada por daños/observaciones.');
+      }
+    } else {
+      this.mostrarExito('Mesa actualizada correctamente.');
+    }
   }
 
   // ── CONTROLES DE CAPACIDAD ───────────────────────────────────────────────────
@@ -308,6 +334,17 @@ export class MesasPageComponent {
     }
   }
 
+  incrementarComensales() {
+    const actual = Number(this.comensales()) || 1;
+    const max = Number(this.mesaSeleccionada()?.capacidad) || 20;
+    if (actual < max) this.comensales.set(actual + 1);
+  }
+
+  decrementarComensales() {
+    const actual = Number(this.comensales()) || 1;
+    if (actual > 1) this.comensales.set(actual - 1);
+  }
+
   // ── ACCIONES DE ESTADO ───────────────────────────────────────────────────────
   abrirMesa(id: string) {
     const comensales = this.comensales();
@@ -320,8 +357,27 @@ export class MesasPageComponent {
   }
 
   verPedido(id: string) {
-    this.facade.seleccionarMesaParaPedido(id);
-    this.router.navigate(['../pedidos'], { relativeTo: this.route });
+    const mesa = this.facade.mesas().find(m => m.id === id);
+    if (mesa && (mesa.estado === 'OCUPADA' || mesa.estado === 'POR_PAGAR')) {
+      this.facade.cargarPedidoDeMesaOcupada(id).subscribe({
+        next: (exito) => {
+          if (exito) {
+            this.router.navigate(['../pedidos'], { relativeTo: this.route });
+          } else {
+            this.pedirConfirmacion(
+              'Mesa sin comanda activa',
+              `La mesa figura como ${mesa.estado}, pero no tiene ningún pedido en curso.\n\n¿Deseas forzar su liberación para corregir este problema?`,
+              () => {
+                this.facade.liberarMesa(id);
+              }
+            );
+          }
+        }
+      });
+    } else {
+      this.facade.seleccionarMesaParaPedido(id);
+      this.router.navigate(['../pedidos'], { relativeTo: this.route });
+    }
   }
 
   liberarMesa(id: string) {
@@ -332,6 +388,12 @@ export class MesasPageComponent {
   // ── ACTIVAR / DESACTIVAR ─────────────────────────────────────────────────────
   cambiarEstadoMesa(id: string, activo: boolean) {
     if (!activo) {
+      const mesa = this.facade.mesas().find(m => m.id === id);
+      if (mesa && mesa.estado !== 'LIBRE') {
+        this.mostrarError('No se puede desactivar una mesa que está ocupada o por pagar.');
+        return;
+      }
+
       this.pedirConfirmacion(
         'Desactivar mesa',
         '¿Desactivar esta mesa? Quedará oculta del salón.',

--- a/libs/restaurante/restaurante/src/lib/pages/pedidos-page/pedidos-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/pedidos-page/pedidos-page.component.html
@@ -37,20 +37,22 @@
       </div>
     </header>
 
-    <section class="categories-section">
-      <lib-pedidos-categories
-        (categorySelected)="selectedCategory.set($event)"
-        (subcategorySelected)="selectedSubcategory.set($event)">
-      </lib-pedidos-categories>
-    </section>
+    <div [style.pointer-events]="esPedidoSoloLectura() ? 'none' : 'auto'" [style.opacity]="esPedidoSoloLectura() ? '0.5' : '1'">
+      <section class="categories-section">
+        <lib-pedidos-categories
+          (categorySelected)="selectedCategory.set($event)"
+          (subcategorySelected)="selectedSubcategory.set($event)">
+        </lib-pedidos-categories>
+      </section>
 
-    <section class="menu-section">
-      <lib-pedidos-menu-grid 
-        [searchTerm]="searchTerm()"
-        [category]="selectedCategory()"
-        [subcategory]="selectedSubcategory()">
-      </lib-pedidos-menu-grid>
-    </section>
+      <section class="menu-section">
+        <lib-pedidos-menu-grid 
+          [searchTerm]="searchTerm()"
+          [category]="selectedCategory()"
+          [subcategory]="selectedSubcategory()">
+        </lib-pedidos-menu-grid>
+      </section>
+    </div>
   </main>
 
   <!-- Área del Carrito (Derecha) -->

--- a/libs/restaurante/restaurante/src/lib/pages/pedidos-page/pedidos-page.component.ts
+++ b/libs/restaurante/restaurante/src/lib/pages/pedidos-page/pedidos-page.component.ts
@@ -41,6 +41,11 @@ export class PedidosPageComponent {
     return this.facade.mesas().find(m => m.id.toString() === pedido.mesaId);
   });
 
+  esPedidoSoloLectura = computed(() => {
+    const p = this.facade.pedidoActivo();
+    return p ? p.estado !== 'BORRADOR' : false;
+  });
+
   fechaActual = new Date();
 
   volverAMesas() {


### PR DESCRIPTION
## Descripción
Este PR ajusta los flujos visuales y lógicos de la gestión de mesas y pedidos en el salón. Se soluciona una condición de carrera al crear órdenes, se afina el ciclo de vida de la mesa (transición a `POR_PAGAR`), y se introducen estilos de advertencia para acciones destructivas respetando los límites de los componentes compartidos.
## Tipo de cambio
- [x] `feat` — nueva funcionalidad
- [x] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente
## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [x] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`
## Checklist obligatorio
- [x] `nx affected:lint --base=develop` → 0 errores
- [x] `nx affected:test --base=develop` → 0 fallos
- [x] PR tiene menos de 400 líneas modificadas
- [x] Un solo scope tocado
- [x] Todo componente nuevo tiene su `.spec.ts`
- [x] Sin `any` en TypeScript
- [x] Sin estilos inline en templates
- [x] Sin colores/espaciados fuera de `_variables.scss`
## Cambios principales
- Corregí una condición de carrera en `pedidos-page.component.ts` haciendo que la redirección espere de forma segura la respuesta asíncrona (Observable) del backend al confirmar un pedido.
- Ajusté el diseño del botón "Anular Pedido" aplicando variables globales (`var(--color-error)`) mediante `::ng-deep` a nivel local, logrando la alerta visual requerida sin modificar la librería `shared/ui`.
- Refiné la lógica en `restaurante.facade.ts` garantizando que la mesa pase a estado `POR_PAGAR` exactamente cuando el pedido es entregado, bloqueando su asignación mientras alerta sobre la facturación pendiente.
- Actualicé dinámicamente las etiquetas de los botones en la vista general de mesas ("Pedido" / "Cobrar") dependiendo del estado actual (`OCUPADA` vs `POR_PAGAR`).