### PR TITLE
feat(shell): asistente GastroIA con panel y colapso de sidebar

### DIFF
--- a/libs/shell/shell/src/lib/shell-layout/asistente/asistente-ui.service.ts
+++ b/libs/shell/shell/src/lib/shell-layout/asistente/asistente-ui.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs';
+
+/**
+ * Unica fuente de verdad del estado del asistente en el layout.
+ *
+ * El boton de la barra superior ESCRIBE (toggle/abrir/cerrar); la barra
+ * lateral, el contenido y el panel solo LEEN `panelAbierto`. Flujo
+ * unidireccional: ningun componente conoce a los demas, todos reaccionan
+ * al mismo signal.
+ *
+ * Al navegar a cualquier modulo (sidebar, barra superior o footer) el panel
+ * se cierra solo escuchando al Router. Asi no hay que enganchar `(click)` en
+ * cada enlace: una sola regla cubre toda la navegacion.
+ */
+@Injectable({ providedIn: 'root' })
+export class AsistenteUiService {
+  private readonly router = inject(Router);
+
+  private readonly _panelAbierto = signal(false);
+
+  /** Estado de apertura del panel del asistente (solo lectura). */
+  readonly panelAbierto = this._panelAbierto.asReadonly();
+
+  /** Estado accesible para `aria-expanded`. */
+  readonly estadoAria = computed(() => this._panelAbierto());
+
+  constructor() {
+    // Cierra el panel ante cualquier navegacion (incluye enlaces de la barra
+    // superior y navegacion programatica). Los enlaces del sidebar ademas
+    // llaman `cerrar()` en su (click) para un refresco inmediato de la vista.
+    this.router.events
+      .pipe(
+        filter((evento) => evento instanceof NavigationEnd),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => this.cerrar());
+  }
+
+  abrir(): void {
+    this._panelAbierto.set(true);
+  }
+
+  cerrar(): void {
+    this._panelAbierto.set(false);
+  }
+
+  toggle(): void {
+    this._panelAbierto.update((abierto) => !abierto);
+  }
+}

--- a/libs/shell/shell/src/lib/shell-layout/asistente/asistente.models.ts
+++ b/libs/shell/shell/src/lib/shell-layout/asistente/asistente.models.ts
@@ -1,0 +1,25 @@
+/**
+ * Modelos del asistente conversacional (GastroIA).
+ *
+ * Por ahora alimentan la capa visual con datos mock. Cuando se conecte
+ * el backend, `MensajeChat` es el contrato que devolvera el servicio real.
+ */
+
+/** Quien emite el mensaje dentro de la conversacion. */
+export type AutorMensaje = 'usuario' | 'asistente';
+
+/** Un mensaje individual del hilo de chat. */
+export interface MensajeChat {
+  id: string;
+  autor: AutorMensaje;
+  texto: string;
+  /** Hora de envio en formato presentacional, p. ej. "10:42 AM". */
+  hora?: string;
+}
+
+/** Configuracion presentacional del encabezado del panel. */
+export interface AsistentePerfil {
+  nombre: string;
+  estado: string;
+  enLinea: boolean;
+}

