### PR TITLE
Feat/restaurante observaciones pedido

### DIFF
--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
@@ -164,10 +164,17 @@
             <h5 class="category-title">Comidas</h5>
             <ul class="summary-list">
               @for (item of comidasPedido(); track item.productoId) {
-                <li>
-                  <span class="qty">{{ item.cantidad }}x</span>
-                  <span class="name">{{ item.nombreProducto }}</span>
-                  <span class="price">{{ (item.cantidad * item.precioUnitario) | currencyCop }}</span>
+                <li class="summary-item-container">
+                  <div class="summary-item-main">
+                    <span class="qty">{{ item.cantidad }}x</span>
+                    <span class="name">{{ item.nombreProducto }}</span>
+                    <span class="price">{{ (item.cantidad * item.precioUnitario) | currencyCop }}</span>
+                  </div>
+                  @if (item.observaciones) {
+                    <div class="summary-item-obs">
+                      {{ item.observaciones }}
+                    </div>
+                  }
                 </li>
               }
             </ul>
@@ -177,10 +184,17 @@
             <h5 class="category-title mt-3">Bebidas</h5>
             <ul class="summary-list">
               @for (item of bebidasPedido(); track item.productoId) {
-                <li>
-                  <span class="qty">{{ item.cantidad }}x</span>
-                  <span class="name">{{ item.nombreProducto }}</span>
-                  <span class="price">{{ (item.cantidad * item.precioUnitario) | currencyCop }}</span>
+                <li class="summary-item-container">
+                  <div class="summary-item-main">
+                    <span class="qty">{{ item.cantidad }}x</span>
+                    <span class="name">{{ item.nombreProducto }}</span>
+                    <span class="price">{{ (item.cantidad * item.precioUnitario) | currencyCop }}</span>
+                  </div>
+                  @if (item.observaciones) {
+                    <div class="summary-item-obs">
+                      {{ item.observaciones }}
+                    </div>
+                  }
                 </li>
               }
             </ul>

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
@@ -8,7 +8,14 @@
       <div class="item-row">
         <div class="item-details">
           <h4 class="name">{{ item.nombreProducto }}</h4>
