### PR TITLE
test(inventario): E2E Playwright full-stack + alinear producto a solo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ BACKLOG_FRONTEND_ORGANIZADO.md
 .ai/domains/inventario.md
 .ai/prompts/vistas/
 .ai/prompts/conectar-vista-backend.md
+
+# Playwright E2E
+/test-results/
+/e2e/.report/
+/e2e/.auth/
+/playwright-report/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,48 @@
+# E2E full-stack — módulo Inventario (Playwright)
+
+Tests end-to-end que manejan la **UI real** (Angular) contra los **microservicios reales** en Docker.
+Cubren formularios, importación desde Excel, y todas las páginas del dominio inventario,
+en **camino feliz** y **camino malo**.
+
+## Requisitos (todo corriendo en local)
+
+| Servicio | Puerto | Cómo |
+|----------|--------|------|
+| Backend inventario | `:8081` | `docker compose up -d` en `ga-ms-inventario-1.1` |
+| Microservicio usuarios (login) | `:8087` | su propio Docker |
+| Frontend (dev server + proxy) | `:4200` | `npm start` (nx serve restaurant-app) |
+
+Credenciales de prueba (admin): `admin@sena.edu.co` / `admin123`.
+
+## Correr
+
+```bash
+npm run e2e            # toda la suite (headless)
+npm run e2e:ui         # modo interactivo
+npm run e2e:report     # ver el último reporte HTML
+npx playwright test e2e/inventario/bienes.spec.ts   # un archivo
+```
+
+## Estructura
+
+```
+e2e/
+├── auth.setup.ts            ← login real (camino feliz) + guarda la sesión para el resto
+├── auth/login.spec.ts       ← login inválido + rutas protegidas (camino malo)
+└── inventario/
+    ├── smoke.spec.ts            ← bienes carga + pega al backend
+    ├── pages-smoke.spec.ts      ← las 11 páginas cargan y consultan su endpoint (2xx)
+    ├── bienes.spec.ts           ← crear bien (feliz) + validación (malo)
+    ├── bienes-import.spec.ts    ← importar .xlsx (feliz) + rechazo sin codigoSena (malo)
+    ├── presupuesto.spec.ts      ← registrar presupuesto (feliz) + validación (malo)
+    └── alertas-config.spec.ts   ← documenta el GAP: umbrales no existe en backend (404)
+```
+
+## Notas
+
+- La sesión se obtiene UNA vez (`auth.setup.ts`) y se reusa via `storageState` (más rápido y estable).
+- Para formularios en modal, enviar con `Enter` en un campo (ngSubmit) evita problemas de overlay.
+- La cadena de negocio completa (solicitud → GIL → factura → conciliación → acta → paquete) está
+  cubierta por el E2E de API del backend (`ga-ms-inventario-1.1/seed/e2e_full.sh`, 62/0). Acá el foco
+  es la UI a nivel de página + los CRUD/import autocontenidos.
+- **GAP abierto**: `alertas/configuracion` llama endpoints de umbrales que el backend aún no tiene.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,23 @@
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = 'e2e/.auth/admin.json';
+
+/**
+ * Camino feliz de login (y además deja la sesión guardada para el resto de tests).
+ * Credenciales reales del admin contra el micro de usuarios (:8087).
+ */
+setup('login admin (camino feliz)', async ({ page }) => {
+  await page.goto('/auth/login');
+
+  await page.locator('input[type="email"]').fill('admin@sena.edu.co');
+  await page.locator('input[type="password"]').first().fill('admin123');
+  await page.locator('button[type="submit"]').click();
+
+  // Tras login el guard nos lleva a /app/...
+  await page.waitForURL(/\/app(\/|$)/, { timeout: 20_000 });
+
+  const token = await page.evaluate(() => localStorage.getItem('auth_token'));
+  expect(token, 'el token debe quedar guardado tras el login').toBeTruthy();
+
+  await page.context().storageState({ path: authFile });
+});