--- a/libs/shell/shell/src/lib/shell-layout/asistente/panel-asistente/panel-asistente.component.html
+++ b/libs/shell/shell/src/lib/shell-layout/asistente/panel-asistente/panel-asistente.component.html
@@ -1,0 +1,75 @@
+@if (asistente.panelAbierto()) {
+  <aside class="panel-asistente" role="complementary" aria-label="Asistente GastroIA">
+
+    <!-- Encabezado -->
+    <header class="panel-asistente__encabezado">
+      <div class="panel-asistente__identidad">
+        <div class="panel-asistente__avatar">
+          <svg lucideBot></svg>
+        </div>
+        <div class="panel-asistente__titulos">
+          <h2 class="panel-asistente__nombre">{{ perfil.nombre }}</h2>
+          <span class="panel-asistente__estado">
+            <span
+              class="panel-asistente__indicador"
+              [class.panel-asistente__indicador--activo]="perfil.enLinea"
+            ></span>
+            {{ perfil.estado }}
+          </span>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        class="panel-asistente__cerrar"
+        aria-label="Cerrar asistente"
+        (click)="cerrar()"
+      >
+        <svg lucideX></svg>
+      </button>
+    </header>
+
+    <!-- Conversacion -->
+    <div class="panel-asistente__conversacion">
+      @for (mensaje of mensajes; track mensaje.id) {
+        <div
+          class="panel-asistente__mensaje"
+          [class.panel-asistente__mensaje--usuario]="mensaje.autor === 'usuario'"
+          [class.panel-asistente__mensaje--asistente]="mensaje.autor === 'asistente'"
+        >
+          @if (mensaje.autor === 'asistente') {
+            <div class="panel-asistente__mensaje-avatar">
+              <svg lucideBot></svg>
+            </div>
+          }
+          <div class="panel-asistente__burbuja">
+            <p class="panel-asistente__texto">{{ mensaje.texto }}</p>
+            @if (mensaje.hora) {
+              <span class="panel-asistente__hora">{{ mensaje.hora }}</span>
+            }
+          </div>
+        </div>
+      }
+    </div>
+
+    <!-- Entrada -->
+    <footer class="panel-asistente__pie">
+      <div class="panel-asistente__campo">
+        <input
+          type="text"
+          class="panel-asistente__input"
+          placeholder="Escribe un mensaje..."
+          aria-label="Escribe un mensaje para GastroIA"
+        />
+        <button type="button" class="panel-asistente__microfono" aria-label="Dictar mensaje">
+          <svg lucideMic></svg>
+        </button>
+        <button type="button" class="panel-asistente__enviar" aria-label="Enviar mensaje">
+          <svg lucideSend></svg>
+        </button>
+      </div>
+      <p class="panel-asistente__aviso">GastroIA puede cometer errores. Verifica la info.</p>
+    </footer>
+
+  </aside>
+}

