### PR TITLE
fix(inventario): consumir listado global de movimientos del backend

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/inventory.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/inventory.api.ts
@@ -5,6 +5,8 @@
  * español (contenido/totalElementos) para cubrir las variaciones del backend.
  */
 export interface MovimientoPageResponse {
+  // Clave real del backend (KardexHttpResponse): array bajo `movimientos`
+  movimientos?:   MovimientoResponse[];
   // Convención inglés (Spring Page<T> estándar — igual que PagedGilResponse)
   content?:       MovimientoResponse[];
   totalElements?: number;

--- a/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/kardex.facade.ts
@@ -45,7 +45,7 @@ export class KardexFacade {
   // ── Kardex ───────────────────────────────────────────────────────────────────
 
   /** Carga el listado global de movimientos (GET /inventory/movimientos). */
-  loadAll(pagina = 0, tamano = 50): void {
+  loadAll(pagina = 0, tamano = 20): void {
     this._loading.set(true);
     this._error.set(null);
     this.movimientosService.getMovimientos(pagina, tamano)

--- a/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/inventory.mapper.ts
@@ -20,8 +20,10 @@ import {
 
 /**
  * Normaliza la respuesta paginada de GET /inventory/movimientos/{productoId}.
- * El backend no documenta el schema en Swagger (type: object genérico) y puede
- * usar convención inglés (content/totalElements) o español (contenido/totalElementos).
+ * El backend no documenta el schema en Swagger (type: object genérico).
+ * La respuesta real expone el array bajo `movimientos` (KardexHttpResponse);
+ * se mantienen los fallbacks inglés (content/totalElements) y español
+ * (contenido/totalElementos) por compatibilidad.
  */
 export function movimientoPageFromApi(resp: MovimientoPageResponse): {
   movimientos:    Movimiento[];
@@ -29,7 +31,7 @@ export function movimientoPageFromApi(resp: MovimientoPageResponse): {
   totalElementos: number;
 } {
   const dtos: MovimientoResponse[] =
-    resp.content ?? resp.contenido ?? [];
+    resp.movimientos ?? resp.content ?? resp.contenido ?? [];
   return {
     movimientos:    dtos.map(movimientoFromApi),
     totalPaginas:   resp.totalPages   ?? resp.totalPaginas   ?? 0,


### PR DESCRIPTION
El backend expone el array paginado bajo la clave 'movimientos' (KardexHttpResponse). El mapper solo leia content/contenido, devolviendo siempre lista vacia. Se antepone 'movimientos' en la cadena de fallback y se agrega el campo a MovimientoPageResponse. Se alinea el tamano de pagina por defecto a 20 (coincide con el default del backend).

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
