### PR TITLE
fix(inventario): contar solo diferencias reales en conciliación GIL

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/mappers/sourcing.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/sourcing.mapper.ts
@@ -80,7 +80,12 @@ export function conciliacionGilFromApi(dto: ConciliacionGilResponse): Conciliaci
     facturaId: dto.facturaId,
     gilId:     dto.gilId,
     estado:    dto.estado,
-    diferencias: dto.detalles.map((d: DetalleGilResponse) => ({
+    // Solo los detalles que NO coinciden son diferencias. Un detalle en estado 'OK'
+    // significa que el ítem cuadra (cantidad, precio e IVA) y no debe contarse ni
+    // listarse como diferencia.
+    diferencias: dto.detalles
+      .filter((d: DetalleGilResponse) => d.estado !== 'OK')
+      .map((d: DetalleGilResponse) => ({
       gilItemId:             d.gilItemId,
       descripcion:           d.descripcion,
       cantidadGil:           d.cantidadGil,


### PR DESCRIPTION
Los detalles en estado OK (ítem que coincide en cantidad, precio e IVA) se contaban y listaban como diferencias, mostrando 'N diferencia(s) encontrada(s)' aunque todo cuadrara. Ahora el mapper solo toma como diferencia los detalles con estado distinto de OK.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