--- a/e2e/auth/login.spec.ts
+++ b/e2e/auth/login.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+// Estos tests NO usan la sesión guardada: prueban el login en sí.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('login con credenciales inválidas muestra error y NO entra (camino malo)', async ({ page }) => {
+  await page.goto('/auth/login');
+
+  await page.locator('input[type="email"]').fill('admin@sena.edu.co');
+  await page.locator('input[type="password"]').first().fill('clave-incorrecta');
+  await page.locator('button[type="submit"]').click();
+
+  // Sigue en login y aparece un mensaje de error; no se guarda token.
+  await expect(page).toHaveURL(/\/auth\/login/);
+  const token = await page.evaluate(() => localStorage.getItem('auth_token'));
+  expect(token, 'no debe guardarse token con credenciales malas').toBeFalsy();
+});
+
+test('rutas protegidas redirigen a login sin sesión (camino malo)', async ({ page }) => {
+  await page.goto('/app/inventario/bienes');
+  await expect(page).toHaveURL(/\/auth\/login/);
+});

--- a/e2e/inventario/alertas-config.spec.ts
+++ b/e2e/inventario/alertas-config.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Configuración de umbrales de stock.
+ *
+ * GAP CONOCIDO: la página llama GET /api/v1/alerts/alertas/umbrales y
+ * PUT /api/v1/alerts/alertas/umbrales/{id}, pero el backend NO implementa esos
+ * endpoints (el AlertaController solo tiene /alertas, /alertas/{id}, /resolver).
+ * Este test DOCUMENTA el gap: la página carga pero su request de umbrales falla (404).
+ * Cuando el backend implemente umbrales, este test debe actualizarse a esperar 200.
+ */
+test('alertas/configuracion: GAP — el endpoint de umbrales no existe en backend (404)', async ({ page }) => {
+  const [resp] = await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/alerts/alertas/umbrales'), {
+      timeout: 25_000,
+    }),
+    page.goto('/app/inventario/alertas/configuracion'),
+  ]);
+
+  // Hoy el backend devuelve 404/4xx porque el endpoint no existe.
+  expect(
+    resp.status(),
+    'GAP conocido: umbrales no implementado en backend — cuando exista, cambiar a 200',
+  ).toBeGreaterThanOrEqual(400);
+});

--- a/e2e/inventario/bienes-import.spec.ts
+++ b/e2e/inventario/bienes-import.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import * as XLSX from 'xlsx';
+
+const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+/** Genera un .xlsx en memoria con las filas dadas. */
+function buildXlsx(rows: Record<string, string | number>[]): Buffer {
+  const ws = XLSX.utils.json_to_sheet(rows);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Bienes');
+  return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+}
+
+async function abrirImportar(page: import('@playwright/test').Page) {
+  await page.goto('/app/inventario/bienes');
+  const importar = page.getByRole('button', { name: /Importar/i }).first();
+  await expect(importar).toBeVisible();
+  await importar.click();
+  await expect(page.locator('input[type="file"]')).toBeAttached();
+}
+
+test.describe('Inventario · Bienes · Importar Excel (contra backend real)', () => {
+  test('importar .xlsx válido carga los bienes en el backend (camino feliz)', async ({ page }) => {
+    const ts = Date.now();
+    const xlsx = buildXlsx([
+      { codigoSena: `IMP-${ts}-1`, descripcion: 'Harina E2E', categoria: 'ALIMENTOS', unidadMedida: 'KG', vrlAdjudicado: 3500, iva: 0 },
+      { codigoSena: `IMP-${ts}-2`, descripcion: 'Aceite E2E', categoria: 'ALIMENTOS', unidadMedida: 'L', vrlAdjudicado: 9000, iva: 19 },
+    ]);
+
+    await abrirImportar(page);
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'bienes-e2e.xlsx', mimeType: XLSX_MIME, buffer: xlsx,
+    });
+
+    const procesar = page.getByRole('button', { name: /Procesar|Importar/i }).last();
+    const [resp] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/api/v1/catalog/productos/importar-excel') && r.request().method() === 'POST',
+        { timeout: 25_000 },
+      ),
+      procesar.click(),
+    ]);
+    expect([200, 201]).toContain(resp.status());
+  });
+
+  test('importar .xlsx sin codigoSena es rechazado por el backend (camino malo)', async ({ page }) => {
+    const xlsx = buildXlsx([
+      { descripcion: 'Sin codigo E2E', categoria: 'ALIMENTOS', unidadMedida: 'KG' },
+    ]);
+
+    await abrirImportar(page);
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'bienes-malo.xlsx', mimeType: XLSX_MIME, buffer: xlsx,
+    });
+
+    const procesar = page.getByRole('button', { name: /Procesar|Importar/i }).last();
+    const [resp] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/api/v1/catalog/productos/importar-excel') && r.request().method() === 'POST',
+        { timeout: 25_000 },
+      ),
+      procesar.click(),
+    ]);
+    expect(resp.status(), 'el backend debe rechazar el lote sin codigoSena').toBeGreaterThanOrEqual(400);
+  });
+});

