### PR TITLE
arreglo error general

### DIFF
--- a/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
+++ b/libs/auth/usuarios/src/lib/data-access/usuarios.service.ts
@@ -150,32 +150,23 @@ export class UsuariosService extends BaseHttpService {
   }
 
   actualizarFoto(userId: string, fotoUrl: string): Observable<void> {
-
     return this.http.patch<void>(
       this.buildUrl(`${this.resource}/${userId}/foto`),
       { fotoUrl }
     );
   }
 
-  // ✅ MÉTODO CORREGIDO - Usa buildUrl en lugar de apiUrl
-obtenerAprendices(): Observable<Usuario[]> {
-  return this.http.get<any>(this.buildUrl(`${this.resource}?rol=APRENDIZ`)).pipe(
-    map((res: any) => {
-      const raw: any[] = Array.isArray(res) ? res : (res.content ?? []);
-      return raw.map((u: any) => ({
-        ...u,
-        id:     u.idUsuario ?? u.id,
-        activo: u.estado    ?? u.activo,
-        rol:    u.rol?.nombreRol ?? u.rol,
-      }));
-    })
-  );
-}
-
-  return this.http.patch<void>(
-    this.buildUrl('perfil/foto'),
-    { fotoUrl }
-  ); 
- }
-
+  obtenerAprendices(): Observable<Usuario[]> {
+    return this.http.get<any>(this.buildUrl(`${this.resource}?rol=APRENDIZ`)).pipe(
+      map((res: any) => {
+        const raw: any[] = Array.isArray(res) ? res : (res.content ?? []);
+        return raw.map((u: any) => ({
+          ...u,
+          id:     u.idUsuario ?? u.id,
+          activo: u.estado    ?? u.activo,
+          rol:    u.rol?.nombreRol ?? u.rol,
+        }));
+      })
+    );
+  }
 }


### PR DESCRIPTION
## Descripción
Corrección del archivo `usuarios.service.ts` que quedó con código duplicado y roto tras un merge entre la funcionalidad de fichas y los cambios de foto de perfil del compañero. Se unificaron ambos aportes en un solo archivo limpio y funcional.

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [x] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
- [ ] `shell` · [x] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [x] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [x] PR tiene menos de 400 líneas modificadas
- [x] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
- Eliminé el código duplicado y roto al final de `usuarios.service.ts` que quedó de un merge incompleto
- Mantuve `actualizarFoto()` del compañero con la implementación correcta
- Mantuve `obtenerAprendices()` necesario para la funcionalidad de asignación de aprendices a fichas

## RF relacionado
RF2.8 — Gestión de fichas: asignación de aprendices, vocero y subvocero
