### PR TITLE
feat(inventario): resolver línea FEL pendiente asociándola a un bien

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
@@ -225,6 +225,36 @@ export class FacturasFacade {
       });
   }
 
+  /**
+   * Asocia una línea PENDIENTE-CATALOGO a un bien existente del catálogo.
+   * Propaga el mensaje del backend (p. ej. "el bien no existe") para guiar al usuario.
+   */
+  resolverLineaPendiente(
+    id: string | number,
+    descripcionLinea: string,
+    codigoProductoSena: string,
+  ): void {
+    this._loading.set(true);
+    this.svc.resolverLineaPendiente(id, descripcionLinea, codigoProductoSena)
+      .pipe(
+        catchError((err: unknown) => {
+          this._error.set(this.mensajeResolverPendiente(err));
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe(res => {
+        if (res) { this._facturaSeleccionada.set(res); this.cargarFacturas(); }
+      });
+  }
+
+  private mensajeResolverPendiente(err: unknown): string {
+    const detail = (err as { error?: { detail?: string } } | null)?.error?.detail;
+    return detail && detail.trim().length > 0
+      ? detail
+      : 'No se pudo asociar la línea al bien.';
+  }
+
   marcarPagada(id: string | number): void {
     this._loading.set(true);
     this.svc.marcarPagada(id)

--- a/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
@@ -127,6 +127,24 @@ export class FacturasService {
       );
   }
 
+  /**
+   * PATCH /sourcing/facturas/{id}/lineas/resolver — asocia una línea PENDIENTE-CATALOGO
+   * a un bien existente del catálogo por su código SENA. El bien debe existir.
+   */
+  resolverLineaPendiente(
+    id: string | number,
+    descripcionLinea: string,
+    codigoProductoSena: string
+  ): Observable<Factura> {
+    const body = { descripcionLinea, codigoProductoSena };
+    return this.http
+      .patch<FacturaResponse>(`${API}/sourcing/facturas/${id}/lineas/resolver`, body)
+      .pipe(
+        map(facturaFromApi),
+        catchError(err => throwError(() => err))
+      );
+  }
+
   /** PATCH /sourcing/facturas/{id}/pagar - solo válido desde estado VERIFICADA */
   marcarPagada(id: string | number): Observable<Factura> {
     return this.http

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.html
@@ -104,7 +104,13 @@
                 <tr>
                   <td class="text-center text-secondary">{{ i + 1 }}</td>
                   <td class="font-medium">{{ item.descripcion }}</td>
-                  <td class="text-secondary">{{ item.productoId || '—' }}</td>
+                  <td class="text-secondary">
+                    @if (esPendiente(item)) {
+                      <span class="badge badge--orange" title="Esta línea aún no está asociada a un bien del catálogo">Sin bien</span>
+                    } @else {
+                      {{ item.productoId || '—' }}
+                    }
+                  </td>
                   <td class="text-right">{{ item.cantidad }}</td>
                   <td class="text-right">{{ item.precioUnitario | currency:'COP':'symbol-narrow':'1.0-0' }}</td>
                   <td class="text-right text-secondary">{{ item.porcentajeIva ?? item.iva }}%</td>
@@ -122,6 +128,51 @@
           </restaurant-data-table>
         </div>
       </section>
+
+      <!-- Cola de revisión: líneas FEL sin bien de catálogo asignado -->
+      @if (lineasPendientes().length > 0) {
+        <section class="bento-card pendientes-card">
+          <div class="card-section">
+            <h4 class="card-section__title">
+              <span class="material-symbols-outlined text-tertiary">rule</span>
+              Líneas sin bien asignado ({{ lineasPendientes().length }})
+            </h4>
+            <p class="pendientes-card__hint">
+              Estas líneas del FEL no se asociaron a un bien del catálogo. Asociá cada una a un bien
+              existente por su código SENA. Si el bien no existe,
+              <button type="button" class="link-btn" (click)="irACrearBien()">creálo primero en Bienes</button>.
+            </p>
+
+            @if (f.estado === 'REGISTRADA') {
+              <ul class="pendientes-list">
+                @for (linea of lineasPendientes(); track linea.descripcion) {
+                  <li class="pendientes-list__item">
+                    <span class="pendientes-list__desc font-medium">{{ linea.descripcion }}</span>
+                    <div class="pendientes-list__action">
+                      <input
+                        type="text"
+                        class="pendientes-input"
+                        placeholder="Código SENA del bien"
+                        [ngModel]="codigosSenaPendientes()[linea.descripcion] ?? ''"
+                        (input)="setCodigoSenaPendiente(linea.descripcion, $event)" />
+                      <restaurant-button
+                        variant="primary"
+                        [disabled]="!(codigosSenaPendientes()[linea.descripcion] || '').trim()"
+                        (click)="resolverPendiente(linea.descripcion)">
+                        Asociar
+                      </restaurant-button>
+                    </div>
+                  </li>
+                }
+              </ul>
+            } @else {
+              <p class="pendientes-card__locked text-secondary">
+                Solo se pueden asociar líneas mientras la factura está en estado REGISTRADA.
+              </p>
+            }
+          </div>
+        </section>
+      }
 
       <!-- Tarjetas inferiores: DIAN + Orden Compra + Resumen Fiscal -->
       <div class="bottom-cards-grid">

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.scss
@@ -122,6 +122,88 @@
     color: var(--color-terciario);
     border-radius: 0.375rem;
   }
+
+  &--orange {
+    background-color: rgba(var(--color-terciario-fijo-dim-rgb, 255, 179, 178), 0.25);
+    color: var(--color-terciario, #8c4a00);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cola de revisión — líneas FEL sin bien de catálogo asignado
+// ─────────────────────────────────────────────────────────────────────────────
+.pendientes-card {
+  border: 1px solid var(--color-contorno, #d9dce0);
+
+  &__hint {
+    margin: 0 0 1rem;
+    color: var(--color-en-superficie-variante);
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+
+  &__locked {
+    margin: 0;
+    font-size: 0.875rem;
+  }
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-primario);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.pendientes-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  &__item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--color-contorno, #d9dce0);
+    border-radius: 0.5rem;
+    background-color: var(--color-superficie-contenedor-bajo, #f5f6f7);
+  }
+
+  &__desc {
+    flex: 1 1 16rem;
+    color: var(--color-en-superficie);
+  }
+
+  &__action {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}
+
+.pendientes-input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-contorno, #d9dce0);
+  border-radius: 0.5rem;
+  font-family: var(--font-family-base);
+  font-size: 0.875rem;
+  background-color: var(--color-superficie, #ffffff);
+  color: var(--color-en-superficie);
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-primario);
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.ts
@@ -1,15 +1,19 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { ButtonComponent, DataTableComponent } from '@restaurant/shared/ui';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
 import { FacturasFacade } from '../../../data-access/facturas.facade';
-import { ConciliacionGilDiferencia } from '../../../models/facturas.model';
+import { ConciliacionGilDiferencia, FacturaLinea } from '../../../models/facturas.model';
+
+/** Sentinel del backend para líneas de factura sin bien de catálogo asignado. */
+const PRODUCTO_PENDIENTE = 'PENDIENTE-CATALOGO';
 
 @Component({
   selector: 'restaurant-factura-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, ButtonComponent, DataTableComponent, BackButtonComponent],
+  imports: [CommonModule, FormsModule, RouterModule, ButtonComponent, DataTableComponent, BackButtonComponent],
   templateUrl: './factura-detail.component.html',
   styleUrl: './factura-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -30,6 +34,17 @@ export class FacturaDetailPageComponent implements OnInit {
 
   showConfirmVerificar  = signal(false);
   showConfirmPagada     = signal(false);
+
+  /** Código SENA tipeado por el usuario para cada línea pendiente (clave: descripción). */
+  codigosSenaPendientes = signal<Record<string, string>>({});
+
+  /** Líneas de la factura que aún no tienen bien de catálogo asignado. */
+  lineasPendientes = computed<FacturaLinea[]>(() =>
+    (this.factura()?.lineas ?? []).filter(l => this.esPendiente(l)));
+
+  esPendiente(linea: FacturaLinea): boolean {
+    return linea.productoId === PRODUCTO_PENDIENTE;
+  }
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -52,6 +67,24 @@ export class FacturaDetailPageComponent implements OnInit {
     if (!obs.trim()) return; // observation required — don't send empty string to backend
     this.facade.resolverDiferenciaGil(c.id, gilItemId, obs);
     this.observaciones.update(o => { const next = { ...o }; delete next[gilItemId]; return next; });
+  }
+
+  setCodigoSenaPendiente(descripcion: string, event: Event): void {
+    const val = (event.target as HTMLInputElement).value;
+    this.codigosSenaPendientes.update(c => ({ ...c, [descripcion]: val }));
+  }
+
+  resolverPendiente(descripcion: string): void {
+    const factura = this.factura();
+    if (!factura) return;
+    const codigo = (this.codigosSenaPendientes()[descripcion] ?? '').trim();
+    if (!codigo) return; // el código SENA es obligatorio
+    this.facade.resolverLineaPendiente(String(factura.id), descripcion, codigo);
+    this.codigosSenaPendientes.update(c => { const next = { ...c }; delete next[descripcion]; return next; });
+  }
+
+  irACrearBien(): void {
+    this.router.navigate(['/app/inventario/bienes']);
   }
 
   onGilVincularChange(event: Event): void {


### PR DESCRIPTION
Cola de revisión en factura-detail: las líneas sin bien de catálogo (PENDIENTE-CATALOGO) se muestran con badge 'Sin bien' y, si la factura está REGISTRADA, se pueden asociar a un bien existente por código SENA (PATCH /sourcing/facturas/{id}/lineas/resolver). Si el bien no existe, enlace para crearlo en Bienes. Propaga el mensaje de error del backend.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