--- a/e2e/inventario/bienes.spec.ts
+++ b/e2e/inventario/bienes.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Inventario · Bienes (CRUD contra backend real)', () => {
+  test('crear bien válido lo persiste en el backend (camino feliz)', async ({ page }) => {
+    await page.goto('/app/inventario/bienes');
+    const nuevo = page.getByRole('button', { name: /Nuevo Bien/i });
+    await expect(nuevo).toBeVisible();
+    await nuevo.click();
+
+    const codigo = `E2E-${Date.now()}`;
+    await page.locator('input[formcontrolname="codigoSena"]').fill(codigo);
+    await page.locator('input[formcontrolname="descripcion"]').fill('Bien creado por E2E Playwright');
+    await page.locator('select[formcontrolname="categoria"]').selectOption({ index: 1 });
+    await page.locator('select[formcontrolname="unidadMedida"]').selectOption('UND');
+    await page.locator('input[formcontrolname="stockMinimo"]').fill('5');
+    await page.locator('input[formcontrolname="vrlAdjudicado"]').fill('1000');
+    await page.locator('input[formcontrolname="iva"]').fill('19');
+
+    const guardar = page.getByRole('button', { name: /Guardar Bien/i });
+    await expect(guardar).toBeEnabled();
+
+    const [resp] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/api/v1/catalog/productos') && r.request().method() === 'POST',
+        { timeout: 20_000 },
+      ),
+      guardar.click(),
+    ]);
+    expect([200, 201]).toContain(resp.status());
+  });
+
+  test('formulario inválido deja el botón Guardar deshabilitado (camino malo)', async ({ page }) => {
+    await page.goto('/app/inventario/bienes');
+    const nuevo = page.getByRole('button', { name: /Nuevo Bien/i });
+    await expect(nuevo).toBeVisible();
+    await nuevo.click();
+
+    // descripción demasiado corta (<3) y sin categoría/UM => form inválido
+    await page.locator('input[formcontrolname="descripcion"]').fill('ab');
+
+    await expect(page.getByRole('button', { name: /Guardar Bien/i })).toBeDisabled();
+  });
+});

--- a/e2e/inventario/pages-smoke.spec.ts
+++ b/e2e/inventario/pages-smoke.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke de TODAS las páginas del módulo inventario: con sesión iniciada,
+ * cada página debe cargar y pegar contra su endpoint real del backend.
+ * Cubre el "todo carga" del dominio y caza páginas que llaman endpoints inexistentes.
+ */
+
+interface PaginaInventario {
+  nombre: string;
+  ruta: string;
+  apiGet: RegExp; // endpoint principal que la página consulta al cargar
+}
+
+const PAGINAS: PaginaInventario[] = [
+  { nombre: 'Bienes',                ruta: 'bienes',                  apiGet: /\/api\/v1\/catalog\/productos/ },
+  { nombre: 'Solicitudes GIL',       ruta: 'solicitudes-gil',         apiGet: /\/api\/v1\/procurement\/giles/ },
+  { nombre: 'Solicitudes de insumos',ruta: 'solicitudes-insumos-page',apiGet: /\/api\/v1\/training\/solicitudes/ },
+  { nombre: 'Facturas',              ruta: 'facturas',                apiGet: /\/api\/v1\/sourcing\/facturas/ },
+  { nombre: 'Consolidado',           ruta: 'consolidado',             apiGet: /\/api\/v1\/budget\/consolidados/ },
+  { nombre: 'Conciliación',          ruta: 'conciliacion',            apiGet: /\/api\/v1\/reconciliation\/conciliaciones/ },
+  { nombre: 'Movimientos',           ruta: 'movimientos',             apiGet: /\/api\/v1\/inventory\/movimientos/ },
+  { nombre: 'Alertas',               ruta: 'alertas',                 apiGet: /\/api\/v1\/alerts\/alertas/ },
+  { nombre: 'Presupuesto',           ruta: 'presupuesto',             apiGet: /\/api\/v1\/budget\/presupuestos/ },
+  { nombre: 'Actas',                 ruta: 'actas',                   apiGet: /\/api\/v1\/legalization\/actas/ },
+  { nombre: 'Paquete probatorio',    ruta: 'paquete-probatorio',      apiGet: /\/api\/v1\/legalization\/paquetes/ },
+];
+
+for (const pagina of PAGINAS) {
+  test(`carga "${pagina.nombre}" y consulta el backend (200)`, async ({ page }) => {
+    const [resp] = await Promise.all([
+      page.waitForResponse((r) => pagina.apiGet.test(r.url()) && r.request().method() === 'GET', {
+        timeout: 25_000,
+      }),
+      page.goto(`/app/inventario/${pagina.ruta}`),
+    ]);
+
+    await expect(page, `debe quedar en la ruta ${pagina.ruta}`).toHaveURL(new RegExp(pagina.ruta));
+    expect(resp.status(), `${pagina.nombre}: el backend debe responder 2xx`).toBeLessThan(300);
+  });
+}

