### PR TITLE
feat(inventario): exportar acta a .docx y detalle de acta por id directo

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/actas.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/actas.facade.ts
@@ -90,6 +90,20 @@ export class ActasFacade {
       });
   }
 
+  /** POST /legalization/actas/{id}/exportar — genera el .docx del acta. */
+  exportarActa(id: string): void {
+    this._loading.set(true);
+    this.actasService.exportarActa(id)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al exportar el acta');
+          return of(false);
+        }),
+        finalize(() => this._loading.set(false))
+      )
+      .subscribe();
+  }
+
   /** POST /legalization/actas/{id}/revisar — revisorId obligatorio (@NotBlank en backend). */
   revisarActa(id: string, revisorId: string): void {
     this._loading.set(true);

--- a/libs/inventario/inventario/src/lib/data-access/services/actas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/actas.service.ts
@@ -8,7 +8,7 @@ import {
   CompromisoActa,
   FirmanteActa,
 } from '../../models/acta.model';
-import { ActasPageResponse, CrearActaRequest } from '../api/legalization.api';
+import { ActaResponse, ActasPageResponse, CrearActaRequest } from '../api/legalization.api';
 import { actaFromApi } from '../mappers/legalization.mapper';
 
 const API = '/api/v1';
@@ -33,15 +33,12 @@ export class ActasService {
       );
   }
 
-  /** Backend no expone GET /actas/{id}: busca en la lista paginada por ID. */
+  /** GET /legalization/actas/{id} — detalle directo (no depende del tamaño de la lista). */
   getActaById(id: string): Observable<ActaLegalizacion | undefined> {
     return this.http
-      .get<ActasPageResponse>(`${API}/legalization/actas`, { params: { size: 100 } })
+      .get<ActaResponse>(`${API}/legalization/actas/${id}`)
       .pipe(
-        map(resp => {
-          const found = resp.contenido.find(a => a.id === id);
-          return found ? actaFromApi(found) : undefined;
-        }),
+        map(actaFromApi),
         catchError(err => throwError(() => err))
       );
   }
@@ -62,6 +59,16 @@ export class ActasService {
 
     return this.http
       .post<void>(`${API}/legalization/actas/${id}/${accion}`, {})
+      .pipe(
+        map(() => true),
+        catchError(err => throwError(() => err))
+      );
+  }
+
+  /** POST /legalization/actas/{id}/exportar — genera el .docx del acta. */
+  exportarActa(id: string): Observable<boolean> {
+    return this.http
+      .post<void>(`${API}/legalization/actas/${id}/exportar`, {})
       .pipe(
         map(() => true),
         catchError(err => throwError(() => err))

--- a/libs/inventario/inventario/src/lib/pages/actas-page/actas-detail/actas-detail.component.html
+++ b/libs/inventario/inventario/src/lib/pages/actas-page/actas-detail/actas-detail.component.html
@@ -19,6 +19,12 @@
         <lucide-icon name="printer" [size]="16"></lucide-icon>
         Exportar GOR-F-084
       </button>
+      <button class="acta-detail__export-btn"
+              [disabled]="loading()"
+              (click)="exportarDocx()">
+        <lucide-icon name="file-text" [size]="16"></lucide-icon>
+        Exportar .docx
+      </button>
       @if (a.estado !== 'ARCHIVADA') {
         <button class="acta-detail__status-btn" (click)="cambiarEstado()">
           <lucide-icon name="refresh-cw" [size]="16"></lucide-icon>

--- a/libs/inventario/inventario/src/lib/pages/actas-page/actas-detail/actas-detail.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/actas-page/actas-detail/actas-detail.component.ts
@@ -108,6 +108,14 @@ export class ActasDetailComponent implements OnInit {
     }
   }
 
+  /** POST /legalization/actas/{id}/exportar — genera el .docx vía backend. */
+  exportarDocx(): void {
+    const id = this.acta()?.id;
+    if (id) {
+      this.facade.exportarActa(id);
+    }
+  }
+
   // ── Navegación ───────────────────────────────────────────────────────────
   volver(): void {
     this.router.navigate(['/app/inventario/actas']);


### PR DESCRIPTION
- getActaById usa GET /legalization/actas/{id} (antes traia la lista size:100 y .find -> se rompia con >100 actas)
- exportarActa: POST /legalization/actas/{id}/exportar en service + facade + boton 'Exportar .docx' en el detalle

Alinea el frontend con endpoints que el backend ya exponia.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