-          <span class="category">{{ item.observaciones || 'Sin observaciones' }}</span>
+            <div class="obs-display">
+              <span class="category" [title]="item.observaciones || 'Sin observaciones'">{{ item.observaciones || 'Sin observaciones' }}</span>
+              @if (!esPedidoSoloLectura()) {
+                <button class="btn-edit-obs" (click)="iniciarEdicionObservacion(i, item.observaciones || '')" title="Agregar/Editar observaciones">
+                  <lucide-icon name="pencil" [size]="14"></lucide-icon>
+                </button>
+              }
+            </div>
           
           <div class="quantity-controls">
             @if (!esPedidoSoloLectura()) {
@@ -194,6 +201,31 @@
       <div class="modal-actions">
         <restaurant-button variant="ghost" (click)="showConfirmModal.set(false)">Revisar de nuevo</restaurant-button>
         <restaurant-button variant="primary" (click)="ejecutarConfirmacion()">Sí, enviar pedido</restaurant-button>
+      </div>
+    </section>
+  </div>
+}
+
+@if (editIndex() !== null) {
+  <div class="custom-modal-backdrop" (click)="cancelarEdicionObservacion()">
+    <section class="custom-modal-dialog" (click)="$event.stopPropagation()">
+      <strong class="modal-title">Observaciones del Producto</strong>
+      <p class="modal-message">Escribe las indicaciones específicas para este plato.</p>
+      
+      <div class="obs-textarea-container">
+        <textarea 
+          [ngModel]="tempObservacion()" 
+          (ngModelChange)="tempObservacion.set($event)"
+          placeholder="Ej: Sin cebolla, bien asado..."
+          rows="4"
+          class="obs-textarea-input"
+          autofocus
+        ></textarea>
+      </div>
+
+      <div class="modal-actions">
+        <restaurant-button variant="ghost" (click)="cancelarEdicionObservacion()">Cancelar</restaurant-button>
+        <restaurant-button variant="primary" (click)="guardarObservacion()">Guardar</restaurant-button>
       </div>
     </section>
   </div>

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
@@ -439,7 +439,27 @@
 
       li {
         display: flex;
+        flex-direction: column;
+        gap: 2px;
         font-size: var(--font-size-sm);
+        
+        .summary-item-main {
+          display: flex;
+          width: 100%;
+        }
+
+        .summary-item-obs {
+          font-size: var(--font-size-xs);
+          color: var(--color-text-secondary);
+          background-color: var(--color-surface-primary);
+          border: 1px dashed var(--color-border);
+          padding: 2px 6px;
+          border-radius: var(--radius-sm);
+          font-style: italic;
+          margin-left: 30px;
+          display: inline-block;
+          width: fit-content;
+        }
         
         .qty {
           font-weight: var(--font-weight-semibold);
@@ -507,7 +527,7 @@
       border-radius: var(--radius-md);
       font-family: var(--font-family-base);
       font-size: var(--font-size-md);
-      background-color: var(--color-background-soft, #f8fafc);
+      background-color: var(--color-surface-primary);
       color: var(--color-text-primary);
       box-sizing: border-box;
       resize: none;

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
@@ -69,7 +69,40 @@
         font-family: var(--font-family-base);
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
+        margin-bottom: 0;
+        
+        /* Truncate text */
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 130px;
+        display: inline-block;
+      }
+
+      .obs-display {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
         margin-bottom: var(--space-2);
+        max-width: 100%;
+
+        .btn-edit-obs {
+          background: none;
+          border: none;
+          color: var(--color-text-tertiary);
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 2px;
+          border-radius: var(--radius-sm);
+          transition: background 0.2s, color 0.2s;
+
+          &:hover {
+            color: var(--color-primario);
+            background-color: var(--color-background-soft);
+          }
+        }
       }
 
       .quantity-controls {
@@ -460,6 +493,38 @@
 
   .text-error {
     color: var(--color-error);
+  }
+
+  .obs-textarea-container {
+    margin-bottom: var(--space-5);
+    margin-top: var(--space-4);
+
+    .obs-textarea-input {
+      width: 100%;
+      min-height: 120px;
+      padding: var(--space-4);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      font-family: var(--font-family-base);
+      font-size: var(--font-size-md);
+      background-color: var(--color-background-soft, #f8fafc);
+      color: var(--color-text-primary);
+      box-sizing: border-box;
+      resize: none;
+      line-height: 1.5;
+      transition: border-color 0.2s, box-shadow 0.2s;
+
+      &:focus {
+        outline: none;
+        border-color: var(--color-primario);
+        box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15); /* Soft green glow */
+      }
+      
+      &::placeholder {
+        color: var(--color-text-tertiary);
+        font-style: italic;
+      }
+    }
   }
 
   .cancel-reason-container {

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.ts
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.ts
@@ -42,6 +42,9 @@ export class PedidosCartComponent {
   showAnularBackendModal = signal(false);
   showEmptyCartModal = signal(false);
   motivoAnulacion = signal('');
+  
+  editIndex = signal<number | null>(null);
+  tempObservacion = signal<string>('');
 
   esPedidoSoloLectura = computed(() => {
     const p = this.pedidoActivo();
@@ -62,6 +65,23 @@ export class PedidosCartComponent {
 
   eliminarItem(index: number) {
     this.facade.eliminarProductoDelPedido(index);
+  }
+
+  iniciarEdicionObservacion(index: number, currentObs: string) {
+    this.editIndex.set(index);
+    this.tempObservacion.set(currentObs || '');
+  }
+
+  guardarObservacion() {
+    const index = this.editIndex();
+    if (index !== null) {
+      this.facade.actualizarObservacionesProducto(index, this.tempObservacion().trim());
+      this.editIndex.set(null);
+    }
+  }
+
+  cancelarEdicionObservacion() {
+    this.editIndex.set(null);
   }
 
   iniciarCancelacion() {

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-categories/pedidos-categories.component.scss
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-categories/pedidos-categories.component.scss
@@ -13,7 +13,8 @@
   display: flex;
   gap: var(--space-4);
   overflow-x: auto;
-  padding-bottom: var(--space-2); 
+  padding-top: 4px; /* Previene que el translateY(-2px) corte el borde superior */
+  padding-bottom: var(--space-2);
   
   &::-webkit-scrollbar {
     height: 6px;

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-categories/pedidos-categories.component.ts
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-categories/pedidos-categories.component.ts
@@ -16,8 +16,8 @@ export class PedidosCategoriesComponent {
 
   categories = [
     { id: 'all', name: 'Todo', icon: 'layout-grid' },
-    { id: 'entrada', name: 'Entradas', icon: 'salad' },
-    { id: 'plato_fuerte', name: 'Plato Fuerte', icon: 'beef' },
+    { id: 'entrada', name: 'Entradas', icon: 'clipboard-list' },
+    { id: 'plato_fuerte', name: 'Plato Fuerte', icon: 'utensils' },
     { id: 'postre', name: 'Postres', icon: 'cake' },
     { id: 'bebidas', name: 'Bebidas', icon: 'coffee' },
   ];

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
@@ -182,7 +182,25 @@ export class RestauranteFacade {
           })
         }));
         
-        pedidosMapeados.sort((a, b) => new Date(b.fechaCreacion).getTime() - new Date(a.fechaCreacion).getTime());
+        const ESTADO_PESO: Record<string, number> = {
+          'LISTO_PARA_SERVIR': 1,
+          'EN_PREPARACION': 2,
+          'ENVIADO_COCINA': 3,
+          'BORRADOR': 4,
+          'ENTREGADO': 5,
+          'FACTURADO': 6,
+          'CANCELADO': 7
+        };
+
+        pedidosMapeados.sort((a, b) => {
+          const pesoA = ESTADO_PESO[a.estado] || 99;
+          const pesoB = ESTADO_PESO[b.estado] || 99;
+          if (pesoA !== pesoB) {
+            return pesoA - pesoB;
+          }
+          return new Date(b.fechaCreacion).getTime() - new Date(a.fechaCreacion).getTime();
+        });
+
         this._ordenesHistorial.set(pedidosMapeados);
       },
       error: (err) => {

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
@@ -8,7 +8,7 @@ import {
 } from '../models/restaurante.model';
 import { RestauranteService } from './restaurante.service';
 import { AuthService } from './auth.service';
-import { catchError, of, Observable, forkJoin } from 'rxjs';
+import { catchError, of, Observable, forkJoin, switchMap } from 'rxjs';
 
 export interface ItemCarrito {
   productoId: string;
@@ -134,13 +134,6 @@ export class RestauranteFacade {
   }
 
   private cargarEstadoLocalNoMesas(): void {
-    const ordenesGuardadas = localStorage.getItem('gastro_ordenes');
-    const turnoGuardado = localStorage.getItem('gastro_turno_caja');
-
-    if (ordenesGuardadas) {
-      this._ordenesHistorial.set(JSON.parse(ordenesGuardadas));
-    }
-
     this.restauranteService.obtenerSesionActiva().pipe(
       catchError((err) => {
         if (err.status !== 404) {
@@ -149,6 +142,53 @@ export class RestauranteFacade {
         return of(null);
       })
     ).subscribe((sesion) => this._turnoCaja.set(sesion));
+  }
+
+  cargarMisOrdenes(): void {
+    this.restauranteService.misPedidos().pipe(
+      switchMap(pedidosResumen => {
+        if (!pedidosResumen || pedidosResumen.length === 0) {
+          return of([]);
+        }
+        const requests = pedidosResumen.map(p => this.restauranteService.obtenerPedidoPorId(p.id).pipe(
+          catchError(err => {
+            console.error(`[RestauranteFacade] Error al cargar detalles del pedido ${p.id}`, err);
+            return of(null);
+          })
+        ));
+        return forkJoin(requests);
+      })
+    ).subscribe({
+      next: (pedidosFull) => {
+        const validPedidos = pedidosFull.filter(p => p !== null);
+        const pedidosMapeados: PedidoCarrito[] = validPedidos.map(p => ({
+          id: p!.id,
+          mesaId: p!.mesaId,
+          meseroId: p!.meseroId,
+          numeroComensales: p!.numeroComensales,
+          estado: p!.estado,
+          fechaCreacion: p!.fechaCreacion,
+          subtotal: p!.subtotal,
+          detalles: p!.detalles.map(d => {
+            const productoCat = this._productosMenu().find(pm => pm.id === d.productoId)?.category || 'COMIDA';
+            return {
+              productoId: d.productoId,
+              nombreProducto: d.nombreProducto,
+              cantidad: d.cantidad,
+              precioUnitario: d.precioUnitario,
+              categoria: productoCat,
+              observaciones: d.observaciones || undefined
+            };
+          })
+        }));
+        
+        pedidosMapeados.sort((a, b) => new Date(b.fechaCreacion).getTime() - new Date(a.fechaCreacion).getTime());
+        this._ordenesHistorial.set(pedidosMapeados);
+      },
+      error: (err) => {
+        console.error('[RestauranteFacade] Error al cargar mis órdenes:', err);
+      }
+    });
   }
 
   private guardarEstadoLocal(): void {

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
@@ -415,6 +415,18 @@ export class RestauranteFacade {
     });
   }
 
+  actualizarObservacionesProducto(index: number, observaciones: string) {
+    this._pedidoActivo.update(pedido => {
+      if (!pedido) return null;
+      if (pedido.estado !== 'BORRADOR') return pedido;
+
+      const detalles = [...pedido.detalles];
+      detalles[index] = { ...detalles[index], observaciones };
+
+      return { ...pedido, detalles };
+    });
+  }
+
   eliminarProductoDelPedido(index: number) {
     this._pedidoActivo.update(pedido => {
       if (!pedido) return null;

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
@@ -359,14 +359,17 @@ export class RestauranteFacade {
                 estado: pedidoFull.estado,
                 fechaCreacion: pedidoFull.fechaCreacion,
                 subtotal: pedidoFull.subtotal,
-                detalles: pedidoFull.detalles.map(d => ({
-                  productoId: d.productoId,
-                  nombreProducto: d.nombreProducto,
-                  cantidad: d.cantidad,
-                  precioUnitario: d.precioUnitario,
-                  categoria: 'COMIDA', // Valor por defecto visual
-                  observaciones: d.observaciones || undefined
-                }))
+                detalles: pedidoFull.detalles.map(d => {
+                  const prod = this._productosMenu().find(m => m.id === d.productoId || m.name === d.nombreProducto);
+                  return {
+                    productoId: d.productoId,
+                    nombreProducto: d.nombreProducto,
+                    cantidad: d.cantidad,
+                    precioUnitario: d.precioUnitario,
+                    categoria: prod ? prod.category : 'COMIDA', // Mapeo dinámico desde el catálogo
+                    observaciones: d.observaciones || undefined
+                  };
+                })
               };
               this._pedidoActivo.set(pedidoParaCarrito);
               observer.next(true);

--- a/libs/restaurante/restaurante/src/lib/pages/historial-estudiante-page/historial-estudiante-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/historial-estudiante-page/historial-estudiante-page.component.html
@@ -6,7 +6,7 @@
     </restaurant-button>
   </div>
 
-  <restaurant-page-header title="Mis Pedidos (Estudiante)"
+  <restaurant-page-header title="Mis Pedidos (Aprendiz)"
     subtitle="Historial y estado actual de los pedidos que he tomado.">
   </restaurant-page-header>
 
@@ -18,8 +18,7 @@
     </div>
   </div>
 
-  <div class="historial-grid">
-    @for (orden of misOrdenes(); track orden.id) {
+  <ng-template #ordenCardTemplate let-orden="orden">
     <restaurant-card class="ticket-card">
       <div class="ticket-card__header" style="flex-wrap: wrap; gap: var(--space-2);">
         <div class="ticket-card__title">
@@ -94,11 +93,86 @@
       </div>
       }
     </restaurant-card>
-    } @empty {
-    <div class="empty-state">
-      <lucide-icon name="user" [size]="48" color="var(--color-text-tertiary)"></lucide-icon>
-      <p>Aún no has registrado ningún pedido.</p>
-    </div>
+  </ng-template>
+
+  <div class="mesas-filters" style="display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 1.5rem; margin-top: 1rem;">
+    <restaurant-button [variant]="filtroEstado() === 'TODAS' ? 'primary' : 'outline'" (click)="filtroEstado.set('TODAS')">
+      Todas
+    </restaurant-button>
+    <restaurant-button [variant]="filtroEstado() === 'LISTO_PARA_SERVIR' ? 'primary' : 'outline'" (click)="filtroEstado.set('LISTO_PARA_SERVIR')">
+      Listo para Servir
+    </restaurant-button>
+    <restaurant-button [variant]="filtroEstado() === 'EN_PREPARACION' ? 'primary' : 'outline'" (click)="filtroEstado.set('EN_PREPARACION')">
+      En Preparación
+    </restaurant-button>
+    <restaurant-button [variant]="filtroEstado() === 'ENVIADO_COCINA' ? 'primary' : 'outline'" (click)="filtroEstado.set('ENVIADO_COCINA')">
+      Enviado a Cocina
+    </restaurant-button>
+    <restaurant-button [variant]="filtroEstado() === 'OTRAS' ? 'primary' : 'outline'" (click)="filtroEstado.set('OTRAS')">
+      Historial
+    </restaurant-button>
+  </div>
+
+  <div class="mesas-page__content" style="margin-top: var(--space-4);">
+    @if ((filtroEstado() === 'TODAS' || filtroEstado() === 'LISTO_PARA_SERVIR') && ordenesListo().length > 0) {
+      <div class="mesas-group mb-4">
+        <h3 class="mesas-group__title" style="margin-bottom: 1rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem; color: #d97706;">
+          <lucide-icon name="bell-ring" [size]="20"></lucide-icon> Listo Para Servir
+        </h3>
+        <div class="historial-grid" style="margin-top: 0;">
+          @for (orden of ordenesListo(); track orden.id) {
+            <ng-container *ngTemplateOutlet="ordenCardTemplate; context: { orden: orden }"></ng-container>
+          }
+        </div>
+      </div>
+    }
+
+    @if ((filtroEstado() === 'TODAS' || filtroEstado() === 'EN_PREPARACION') && ordenesPreparacion().length > 0) {
+      <div class="mesas-group mb-4">
+        <h3 class="mesas-group__title text-warning" style="margin-bottom: 1rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem;">
+          <lucide-icon name="chef-hat" [size]="20"></lucide-icon> En Preparación
+        </h3>
+        <div class="historial-grid" style="margin-top: 0;">
+          @for (orden of ordenesPreparacion(); track orden.id) {
+            <ng-container *ngTemplateOutlet="ordenCardTemplate; context: { orden: orden }"></ng-container>
+          }
+        </div>
+      </div>
+    }
+
+    @if ((filtroEstado() === 'TODAS' || filtroEstado() === 'ENVIADO_COCINA') && ordenesEnviado().length > 0) {
+      <div class="mesas-group mb-4">
+        <h3 class="mesas-group__title text-primary" style="margin-bottom: 1rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem; color: #3b82f6;">
+          <lucide-icon name="send" [size]="20"></lucide-icon> Enviado a Cocina
+        </h3>
+        <div class="historial-grid" style="margin-top: 0;">
+          @for (orden of ordenesEnviado(); track orden.id) {
+            <ng-container *ngTemplateOutlet="ordenCardTemplate; context: { orden: orden }"></ng-container>
+          }
+        </div>
+      </div>
+    }
+
+
+
+    @if ((filtroEstado() === 'TODAS' || filtroEstado() === 'OTRAS') && ordenesOtras().length > 0) {
+      <div class="mesas-group mb-4">
+        <h3 class="mesas-group__title text-success" style="margin-bottom: 1rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem; color: #10b981;">
+          <lucide-icon name="check-circle" [size]="20"></lucide-icon> Historial
+        </h3>
+        <div class="historial-grid" style="margin-top: 0;">
+          @for (orden of ordenesOtras(); track orden.id) {
+            <ng-container *ngTemplateOutlet="ordenCardTemplate; context: { orden: orden }"></ng-container>
+          }
+        </div>
+      </div>
+    }
+
+    @if (misOrdenes().length === 0) {
+      <div class="empty-state">
+        <lucide-icon name="user" [size]="48" color="var(--color-text-tertiary)"></lucide-icon>
+        <p>Aún no has registrado ningún pedido.</p>
+      </div>
     }
   </div>
 </div>

--- a/libs/restaurante/restaurante/src/lib/pages/historial-estudiante-page/historial-estudiante-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/historial-estudiante-page/historial-estudiante-page.component.html
@@ -29,7 +29,7 @@
           </h3>
         </div>
         @if (orden.estado) {
-        <restaurant-status-badge [label]="orden.estado"
+        <restaurant-status-badge [label]="formatearEstado(orden.estado)"
           [variant]="getBadgeType(orden.estado)"></restaurant-status-badge>
         }
       </div>
@@ -37,11 +37,11 @@
       <div class="ticket-card__body">
         <div class="ticket-info-row">
           <span class="ticket-label">Mesa:</span>
-          <span class="ticket-value">Mesa {{ orden.mesaId }}</span>
+          <span class="ticket-value">{{ obtenerNombreMesa(orden.mesaId) }}</span>
         </div>
         <div class="ticket-info-row">
           <span class="ticket-label">Fecha:</span>
-          <span class="ticket-value">{{ orden.fechaCreacion | date:'shortTime' }}</span>
+          <span class="ticket-value">{{ orden.fechaCreacion | date:'d/MM/yyyy' }}</span>
         </div>
 
           <div class="ticket-items" *ngIf="orden.detalles && orden.detalles.length > 0">

--- a/libs/restaurante/restaurante/src/lib/pages/historial-estudiante-page/historial-estudiante-page.component.ts
+++ b/libs/restaurante/restaurante/src/lib/pages/historial-estudiante-page/historial-estudiante-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, computed, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, computed, signal, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
@@ -31,10 +31,14 @@ import { CurrencyCopPipe } from '@restaurant/shared/util';
   styleUrls: ['../historial-instructor-page/historial-instructor-page.component.scss'], // Estilos compartidos
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HistorialEstudiantePageComponent {
+export class HistorialEstudiantePageComponent implements OnInit {
   private facade = inject(RestauranteFacade);
 
   public terminoBusqueda = signal<string>('');
+
+  ngOnInit() {
+    this.facade.cargarMisOrdenes();
+  }
 
   // Prototipo: mostramos todos los pedidos pero en el futuro aquí se filtrará:
   public todasMisOrdenes = this.facade.ordenesHistorial;
@@ -59,6 +63,16 @@ export class HistorialEstudiantePageComponent {
       case 'BORRADOR': return 'info';
       default: return 'info';
     }
+  }
+
+  formatearEstado(estado: string): string {
+    if (!estado) return '';
+    return estado.replace(/_/g, ' ');
+  }
+
+  obtenerNombreMesa(mesaId: string): string {
+    const mesa = this.facade.mesas().find(m => m.id === mesaId);
+    return mesa ? mesa.nombre : 'Mesa ' + mesaId.substring(0, 4);
   }
 
   marcarEntregado(pedidoId: string): void {

--- a/libs/restaurante/restaurante/src/lib/pages/historial-estudiante-page/historial-estudiante-page.component.ts
+++ b/libs/restaurante/restaurante/src/lib/pages/historial-estudiante-page/historial-estudiante-page.component.ts
@@ -35,6 +35,7 @@ export class HistorialEstudiantePageComponent implements OnInit {
   private facade = inject(RestauranteFacade);
 
   public terminoBusqueda = signal<string>('');
+  public filtroEstado = signal<string>('TODAS');
 
   ngOnInit() {
     this.facade.cargarMisOrdenes();
@@ -53,6 +54,12 @@ export class HistorialEstudiantePageComponent implements OnInit {
 
     return ordenes;
   });
+
+  public ordenesListo = computed(() => this.misOrdenes().filter(o => o.estado === 'LISTO_PARA_SERVIR'));
+  public ordenesPreparacion = computed(() => this.misOrdenes().filter(o => o.estado === 'EN_PREPARACION'));
+  public ordenesEnviado = computed(() => this.misOrdenes().filter(o => o.estado === 'ENVIADO_COCINA'));
+  public ordenesBorrador = computed(() => this.misOrdenes().filter(o => o.estado === 'BORRADOR'));
+  public ordenesOtras = computed(() => this.misOrdenes().filter(o => ['ENTREGADO', 'FACTURADO', 'CANCELADO'].includes(o.estado)));
 
   getBadgeType(estado: string): 'info' | 'success' | 'warning' | 'danger' {
     switch (estado) {

--- a/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.html
@@ -44,53 +44,127 @@
     </div>
   </div>
 
-  <div class="historial-grid">
-    @for (orden of ordenes(); track orden.id) {
-      <restaurant-card class="ticket-card">
-        <div class="ticket-card__header">
-          <div class="ticket-card__title">
-            <lucide-icon name="clipboard-list" [size]="20"></lucide-icon>
-            <h3>Pedido {{ orden.id ? orden.id.substring(0, 8) : 'N/A' }}</h3>
-          </div>
-          @if (orden.estado) {
-            <restaurant-status-badge [label]="formatearEstado(orden.estado)" [variant]="getBadgeType(orden.estado)"></restaurant-status-badge>
+  <ng-template #ordenCardTemplate let-orden="orden">
+    <restaurant-card class="ticket-card">
+      <div class="ticket-card__header">
+        <div class="ticket-card__title">
+          <lucide-icon name="clipboard-list" [size]="20"></lucide-icon>
+          <h3>Pedido {{ orden.id ? orden.id.substring(0, 8) : 'N/A' }}</h3>
+        </div>
+        @if (orden.estado) {
+          <restaurant-status-badge [label]="formatearEstado(orden.estado)" [variant]="getBadgeType(orden.estado)"></restaurant-status-badge>
+        }
+      </div>
+      
+      <div class="ticket-card__body">
+        <div class="ticket-info-row">
+          <span class="ticket-label">Mesa:</span>
+          <span class="ticket-value">{{ obtenerNombreMesa(orden.mesaId) }}</span>
+        </div>
+        <div class="ticket-info-row">
+          <span class="ticket-label">Mesero:</span>
+          <span class="ticket-value">{{ acortarMesero(orden.meseroId) }}</span>
+        </div>
+        <div class="ticket-info-row">
+          <span class="ticket-label">Fecha:</span>
+          <span class="ticket-value">{{ orden.fechaCreacion | date:'d/MM/yyyy' }}</span>
+        </div>
+        
+        <div class="ticket-items" *ngIf="orden.detalles && orden.detalles.length > 0">
+          <h4>Productos ({{ orden.detalles.length }})</h4>
+          <ul>
+            @for (item of orden.detalles; track item.productoId) {
+              <li>
+                <span class="item-qty">{{ item.cantidad }}x</span>
+                <span class="item-name">{{ item.nombreProducto }}</span>
+                <span class="item-price">{{ item.precioUnitario | currency }}</span>
+              </li>
+            }
+          </ul>
+        </div>
+      </div>
+      
+      <div class="ticket-card__footer">
+        <span class="ticket-total-label">Total</span>
+        <span class="ticket-total-value">{{ orden.subtotal | currency }}</span>
+      </div>
+    </restaurant-card>
+  </ng-template>
+
+  <div class="mesas-filters" style="display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 1.5rem; margin-top: 1rem;">
+    <restaurant-button [variant]="filtroEstado() === 'TODAS' ? 'primary' : 'outline'" (click)="filtroEstado.set('TODAS')">
+      Todas
+    </restaurant-button>
+    <restaurant-button [variant]="filtroEstado() === 'LISTO_PARA_SERVIR' ? 'primary' : 'outline'" (click)="filtroEstado.set('LISTO_PARA_SERVIR')">
+      Listo para Servir
+    </restaurant-button>
+    <restaurant-button [variant]="filtroEstado() === 'EN_PREPARACION' ? 'primary' : 'outline'" (click)="filtroEstado.set('EN_PREPARACION')">
+      En Preparación
+    </restaurant-button>
+    <restaurant-button [variant]="filtroEstado() === 'ENVIADO_COCINA' ? 'primary' : 'outline'" (click)="filtroEstado.set('ENVIADO_COCINA')">
+      Enviado a Cocina
+    </restaurant-button>
+    <restaurant-button [variant]="filtroEstado() === 'OTRAS' ? 'primary' : 'outline'" (click)="filtroEstado.set('OTRAS')">
+      Historial
+    </restaurant-button>
+  </div>
+
+  <div class="mesas-page__content" style="margin-top: var(--space-4);">
+    @if ((filtroEstado() === 'TODAS' || filtroEstado() === 'LISTO_PARA_SERVIR') && ordenesListo().length > 0) {
+      <div class="mesas-group mb-4">
+        <h3 class="mesas-group__title" style="margin-bottom: 1rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem; color: #d97706;">
+          <lucide-icon name="bell-ring" [size]="20"></lucide-icon> Listo Para Servir
+        </h3>
+        <div class="historial-grid" style="margin-top: 0;">
+          @for (orden of ordenesListo(); track orden.id) {
+            <ng-container *ngTemplateOutlet="ordenCardTemplate; context: { orden: orden }"></ng-container>
           }
         </div>
-        
-        <div class="ticket-card__body">
-          <div class="ticket-info-row">
-            <span class="ticket-label">Mesa:</span>
-            <span class="ticket-value">{{ obtenerNombreMesa(orden.mesaId) }}</span>
-          </div>
-          <div class="ticket-info-row">
-            <span class="ticket-label">Mesero:</span>
-            <span class="ticket-value">{{ acortarMesero(orden.meseroId) }}</span>
-          </div>
-          <div class="ticket-info-row">
-            <span class="ticket-label">Fecha:</span>
-            <span class="ticket-value">{{ orden.fechaCreacion | date:'d/MM/yyyy' }}</span>
-          </div>
-          
-          <div class="ticket-items" *ngIf="orden.detalles && orden.detalles.length > 0">
-            <h4>Productos ({{ orden.detalles.length }})</h4>
-            <ul>
-              @for (item of orden.detalles; track item.productoId) {
-                <li>
-                  <span class="item-qty">{{ item.cantidad }}x</span>
-                  <span class="item-name">{{ item.nombreProducto }}</span>
-                  <span class="item-price">{{ item.precioUnitario | currency }}</span>
-                </li>
-              }
-            </ul>
-          </div>
+      </div>
+    }
+
+    @if ((filtroEstado() === 'TODAS' || filtroEstado() === 'EN_PREPARACION') && ordenesPreparacion().length > 0) {
+      <div class="mesas-group mb-4">
+        <h3 class="mesas-group__title text-warning" style="margin-bottom: 1rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem;">
+          <lucide-icon name="chef-hat" [size]="20"></lucide-icon> En Preparación
+        </h3>
+        <div class="historial-grid" style="margin-top: 0;">
+          @for (orden of ordenesPreparacion(); track orden.id) {
+            <ng-container *ngTemplateOutlet="ordenCardTemplate; context: { orden: orden }"></ng-container>
+          }
         </div>
-        
-        <div class="ticket-card__footer">
-          <span class="ticket-total-label">Total</span>
-          <span class="ticket-total-value">{{ orden.subtotal | currency }}</span>
+      </div>
+    }
+
+    @if ((filtroEstado() === 'TODAS' || filtroEstado() === 'ENVIADO_COCINA') && ordenesEnviado().length > 0) {
+      <div class="mesas-group mb-4">
+        <h3 class="mesas-group__title text-primary" style="margin-bottom: 1rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem; color: #3b82f6;">
+          <lucide-icon name="send" [size]="20"></lucide-icon> Enviado a Cocina
+        </h3>
+        <div class="historial-grid" style="margin-top: 0;">
+          @for (orden of ordenesEnviado(); track orden.id) {
+            <ng-container *ngTemplateOutlet="ordenCardTemplate; context: { orden: orden }"></ng-container>
+          }
         </div>
-      </restaurant-card>
-    } @empty {
+      </div>
+    }
+
+
+
+    @if ((filtroEstado() === 'TODAS' || filtroEstado() === 'OTRAS') && ordenesOtras().length > 0) {
+      <div class="mesas-group mb-4">
+        <h3 class="mesas-group__title text-success" style="margin-bottom: 1rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem; color: #10b981;">
+          <lucide-icon name="check-circle" [size]="20"></lucide-icon> Historial
+        </h3>
+        <div class="historial-grid" style="margin-top: 0;">
+          @for (orden of ordenesOtras(); track orden.id) {
+            <ng-container *ngTemplateOutlet="ordenCardTemplate; context: { orden: orden }"></ng-container>
+          }
+        </div>
+      </div>
+    }
+
+    @if (ordenes().length === 0) {
       <div class="empty-state">
         <lucide-icon name="clipboard-list" [size]="48" color="var(--color-text-tertiary)"></lucide-icon>
         <p>No hay pedidos registrados en este turno.</p>

--- a/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.html
@@ -53,22 +53,22 @@
             <h3>Pedido {{ orden.id ? orden.id.substring(0, 8) : 'N/A' }}</h3>
           </div>
           @if (orden.estado) {
-            <restaurant-status-badge [label]="orden.estado" [variant]="getBadgeType(orden.estado)"></restaurant-status-badge>
+            <restaurant-status-badge [label]="formatearEstado(orden.estado)" [variant]="getBadgeType(orden.estado)"></restaurant-status-badge>
           }
         </div>
         
         <div class="ticket-card__body">
           <div class="ticket-info-row">
             <span class="ticket-label">Mesa:</span>
-            <span class="ticket-value">Mesa {{ orden.mesaId }}</span>
+            <span class="ticket-value">{{ obtenerNombreMesa(orden.mesaId) }}</span>
           </div>
           <div class="ticket-info-row">
             <span class="ticket-label">Mesero:</span>
-            <span class="ticket-value">{{ orden.meseroId }}</span>
+            <span class="ticket-value">{{ acortarMesero(orden.meseroId) }}</span>
           </div>
           <div class="ticket-info-row">
             <span class="ticket-label">Fecha:</span>
-            <span class="ticket-value">{{ orden.fechaCreacion | date:'medium' }}</span>
+            <span class="ticket-value">{{ orden.fechaCreacion | date:'d/MM/yyyy' }}</span>
           </div>
           
           <div class="ticket-items" *ngIf="orden.detalles && orden.detalles.length > 0">

--- a/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.scss
+++ b/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.scss
@@ -181,7 +181,8 @@
 
   .ticket-info-row {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
+    gap: var(--space-2);
     font-size: var(--font-size-sm);
     
     .ticket-label {

--- a/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.ts
+++ b/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.ts
@@ -34,6 +34,7 @@ export class HistorialInstructorPageComponent {
   public todasLasOrdenes = this.facade.ordenesHistorial;
   public meseroFiltrado = signal<string>('');
   public terminoBusqueda = signal<string>('');
+  public filtroEstado = signal<string>('TODAS');
   public isDropdownOpen = signal<boolean>(false);
 
   public meserosUnicos = computed(() => {
@@ -57,6 +58,12 @@ export class HistorialInstructorPageComponent {
 
     return ordenes;
   });
+
+  public ordenesListo = computed(() => this.ordenes().filter(o => o.estado === 'LISTO_PARA_SERVIR'));
+  public ordenesPreparacion = computed(() => this.ordenes().filter(o => o.estado === 'EN_PREPARACION'));
+  public ordenesEnviado = computed(() => this.ordenes().filter(o => o.estado === 'ENVIADO_COCINA'));
+  public ordenesBorrador = computed(() => this.ordenes().filter(o => o.estado === 'BORRADOR'));
+  public ordenesOtras = computed(() => this.ordenes().filter(o => ['ENTREGADO', 'FACTURADO', 'CANCELADO'].includes(o.estado)));
 
   toggleDropdown() {
     this.isDropdownOpen.update(v => !v);

--- a/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.ts
+++ b/libs/restaurante/restaurante/src/lib/pages/historial-instructor-page/historial-instructor-page.component.ts
@@ -72,8 +72,24 @@ export class HistorialInstructorPageComponent {
       case 'ENTREGADO': return 'success';
       case 'FACTURADO': return 'success';
       case 'EN_PREPARACION': return 'warning';
+      case 'LISTO_PARA_SERVIR': return 'warning';
       case 'BORRADOR': return 'info';
       default: return 'info';
     }
+  }
+
+  formatearEstado(estado: string): string {
+    if (!estado) return '';
+    return estado.replace(/_/g, ' ');
+  }
+
+  obtenerNombreMesa(mesaId: string): string {
+    const mesa = this.facade.mesas().find(m => m.id === mesaId);
+    return mesa ? mesa.nombre : 'Mesa ' + mesaId.substring(0, 4);
+  }
+
+  acortarMesero(meseroId: string): string {
+    if (!meseroId) return 'N/A';
+    return meseroId.length > 8 ? 'Mesero ' + meseroId.substring(meseroId.length - 8) : meseroId;
   }
 }

--- a/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.html
@@ -567,10 +567,17 @@
           <h5 class="category-title">Comidas</h5>
           <ul class="summary-list">
             @for (item of comidasPedidoCuenta(); track item.productoId) {
-              <li>
-                <span class="qty">{{ item.cantidad }}x</span>
-                <span class="name">{{ item.nombreProducto }}</span>
-                <span class="price">{{ (item.cantidad * item.precioUnitario) | currencyCop }}</span>
+              <li class="summary-item-container">
+                <div class="summary-item-main">
+                  <span class="qty">{{ item.cantidad }}x</span>
+                  <span class="name">{{ item.nombreProducto }}</span>
+                  <span class="price">{{ (item.cantidad * item.precioUnitario) | currencyCop }}</span>
+                </div>
+                @if (item.observaciones) {
+                  <div class="summary-item-obs">
+                    {{ item.observaciones }}
+                  </div>
+                }
               </li>
             }
           </ul>
@@ -580,10 +587,17 @@
           <h5 class="category-title mt-3">Bebidas</h5>
           <ul class="summary-list">
             @for (item of bebidasPedidoCuenta(); track item.productoId) {
-              <li>
-                <span class="qty">{{ item.cantidad }}x</span>
-                <span class="name">{{ item.nombreProducto }}</span>
-                <span class="price">{{ (item.cantidad * item.precioUnitario) | currencyCop }}</span>
+              <li class="summary-item-container">
+                <div class="summary-item-main">
+                  <span class="qty">{{ item.cantidad }}x</span>
+                  <span class="name">{{ item.nombreProducto }}</span>
+                  <span class="price">{{ (item.cantidad * item.precioUnitario) | currencyCop }}</span>
+                </div>
+                @if (item.observaciones) {
+                  <div class="summary-item-obs">
+                    {{ item.observaciones }}
+                  </div>
+                }
               </li>
             }
           </ul>

--- a/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.scss
+++ b/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.scss
@@ -97,6 +97,7 @@
       font-family: inherit;
       font-size: var(--font-size-sm);
       background-color: var(--color-surface-primary);
+      color: var(--color-text-primary);
       outline: none;
       transition: border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
 
@@ -591,6 +592,8 @@
       border: 1px solid var(--color-border);
       border-radius: var(--radius-md);
       font-family: inherit;
+      background-color: var(--color-surface-primary);
+      color: var(--color-text-primary);
       outline: none;
 
       &:focus {
@@ -667,6 +670,8 @@
         border-right: 1px solid var(--color-border);
         text-align: center;
         -moz-appearance: textfield;
+        background-color: var(--color-surface-primary);
+        color: var(--color-text-primary);
         
         &::-webkit-outer-spin-button,
         &::-webkit-inner-spin-button {
@@ -803,6 +808,7 @@
         font-family: inherit;
         font-size: var(--font-size-sm);
         background-color: var(--color-surface-primary);
+        color: var(--color-text-primary);
         outline: none;
         transition: border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
 

--- a/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.scss
+++ b/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.scss
@@ -961,7 +961,27 @@
 
       li {
         display: flex;
+        flex-direction: column;
+        gap: 2px;
         font-size: var(--font-size-sm);
+        
+        .summary-item-main {
+          display: flex;
+          width: 100%;
+        }
+
+        .summary-item-obs {
+          font-size: var(--font-size-xs);
+          color: var(--color-text-secondary);
+          background-color: var(--color-surface-primary);
+          border: 1px dashed var(--color-border);
+          padding: 2px 6px;
+          border-radius: var(--radius-sm);
+          font-style: italic;
+          margin-left: 30px;
+          display: inline-block;
+          width: fit-content;
+        }
         
         .qty {
           font-weight: var(--font-weight-semibold);

--- a/libs/restaurante/restaurante/src/lib/pages/pedidos-hub-page/pedidos-hub-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/pedidos-hub-page/pedidos-hub-page.component.html
@@ -27,7 +27,7 @@
         <div class="hub-card__icon-wrapper student-icon">
           <lucide-icon name="user" [size]="48"></lucide-icon>
         </div>
-        <h3 class="hub-card__title">Mis Pedidos (Estudiante)</h3>
+        <h3 class="hub-card__title">Mis Pedidos (Aprendiz)</h3>
         <p class="hub-card__description">Revisa el historial de pedidos que has tomado durante tu turno actual.</p>
       </div>
     </restaurant-card>


### PR DESCRIPTION
## Descripción
Este Pull Request incluye mejoras en el módulo de Restaurante (libs/restaurante), enfocándose en pulir la experiencia de usuario en el historial de pedidos, corregir inconsistencias del modo oscuro y mejorar la visibilidad de las observaciones en comandas y facturación.
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ x] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [x ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ x] `nx affected:lint --base=develop` → 0 errores
- [x ] `nx affected:test --base=develop` → 0 fallos
- [ x] PR tiene menos de 400 líneas modificadas
- [x ] Un solo scope tocado
- [ x] Todo componente nuevo tiene su `.spec.ts`
- [ x] Sin `any` en TypeScript
- [x ] Sin estilos inline en templates
- [x ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
✨ Nuevas Características & Mejoras
Visualización de Observaciones por Plato: Ahora las especificaciones de cada ítem (ej. "sin cebolla", "poca salsa") se muestran de manera clara justo debajo de cada producto tanto en el modal de Enviar a Cocina (Toma de Pedidos) como en el modal de Detalle de la Cuenta (Checkout).
Cambio de Terminología: Se actualizó el título y las tarjetas de la interfaz de "Estudiante" a "Aprendiz" (Mis Pedidos (Aprendiz)).
Limpieza de Historial de Pedidos: Se eliminó la pestaña de filtros de "Borradores" en las vistas de Aprendiz e Instructor, dejando la interfaz enfocada únicamente en los pedidos en progreso e históricos reales.
🐛 Correcciones de Errores (Fixes)
Reparación del Modo Oscuro en Formularios: Se corrigió un fallo que provocaba que los campos de texto y áreas de texto (como en crear mesa, editar mesa, observaciones de platos y el buscador) mantuvieran un fondo blanco quemado. Ahora se adaptan correctamente a las variables de surface-primary del tema.
Agrupación de Categorías en "Ver Cuenta": Se corrigió un bug donde al cargar una orden para cobrar, todas las bebidas aparecían listadas bajo la sección "Comidas". Esto se solucionó haciendo que el Frontend cruce la información del pedido que envía el Backend con el catálogo local para inyectar dinámicamente la categoría correcta.