--- a/e2e/inventario/presupuesto.spec.ts
+++ b/e2e/inventario/presupuesto.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Inventario · Presupuesto (registrar contra backend real)', () => {
+  test('registrar presupuesto válido lo persiste (camino feliz)', async ({ page }) => {
+    await page.goto('/app/inventario/presupuesto/registrar');
+
+    await expect(page.locator('input[formcontrolname="fichaId"]')).toBeVisible();
+    await page.locator('input[formcontrolname="fichaId"]').fill(`${Date.now()}`.slice(-7));
+    await page.locator('input[formcontrolname="programaFormacion"]').fill('Cocina E2E');
+    await page.locator('select[formcontrolname="vigencia"]').selectOption({ index: 1 });
+    await page.locator('input[formcontrolname="fechaAprobacion"]').fill('2026-06-09');
+    await page.locator('input[formcontrolname="rubroDescripcion"]').fill('Insumos de cocina');
+    await page.locator('input[formcontrolname="rubroCodigo"]').fill('RUB-E2E-1');
+    await page.locator('input[formcontrolname="rubroPosicionPresupuestal"]').fill('A-02-02');
+    await page.locator('input[formcontrolname="rubroDependencia"]').fill('Centro E2E');
+    await page.locator('select[formcontrolname="rubroFuente"]').selectOption({ index: 1 });
+    const monto = page.locator('input[formcontrolname="montoAsignado"]');
+    await monto.fill('5000000');
+
+    await expect(page.getByRole('button', { name: /Guardar Presupuesto/i })).toBeEnabled();
+
+    // Enviar vía ngSubmit (Enter en un campo) — robusto frente a overlays del modal.
+    const [resp] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/api/v1/budget/presupuestos') && r.request().method() === 'POST',
+        { timeout: 20_000 },
+      ),
+      monto.press('Enter'),
+    ]);
+    expect([200, 201]).toContain(resp.status());
+  });
+
+  test('presupuesto sin campos obligatorios deja Guardar deshabilitado (camino malo)', async ({ page }) => {
+    await page.goto('/app/inventario/presupuesto/registrar');
+    await expect(page.locator('input[formcontrolname="fichaId"]')).toBeVisible();
+    // Sin llenar nada → form inválido
+    await expect(page.getByRole('button', { name: /Guardar Presupuesto/i })).toBeDisabled();
+  });
+});

--- a/e2e/inventario/smoke.spec.ts
+++ b/e2e/inventario/smoke.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke: con sesión iniciada, el módulo inventario carga y pega contra el backend real.
+ */
+test('inventario / bienes carga y lista productos del backend', async ({ page }) => {
+  // Enganchamos el listener ANTES de navegar para no perder la respuesta (race).
+  const [resp] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes('/api/v1/catalog/productos') && r.request().method() === 'GET',
+      { timeout: 20_000 },
+    ),
+    page.goto('/app/inventario/bienes'),
+  ]);
+
+  expect(resp.status(), 'el backend de inventario debe responder OK').toBe(200);
+  await expect(page).toHaveURL(/inventario\/bienes/);
+  await expect(page.locator('body')).toContainText(/bien|stock|inventario/i);
+});

