### PR TITLE
fix(inventario): mover "GIL a vincular" fuera de la zona de subida en…

### DIFF
--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.html
@@ -37,6 +37,20 @@
 
   <div class="import-grid">
     <div class="upload-zone-wrapper">
+      <div class="field-group gil-vincular-field">
+        <label class="field-label">GIL a vincular (opcional)</label>
+        <select
+          class="field-input"
+          [value]="gilId()"
+          (change)="onGilSelect($event)"
+        >
+          <option value="">Sin GIL</option>
+          @for (gil of gilesDisponibles(); track gil.id) {
+            <option [value]="gil.id">{{ gil.numeroGil }} — {{ gil.destino }}</option>
+          }
+        </select>
+      </div>
+
       <div
         class="upload-zone"
         [class.upload-zone--active]="isDragOver()"
@@ -52,21 +66,6 @@
         </div>
         <h3 class="upload-zone__title">Arrastrá el XML UBL 2.1 acá</h3>
         <p class="upload-zone__subtitle">Solo archivos .xml · máximo 10 MB</p>
-
-        <div class="field-group upload-zone__field">
-          <label class="field-label">GIL a vincular (opcional)</label>
-          <select
-            class="field-input"
-            [value]="gilId()"
-            (change)="onGilSelect($event); $event.stopPropagation()"
-            (click)="$event.stopPropagation()"
-          >
-            <option value="">Sin GIL</option>
-            @for (gil of gilesDisponibles(); track gil.id) {
-              <option [value]="gil.id">{{ gil.numeroGil }} — {{ gil.destino }}</option>
-            }
-          </select>
-        </div>
 
         <button class="btn btn--primary" (click)="fileInput.click(); $event.stopPropagation()">
           Seleccionar archivo

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.scss
@@ -129,7 +129,13 @@
 // Upload Zone
 .upload-zone-wrapper {
   display: flex;
+  flex-direction: column;
+  gap: 1rem;
   height: 100%;
+}
+
+.gil-vincular-field {
+  width: 100%;
 }
 
 .upload-zone {


### PR DESCRIPTION
… import FEL

El select de GIL estaba dentro del dropzone (que tiene click → abrir selector de archivos). Al hacer clic en su label o el espacio alrededor, el evento burbujeaba y abría el gestor de archivos. Se movió el campo a su propia fila, arriba de la zona de subida, para un acceso claro y sin disparar el file picker.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
