### PR TITLE
feat(inventario): importar FEL solo por XML (eliminar import PDF)

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
@@ -124,29 +124,6 @@ export class FacturasFacade {
       });
   }
 
-  importarFacturaFel(file: File, gilId?: string): void {
-    this._loading.set(true);
-    this._error.set(null);
-    this._facturaImportada.set(null);
-
-    this.svc.importarFacturaFel(file, gilId)
-      .pipe(
-        catchError((error) => {
-          this._error.set(this.getImportErrorMessage(error));
-          return of(null);
-        }),
-        finalize(() => this._loading.set(false))
-      )
-      .subscribe((factura) => {
-        if (factura !== null) {
-          this._facturaImportada.set(factura);
-          this._facturaSeleccionada.set(factura);
-          this.cargarFacturas();
-          this.cargarKpis();
-        }
-      });
-  }
-
   importarFacturaFelXml(file: File, gilId?: string): void {
     this._loading.set(true);
     this._error.set(null);
@@ -378,7 +355,7 @@ export class FacturasFacade {
     if (httpError?.error?.detail) return httpError.error.detail;
     if (httpError?.error?.title) return httpError.error.title;
     if (httpError?.status === 409) return 'La factura ya existe en el sistema.';
-    if (httpError?.status === 400) return 'El archivo no es un PDF FEL válido.';
+    if (httpError?.status === 400) return 'El archivo no es un XML FEL válido.';
     if (httpError?.status === 422) return 'No se pudo procesar el contenido de la factura.';
 
     return 'Error al importar la factura electrónica';

--- a/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
@@ -85,21 +85,6 @@ export class FacturasService {
       );
   }
 
-  importarFacturaFel(file: File, gilId?: string): Observable<Factura> {
-    const formData = new FormData();
-    formData.append('archivo', file, file.name);
-
-    let params = new HttpParams();
-    if (gilId) params = params.set('gilId', gilId);
-
-    return this.http
-      .post<FacturaResponse>(`${API}/sourcing/facturas/importar-fel`, formData, { params })
-      .pipe(
-        map(facturaFromApi),
-        catchError(err => throwError(() => err))
-      );
-  }
-
   importarFacturaFelXml(file: File, gilId?: string): Observable<Factura> {
     const formData = new FormData();
     formData.append('archivo', file, file.name);

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.html
@@ -3,7 +3,7 @@
     <inventario-back-button (clicked)="goBack()" />
     <div>
       <h1 class="page-header__title">Importar Factura Electrónica</h1>
-      <p class="page-header__subtitle">Subí el PDF de la factura electrónica para registrarla en el sistema.</p>
+      <p class="page-header__subtitle">Subí el XML de la factura electrónica para registrarla en el sistema.</p>
     </div>
   </header>
 
@@ -35,30 +35,6 @@
     </div>
   }
 
-  <div class="formato-toggle">
-    <restaurant-button
-      [variant]="formato() === 'pdf' ? 'primary' : 'ghost'"
-      (click)="setFormato('pdf')"
-    >
-      <span class="material-symbols-outlined">picture_as_pdf</span>
-      PDF
-    </restaurant-button>
-    <restaurant-button
-      [variant]="formato() === 'xml' ? 'primary' : 'ghost'"
-      (click)="setFormato('xml')"
-    >
-      <span class="material-symbols-outlined">code</span>
-      XML · UBL 2.1
-    </restaurant-button>
-  </div>
-
-  @if (formato() === 'xml') {
-    <div class="formato-banner">
-      <span class="material-symbols-outlined">verified</span>
-      <span>Importación desde XML estructurado DIAN — mayor exactitud en la extracción de ítems</span>
-    </div>
-  }
-
   <div class="import-grid">
     <div class="upload-zone-wrapper">
       <div
@@ -71,15 +47,11 @@
       >
         <div class="upload-zone__icon-wrapper">
           <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1">
-            {{ formato() === 'xml' ? 'code' : 'cloud_upload' }}
+            code
           </span>
         </div>
-        <h3 class="upload-zone__title">
-          {{ formato() === 'xml' ? 'Arrastrá el XML UBL 2.1 acá' : 'Arrastrá tu factura acá' }}
-        </h3>
-        <p class="upload-zone__subtitle">
-          {{ formato() === 'xml' ? 'Solo archivos .xml · máximo 10 MB' : 'Solo archivos .pdf · máximo 10 MB' }}
-        </p>
+        <h3 class="upload-zone__title">Arrastrá el XML UBL 2.1 acá</h3>
+        <p class="upload-zone__subtitle">Solo archivos .xml · máximo 10 MB</p>
 
         <div class="field-group upload-zone__field">
           <label class="field-label">GIL a vincular (opcional)</label>
@@ -103,7 +75,7 @@
         <input
           #fileInput
           type="file"
-          [attr.accept]="formato() === 'xml' ? '.xml' : '.pdf'"
+          accept=".xml"
           hidden
           (change)="onFileInput($event)"
         >
@@ -118,7 +90,7 @@
       <ul class="instructions-list">
         <li>
           <div class="step-badge">1</div>
-          <p>Subí el PDF de la factura electrónica original. El sistema extrae automáticamente los datos del documento.</p>
+          <p>Subí el XML de la factura electrónica original. El sistema extrae automáticamente los datos del documento.</p>
         </li>
         <li>
           <div class="step-badge">2</div>

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.scss
@@ -769,40 +769,6 @@
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Format Toggle (PDF / XML)
-// ─────────────────────────────────────────────────────────────────────────────
-.formato-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  background-color: var(--color-superficie-contenedor);
-  border-radius: var(--radius-lg);
-  padding: var(--space-1);
-  width: fit-content;
-  box-shadow: var(--shadow-xs);
-}
-
-.formato-banner {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
-  border-radius: var(--radius-md);
-  background-color: var(--color-info-bg);
-  border: 1px solid var(--color-info-border);
-  color: var(--color-info-text);
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  animation: slideDown var(--duration-base) var(--ease-decelerate);
-
-  .material-symbols-outlined {
-    color: var(--color-info);
-    font-size: 1.25rem;
-    flex-shrink: 0;
-  }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Animations
 // ─────────────────────────────────────────────────────────────────────────────
 @keyframes slideDown {

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.ts
@@ -3,16 +3,14 @@ import { Router, RouterModule } from '@angular/router';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
 import { FacturasFacade } from '../../../data-access/facturas.facade';
 import { FacturaLinea } from '../../../models/facturas.model';
-import { ButtonComponent } from '@restaurant/shared/ui';
 import { BienGilResponse } from '../../../data-access/api/procurement.api';
 
 export type ImportStatus = 'idle' | 'loading' | 'success' | 'error';
-export type FormatoArchivo = 'pdf' | 'xml';
 
 @Component({
   selector: 'restaurant-factura-import',
   standalone: true,
-  imports: [RouterModule, BackButtonComponent, ButtonComponent],
+  imports: [RouterModule, BackButtonComponent],
   templateUrl: './factura-import.component.html',
   styleUrl: './factura-import.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -25,7 +23,6 @@ export class FacturaImportPageComponent implements OnInit {
   fileName = signal('');
   gilId = signal('');
   localError = signal<string | null>(null);
-  formato = signal<FormatoArchivo>('pdf');
 
   facturaImportada        = this.facade.facturaImportada;
   gilesDisponibles        = this.facade.gilesDisponibles;
@@ -158,12 +155,6 @@ export class FacturaImportPageComponent implements OnInit {
       .trim();
   }
 
-  setFormato(f: FormatoArchivo): void {
-    if (this.formato() === f) return;
-    this.formato.set(f);
-    this.resetImport();
-  }
-
   goBack(): void {
     this.router.navigate(['/app/inventario/facturas']);
   }
@@ -215,19 +206,11 @@ export class FacturaImportPageComponent implements OnInit {
     const normalizedGilId = this.gilId().trim();
     const ext = file.name.toLowerCase().split('.').pop();
 
-    if (this.formato() === 'xml') {
-      if (ext !== 'xml') {
-        this.localError.set('Para importación XML seleccioná un archivo .xml');
-        return;
-      }
-      this.facade.importarFacturaFelXml(file, normalizedGilId || undefined);
-    } else {
-      if (ext !== 'pdf') {
-        this.localError.set('Para importación PDF seleccioná un archivo .pdf');
-        return;
-      }
-      this.facade.importarFacturaFel(file, normalizedGilId || undefined);
+    if (ext !== 'xml') {
+      this.localError.set('Para importación XML seleccioná un archivo .xml');
+      return;
     }
+    this.facade.importarFacturaFelXml(file, normalizedGilId || undefined);
   }
 
   private groupIva(lineas: FacturaLinea[]): Array<{ porcentaje: number; valor: number }> {


### PR DESCRIPTION
## Qué cambia
Se elimina **toda** la importación de FEL por **PDF** en el frontend; queda **solo XML**.

- `factura-import`: se quita el toggle de formato PDF/XML y el tipo `FormatoArchivo`. La pantalla importa siempre XML (`accept=".xml"`), sin validaciones ni textos de PDF.
- `facturas.service`: eliminado el método de import por PDF (`POST /sourcing/facturas/importar-fel`); se conserva el de XML (`/importar-fel-xml`).
- `facturas.facade`: eliminado el método de import PDF; el texto de error pasa a referirse a XML.

## Verificación
- `nx lint inventario` ✅
- `nx build restaurant-app` ✅ (build fresco, sin caché)

> Acompaña al cambio de backend (rama `fix/fel-solo-xml-y-matcher`) que elimina el endpoint/usecase/parser PDF.