--- a/libs/inventario/inventario/src/lib/data-access/api/catalog.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/catalog.api.ts
@@ -21,7 +21,6 @@ export interface ProductoResponse {
   id: string;
   codigoSena: string;
   codigoProveedor?: string;
-  nombre: string;
   descripcion?: string;
   categoria: string;
   unidadMedida: string;

--- a/libs/inventario/inventario/src/lib/data-access/mappers/catalog.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/catalog.mapper.ts
@@ -24,7 +24,6 @@ export function productoFromApi(dto: ProductoResponse): ProductoCatalogo {
     id: dto.id,
     codigoSena: dto.codigoSena,
     codigoProveedor: dto.codigoProveedor,
-    nombre: dto.nombre,
     descripcion: dto.descripcion,
     categoria: dto.categoria,
     unidadMedida: dto.unidadMedida,

--- a/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
@@ -31,7 +31,7 @@ export class BienesService {
   /** GET /catalog/productos — lista paginada (page 0-based, size por defecto 20). */
   getBienes(filtros?: BienFiltros): Observable<{ bienes: Bien[]; paginacion: BienPaginacion }> {
     let params = new HttpParams();
-    if (filtros?.busqueda)              params = params.set('nombre', filtros.busqueda);
+    if (filtros?.busqueda)              params = params.set('descripcion', filtros.busqueda);
     if (filtros?.categoria)             params = params.set('categoria', filtros.categoria);
     if (filtros?.estado === 'Activo')   params = params.set('activo', 'true');
     if (filtros?.estado === 'Inactivo') params = params.set('activo', 'false');

--- a/libs/inventario/inventario/src/lib/models/inventario.model.ts
+++ b/libs/inventario/inventario/src/lib/models/inventario.model.ts
@@ -113,7 +113,6 @@ export interface ProductoCatalogo {
   id: string | number;
   codigoSena: string;
   codigoProveedor?: string;
-  nombre: string;
   descripcion?: string;
   categoria: string;
   unidadMedida: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@nx/angular": "^20.0.0",
         "@nx/eslint": "^20.0.0",
         "@nx/eslint-plugin": "^20.0.0",
+        "@playwright/test": "^1.60.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.2",
         "@typescript-eslint/eslint-plugin": "^8.59.4",
@@ -46,7 +47,8 @@
         "nx": "^20.0.0",
         "prettier": "^3.4.2",
         "ts-mockito": "^2.6.1",
-        "typescript": "~5.9.3"
+        "typescript": "~5.9.3",
+        "xlsx": "^0.18.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8236,6 +8238,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -10763,6 +10781,16 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/adm-zip": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
@@ -11671,6 +11699,20 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -11939,6 +11981,16 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -12273,6 +12325,19 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cron-parser": {
@@ -14959,6 +15024,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -19903,6 +19978,53 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
@@ -22470,6 +22592,19 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/ssri": {
       "version": "13.0.1",
@@ -25227,6 +25362,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -25378,6 +25533,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "test": "nx affected:test --base=develop",
     "graph": "nx graph",
     "format": "nx format:write",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:report": "playwright show-report e2e/.report",
     "prepare": "husky"
   },
   "dependencies": {
@@ -40,6 +43,7 @@
     "@nx/angular": "^20.0.0",
     "@nx/eslint": "^20.0.0",
     "@nx/eslint-plugin": "^20.0.0",
+    "@playwright/test": "^1.60.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
@@ -50,7 +54,8 @@
     "nx": "^20.0.0",
     "prettier": "^3.4.2",
     "ts-mockito": "^2.6.1",
-    "typescript": "~5.9.3"
+    "typescript": "~5.9.3",
+    "xlsx": "^0.18.5"
   },
   "overrides": {
     "@angular-devkit/build-angular": "npm:@angular/build@^20.3.24"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E full-stack del dominio inventario: la UI real (Angular en :4200, vía proxy)
+ * contra los microservicios reales (inventario :8081, usuarios :8087) en Docker.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  retries: 1,
+  reporter: [['list'], ['html', { outputFolder: 'e2e/.report', open: 'never' }]],
+  timeout: 45_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: 'http://localhost:4200',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 15_000,
+  },
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'inventario',
+      use: { ...devices['Desktop Chrome'], storageState: 'e2e/.auth/admin.json' },
+      dependencies: ['setup'],
+      testIgnore: /auth\.setup\.ts/,
+    },
+  ],
+});


### PR DESCRIPTION
…-descripcion

- Suite Playwright (22 tests) UI real contra microservicios en Docker: login (feliz/malo), bienes crear + import .xlsx (feliz/malo), presupuesto registrar (feliz/malo), smoke de las 11 paginas, y doc del GAP umbrales. playwright.config + sesion via storageState.
- Quita 'nombre' del producto en el front (ProductoResponse, mapper, ProductoCatalogo, filtro de busqueda nombre -> descripcion), alineado con el backend.
- Scripts npm e2e/e2e:ui/e2e:report, README en e2e/, .gitignore de artefactos.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