--- a/libs/shell/shell/src/lib/shell-layout/asistente/panel-asistente/panel-asistente.component.scss
+++ b/libs/shell/shell/src/lib/shell-layout/asistente/panel-asistente/panel-asistente.component.scss
@@ -1,0 +1,251 @@
+// Dimensiones del panel — alineadas con el colapso del layout.
+// Sidebar normal 16rem -> colapsada 5rem; panel 22rem.
+$panel-ancho: 22rem;
+
+.panel-asistente {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: $panel-ancho;
+  height: 100%;
+  background-color: var(--color-superficie-contenedor-mas-bajo);
+  border-left: 1px solid var(--color-pizarra-100);
+  display: flex;
+  flex-direction: column;
+  z-index: 60;                         // por encima de barra-superior (z 50)
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.04);
+  animation: panel-asistente-entrada 0.25s cubic-bezier(0, 0, 0.2, 1);
+
+  // ---- Encabezado ----
+  &__encabezado {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--color-pizarra-100);
+  }
+
+  &__identidad {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  &__avatar {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.75rem;
+    background: linear-gradient(135deg, var(--color-primario) 0%, var(--color-primario-gradient-end) 100%);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    box-shadow: 0 4px 6px -1px rgba(57, 169, 0, 0.3);
+  }
+
+  &__nombre {
+    font-family: var(--font-family-headline);
+    font-size: 1rem;
+    font-weight: 800;
+    color: var(--color-en-superficie);
+    line-height: 1.2;
+  }
+
+  &__estado {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    color: var(--color-pizarra-500);
+  }
+
+  &__indicador {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 999px;
+    background-color: var(--color-pizarra-300);
+
+    &--activo {
+      background-color: var(--color-primario);
+    }
+  }
+
+  &__cerrar {
+    background: transparent;
+    border: none;
+    color: var(--color-pizarra-500);
+    padding: 0.375rem;
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: var(--color-pizarra-50);
+      color: var(--color-pizarra-700);
+    }
+
+    &:active {
+      transform: scale(0.95);
+    }
+  }
+
+  // ---- Conversacion ----
+  &__conversacion {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    background-color: var(--color-superficie);
+
+    &::-webkit-scrollbar { width: 4px; }
+    &::-webkit-scrollbar-track { background: transparent; }
+    &::-webkit-scrollbar-thumb { background: var(--color-pizarra-200); border-radius: 10px; }
+  }
+
+  &__mensaje {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.5rem;
+    max-width: 90%;
+
+    &--usuario {
+      align-self: flex-end;
+      flex-direction: row-reverse;
+    }
+
+    &--asistente {
+      align-self: flex-start;
+    }
+  }
+
+  &__mensaje-avatar {
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 0.75rem;
+    background-color: var(--color-pizarra-100);
+    color: var(--color-primario);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  &__burbuja {
+    padding: 0.625rem 0.875rem;
+    border-radius: 1rem;
+    background-color: var(--color-superficie-contenedor-mas-bajo);
+    border: 1px solid var(--color-pizarra-100);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.02);
+  }
+
+  &__mensaje--usuario &__burbuja {
+    background: linear-gradient(135deg, var(--color-primario) 0%, var(--color-primario-gradient-end) 100%);
+    border-color: transparent;
+
+    .panel-asistente__texto { color: white; }
+    .panel-asistente__hora { color: rgba(255, 255, 255, 0.8); }
+  }
+
+  &__texto {
+    font-size: 0.875rem;
+    line-height: 1.45;
+    color: var(--color-en-superficie);
+  }
+
+  &__hora {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.625rem;
+    color: var(--color-pizarra-400);
+    text-align: right;
+  }
+
+  // ---- Entrada ----
+  &__pie {
+    flex-shrink: 0;
+    padding: 0.875rem 1rem 1rem;
+    border-top: 1px solid var(--color-pizarra-100);
+    background-color: var(--color-superficie-contenedor-mas-bajo);
+  }
+
+  &__campo {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    background-color: var(--color-pizarra-50);
+    border-radius: 999px;
+    padding: 0.25rem 0.25rem 0.25rem 1rem;
+    transition: box-shadow 0.2s ease;
+
+    &:focus-within {
+      box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.2);
+    }
+  }
+
+  &__input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    font-family: var(--font-family-base);
+    font-size: 0.875rem;
+    color: var(--color-en-superficie);
+
+    &:focus { outline: none; }
+  }
+
+  &__microfono {
+    background: transparent;
+    border: none;
+    color: var(--color-pizarra-400);
+    padding: 0.5rem;
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    transition: all 0.2s ease;
+
+    &:hover { color: var(--color-pizarra-600); }
+  }
+
+  &__enviar {
+    background: linear-gradient(135deg, var(--color-primario) 0%, var(--color-primario-gradient-end) 100%);
+    border: none;
+    color: white;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: all 0.2s ease;
+
+    &:hover { box-shadow: 0 4px 12px rgba(57, 169, 0, 0.35); }
+    &:active { transform: scale(0.95); }
+  }
+
+  &__aviso {
+    margin-top: 0.5rem;
+    font-size: 0.625rem;
+    color: var(--color-pizarra-400);
+    text-align: center;
+  }
+}
+
+@keyframes panel-asistente-entrada {
+  from {
+    transform: translateX(100%);
+    opacity: 0.4;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}

--- a/libs/shell/shell/src/lib/shell-layout/asistente/panel-asistente/panel-asistente.component.ts
+++ b/libs/shell/shell/src/lib/shell-layout/asistente/panel-asistente/panel-asistente.component.ts
@@ -1,0 +1,49 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LucideBot, LucideMic, LucideSend, LucideX } from '@lucide/angular';
+import { AsistenteUiService } from '../asistente-ui.service';
+import { AsistentePerfil, MensajeChat } from '../asistente.models';
+
+@Component({
+  selector: 'restaurant-panel-asistente',
+  standalone: true,
+  imports: [CommonModule, LucideBot, LucideMic, LucideSend, LucideX],
+  templateUrl: './panel-asistente.component.html',
+  styleUrls: ['./panel-asistente.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PanelAsistenteComponent {
+  protected readonly asistente = inject(AsistenteUiService);
+
+  /** Perfil del asistente (mock — vendra del backend mas adelante). */
+  protected readonly perfil: AsistentePerfil = {
+    nombre: 'GastroIA',
+    estado: 'En linea',
+    enLinea: true,
+  };
+
+  /** Conversacion de ejemplo. Datos mock hasta conectar el backend. */
+  protected readonly mensajes: MensajeChat[] = [
+    {
+      id: 'm1',
+      autor: 'asistente',
+      texto: '¡Hola! Soy GastroIA. ¿En que te puedo ayudar con el inventario hoy?',
+    },
+    {
+      id: 'm2',
+      autor: 'usuario',
+      texto: '¿Cuanto stock queda de harina de trigo?',
+      hora: '10:42 AM',
+    },
+    {
+      id: 'm3',
+      autor: 'asistente',
+      texto:
+        'Stock actual de Harina de trigo: 12 kg disponibles (minimo 50 kg). Estado: bajo stock — alerta activa.',
+    },
+  ];
+
+  protected cerrar(): void {
+    this.asistente.cerrar();
+  }
+}

--- a/libs/shell/shell/src/lib/shell-layout/shell-layout.component.html
+++ b/libs/shell/shell/src/lib/shell-layout/shell-layout.component.html
@@ -1,4 +1,7 @@
-<div class="layout-principal">
+<div
+  class="layout-principal"
+  [class.layout-principal--asistente]="asistente.panelAbierto()"
+>
   <restaurant-barra-lateral [config]="sidebarConfig"></restaurant-barra-lateral>
 
   <main class="contenido-principal">
@@ -12,4 +15,6 @@
       <router-outlet></router-outlet>
     </div>
   </main>
+
+  <restaurant-panel-asistente></restaurant-panel-asistente>
 </div>

--- a/libs/shell/shell/src/lib/shell-layout/shell-layout.component.scss
+++ b/libs/shell/shell/src/lib/shell-layout/shell-layout.component.scss
@@ -2,6 +2,22 @@
   display: block;
 }
 
+.contenido-principal {
+  // Sincroniza con los anchos fijos del sidebar (16rem) y la barra superior.
+  transition: margin-left 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+              margin-right 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+              max-width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+// Panel del asistente abierto: barra colapsada (5rem) + espacio del panel (22rem).
+// Sobrescribe el margen global de `.contenido-principal` (libs/shared/ui) por
+// especificidad de estilos scoped del componente.
+.layout-principal--asistente .contenido-principal {
+  margin-left: 5rem;
+  margin-right: 22rem;
+  max-width: calc(100vw - 5rem - 22rem);
+}
+
 .contenido-principal__contenedor {
   min-height: calc(100vh - 6rem);
 }

--- a/libs/shell/shell/src/lib/shell-layout/shell-layout.component.ts
+++ b/libs/shell/shell/src/lib/shell-layout/shell-layout.component.ts
@@ -3,12 +3,19 @@ import { RouterOutlet } from '@angular/router';
 import { AuthService } from '@restaurant/shared/auth';
 import { BarraLateralComponent } from './sidebar/barra-lateral.component';
 import { BarraSuperiorComponent } from './topbar/barra-superior.component';
+import { PanelAsistenteComponent } from './asistente/panel-asistente/panel-asistente.component';
+import { AsistenteUiService } from './asistente/asistente-ui.service';
 import { SIDEBAR_CONFIG, TOP_MENU_CONFIG } from '../nav/nav-config';
 
 @Component({
   selector: 'restaurant-shell-layout',
   standalone: true,
-  imports: [RouterOutlet, BarraLateralComponent, BarraSuperiorComponent],
+  imports: [
+    RouterOutlet,
+    BarraLateralComponent,
+    BarraSuperiorComponent,
+    PanelAsistenteComponent,
+  ],
   templateUrl: './shell-layout.component.html',
   styleUrls: ['./shell-layout.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -19,4 +26,5 @@ export class ShellLayoutComponent {
   protected readonly sidebarConfig = SIDEBAR_CONFIG;
   protected readonly topMenu = TOP_MENU_CONFIG;
   protected readonly currentUser = computed(() => this.authService.currentUser());
+  protected readonly asistente = inject(AsistenteUiService);
 }

--- a/libs/shell/shell/src/lib/shell-layout/sidebar/barra-lateral.component.html
+++ b/libs/shell/shell/src/lib/shell-layout/sidebar/barra-lateral.component.html
@@ -1,4 +1,7 @@
-<aside class="barra-lateral">
+<aside
+  class="barra-lateral"
+  [class.barra-lateral--colapsada]="asistente.panelAbierto()"
+>
   <div class="barra-lateral__encabezado">
     <div class="barra-lateral__logo-contenedor">
       <div class="barra-lateral__logo-icono barra-lateral__logo-icono--imagen">
@@ -29,7 +32,7 @@
               <button
                 class="barra-lateral__enlace barra-lateral__enlace--expandible"
                 [class.barra-lateral__enlace--expandido]="isExpanded(item.ruta)"
-                (click)="toggleItem(item.ruta)"
+                (click)="asistente.cerrar(); toggleItem(item.ruta)"
                 type="button"
               >
                 @if (item.icono) {
@@ -55,6 +58,7 @@
                       [routerLink]="child.ruta"
                       routerLinkActive="barra-lateral__subenlace--activo"
                       class="barra-lateral__subenlace"
+                      (click)="asistente.cerrar()"
                     >
                       @if (child.icono) {
                         <svg [lucideIcon]="child.icono!" class="barra-lateral__subicono"></svg>
@@ -74,6 +78,7 @@
                 [routerLinkActiveOptions]="{ exact: item.exact ?? false }"
                 class="barra-lateral__enlace"
                 [class.barra-lateral__enlace--con-insignia]="item.insignia !== undefined"
+                (click)="asistente.cerrar()"
               >
                 @if (item.icono) {
                   <svg [lucideIcon]="item.icono!" class="barra-lateral__icono"></svg>
@@ -96,11 +101,11 @@
 
   <!-- PIE DEL SIDEBAR (enlaces fijos: Perfil, Configuración, Cerrar Sesión) -->
   <div class="barra-lateral__pie">
-    <a routerLink="/app/configuracion" class="barra-lateral__enlace">
+    <a routerLink="/app/configuracion" class="barra-lateral__enlace" (click)="asistente.cerrar()">
       <svg lucideSettings class="barra-lateral__icono"></svg>
       <span class="barra-lateral__texto">Configuración</span>
     </a>
-    <a routerLink="/app/perfil" class="barra-lateral__enlace">
+    <a routerLink="/app/perfil" class="barra-lateral__enlace" (click)="asistente.cerrar()">
       <svg lucideUser class="barra-lateral__icono"></svg>
       <span class="barra-lateral__texto">Perfil</span>
     </a>

--- a/libs/shell/shell/src/lib/shell-layout/sidebar/barra-lateral.component.scss
+++ b/libs/shell/shell/src/lib/shell-layout/sidebar/barra-lateral.component.scss
@@ -18,6 +18,7 @@ $verde-sena-hover: rgba($verde-sena-nuevo, 0.05);
   border-right: 1px solid var(--color-pizarra-200);
   z-index: 50;
   overflow: hidden;
+  transition: width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 
   &__encabezado {
     padding: 0 1.5rem;
@@ -289,5 +290,49 @@ $verde-sena-hover: rgba($verde-sena-nuevo, 0.05);
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
+  }
+
+  // ====================================================================
+  // ESTADO COLAPSADO — panel del asistente abierto: solo iconos visibles
+  // ====================================================================
+  &--colapsada {
+    width: 5rem;
+
+    .barra-lateral__logo-texto,
+    .barra-lateral__subtitulo,
+    .barra-lateral__etiqueta-grupo,
+    .barra-lateral__texto,
+    .barra-lateral__insignia,
+    .barra-lateral__chevron,
+    .barra-lateral__subgrupo {
+      display: none;
+    }
+
+    .barra-lateral__encabezado {
+      padding: 0;
+    }
+
+    .barra-lateral__logo-contenedor {
+      justify-content: center;
+    }
+
+    .barra-lateral__navegacion {
+      padding: 0 0.5rem;
+    }
+
+    .barra-lateral__enlace,
+    .barra-lateral__enlace--activo {
+      justify-content: center;
+      padding: 0.625rem;
+      border-left: none;
+    }
+
+    .barra-lateral__pie {
+      align-items: center;
+
+      .barra-lateral__enlace {
+        width: 100%;
+      }
+    }
   }
 }

--- a/libs/shell/shell/src/lib/shell-layout/sidebar/barra-lateral.component.ts
+++ b/libs/shell/shell/src/lib/shell-layout/sidebar/barra-lateral.component.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { LucideBox, LucideDynamicIcon, LucideLogOut, LucideSettings, LucideUser } from '@lucide/angular';
 import { AuthService } from '@restaurant/shared/auth';
 import { BarraLateralConfig } from '../../nav/nav.models';
+import { AsistenteUiService } from '../asistente/asistente-ui.service';
 
 @Component({
   selector: 'restaurant-barra-lateral',
@@ -22,6 +23,7 @@ import { BarraLateralConfig } from '../../nav/nav.models';
 })
 export class BarraLateralComponent {
   private readonly authService = inject(AuthService);
+  protected readonly asistente = inject(AsistenteUiService);
 
   @Input() config: BarraLateralConfig = {
     titulo: 'Mi App',

--- a/libs/shell/shell/src/lib/shell-layout/topbar/barra-superior.component.html
+++ b/libs/shell/shell/src/lib/shell-layout/topbar/barra-superior.component.html
@@ -1,4 +1,7 @@
-<header class="barra-superior">
+<header
+  class="barra-superior"
+  [class.barra-superior--comprimida]="asistente.panelAbierto()"
+>
   @if (enlaces.length > 0) {
     <nav class="barra-superior__nav">
       @for (enlace of enlaces; track enlace.ruta) {
@@ -24,8 +27,11 @@
     <div class="barra-superior__herramientas">
       <button
         class="barra-superior__boton-icono barra-superior__boton-icono--ia"
+        [class.barra-superior__boton-icono--ia-activo]="asistente.panelAbierto()"
+        [attr.aria-pressed]="asistente.panelAbierto()"
         title="Asistente IA"
         type="button"
+        (click)="asistente.toggle()"
       >
         <svg lucideBrainCircuit></svg>
       </button>

--- a/libs/shell/shell/src/lib/shell-layout/topbar/barra-superior.component.scss
+++ b/libs/shell/shell/src/lib/shell-layout/topbar/barra-superior.component.scss
@@ -11,6 +11,14 @@
   align-items: center;
   padding: 0 1.5rem;
   z-index: 50;
+  transition: width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+              right 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+
+  // Panel del asistente abierto: barra lateral colapsada (5rem) + panel (22rem)
+  &--comprimida {
+    right: 22rem;
+    width: calc(100% - 5rem - 22rem);
+  }
 
   &__nav {
     display: flex;
@@ -98,6 +106,16 @@
       &:hover {
         background-color: rgba(57, 169, 0, 0.08);
         color: var(--color-brand-primary-strong);
+      }
+    }
+
+    &--ia-activo {
+      background: linear-gradient(135deg, var(--color-primario) 0%, var(--color-primario-gradient-end) 100%);
+      color: white;
+
+      &:hover {
+        background: linear-gradient(135deg, var(--color-primario) 0%, var(--color-primario-gradient-end) 100%);
+        color: white;
       }
     }
   }

--- a/libs/shell/shell/src/lib/shell-layout/topbar/barra-superior.component.ts
+++ b/libs/shell/shell/src/lib/shell-layout/topbar/barra-superior.component.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { LucideBell, LucideBrainCircuit, LucideMoon, LucideSearch, LucideSun, LucideUser } from '@lucide/angular';
 import { PerfilConfig, TopNavLink } from '../../nav/nav.models';
 import { NotificacionesService } from '@restaurant/notificaciones';
+import { AsistenteUiService } from '../asistente/asistente-ui.service';
 
 @Component({
   selector: 'restaurant-barra-superior',
@@ -20,6 +21,7 @@ export class BarraSuperiorComponent implements OnInit, OnDestroy {
   readonly esOscuro = signal(false);
   readonly contadorNotificaciones = signal(0);
 
+  protected readonly asistente = inject(AsistenteUiService);
   private notificacionesService = inject(NotificacionesService);
   private intervalId: any;
 


### PR DESCRIPTION
## Qué hace

Agrega el asistente conversacional **GastroIA** como panel lateral en el layout del shell.

- Botón **Asistente IA** de la barra superior abre/cierra el panel (estado activo en verde).
- Al abrirse, la **barra lateral se colapsa a iconos** y el contenido se desplaza para dar espacio al panel.
- Al **navegar a un módulo** (enlaces, sub-enlaces, items expandibles, footer) el panel **se cierra solo** y el sidebar se re-expande.
- Capa **visual con mensajes mock**; lista para conectar al **backend Python** mediante el contrato tipado `MensajeChat`.

## Arquitectura

- `AsistenteUiService` (signal `panelAbierto`) — única fuente de verdad. Flujo unidireccional: la topbar escribe, sidebar/contenido/panel leen.
- Cierre en el evento `click` de los enlaces del nav (refresco inmediato de vista) + suscripción a `NavigationEnd` como respaldo.
- Estilos con los design tokens compartidos (`var(--color-*)`), sin tocar `libs/shared`.

## Alcance
Solo `libs/shell/shell/src/lib/shell-layout/`. Verificado con `ngc` (typecheck + plantillas) y probado en navegador.

## Pendiente (siguiente fase)
Conectar el panel a la API Python (definir REST vs streaming).