### PR TITLE
fix(restaurante): arreglar modales de registrar pago en caja

### DIFF
--- a/libs/restaurante/restaurante/src/lib/pages/caja-pagar-page/caja-pagar-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/caja-pagar-page/caja-pagar-page.component.html
@@ -3,164 +3,154 @@
         <button class="back-btn" (click)="volver()">
             <lucide-icon name="arrow-left" [size]="20"></lucide-icon>
         </button>
-        <restaurant-page-header
-                title="Registrar Pago"
-                subtitle="Cuentas pendientes por recaudar e imprimir comprobante"
-        ></restaurant-page-header>
+        <restaurant-page-header title="Registrar Pago"
+            subtitle="Cuentas pendientes por recaudar e imprimir comprobante"></restaurant-page-header>
     </div>
 
     <div class="main-content-block">
-    <restaurant-data-table tableTitle="Pedidos por Cobrar" tableIcon="dollar-sign" class="mt-4" style="display: block;">
-      <ng-container dtHeader>
-        <span class="subtitle" style="display: block; padding: 0 var(--space-6) var(--space-4) var(--space-6); margin-top: calc(var(--space-2) * -1); font-size: var(--font-size-sm); color: var(--color-text-secondary);">Seleccione el pedido que desea facturar</span>
-      </ng-container>
+        <restaurant-data-table tableTitle="Pedidos por Cobrar" tableIcon="dollar-sign" class="mt-4 data-table-wrapper">
+            <ng-container dtHeader>
+                <span class="subtitle">Seleccione el pedido que desea facturar</span>
+            </ng-container>
 
-      <thead>
-        <tr>
-          <th>Mesa</th>
-          <th>Cajero</th>
-          <th>Total Pedido</th>
-          <th class="text-center">Acción</th>
-        </tr>
-      </thead>
-      <tbody>
-        @for (pedido of pedidosPorPagar(); track pedido.id) {
-        <tr>
-          <td><strong>{{ pedido.nombreMesa || 'Para Llevar' }}</strong></td>
-          <td title="{{ pedido.meseroId }}"><span class="badge-count">{{ pedido.meseroId | slice:0:8 }}...</span></td>
-          <td class="amount-pending" style="font-weight: var(--font-weight-semibold); color: var(--color-text-primary);">{{ pedido.subtotal | currency:'COP':'symbol-narrow':'1.0-0' }}</td>
-          <td class="text-center">
-            <restaurant-button variant="primary" (click)="abrirCobro(pedido)" style="font-size: 0.85rem; padding: 0.25rem 0.75rem;">
-              <lucide-icon name="dollar-sign" [size]="16"></lucide-icon>
-              <span>Cobrar</span>
-            </restaurant-button>
-          </td>
-        </tr>
-        } @empty {
-        <tr>
-          <td colspan="4" class="p-0 border-0">
-            <restaurant-empty-state
-                    title="Todo al día"
-                    message="No hay pedidos pendientes por cobrar en este momento.">
-            </restaurant-empty-state>
-          </td>
-        </tr>
-        }
-      </tbody>
-    </restaurant-data-table>
-  </div>
+            <thead>
+                <tr>
+                    <th>Mesa</th>
+                    <th>Cajero</th>
+                    <th>Total Pedido</th>
+                    <th class="text-center">Acción</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for (pedido of pedidosPorPagar(); track pedido.id) {
+                <tr>
+                    <td><strong>{{ pedido.nombreMesa || 'Para Llevar' }}</strong></td>
+                    <td title="{{ pedido.meseroId }}"><span class="badge-count">{{ pedido.meseroId | slice:0:8
+                            }}...</span></td>
+                    <td class="amount-pending">{{ pedido.subtotal | currency:'COP':'symbol-narrow':'1.0-0' }}</td>
+                    <td class="text-center">
+                        <restaurant-button variant="primary" (click)="abrirCobro(pedido)" class="cobrar-btn">
+                            <lucide-icon name="dollar-sign" [size]="16"></lucide-icon>
+                            <span>Cobrar</span>
+                        </restaurant-button>
+                    </td>
+                </tr>
+                } @empty {
+                <tr>
+                    <td colspan="4" class="p-0 border-0">
+                        <restaurant-empty-state title="Todo al día"
+                            message="No hay pedidos pendientes por cobrar en este momento.">
+                        </restaurant-empty-state>
+                    </td>
+                </tr>
+                }
+            </tbody>
+        </restaurant-data-table>
+    </div>
 
     @if (modalAbierto()) {
     <div class="modal-overlay" (click)="cerrarModal()">
-        <div class="modal-content" (click)="$event.stopPropagation()">
+        <div class="modal-card" (click)="$event.stopPropagation()">
 
-            <div class="modal-header-colored">
+            <div class="modal-header">
                 <h3>Procesar Pago - Pedido #{{ pedidoSeleccionado()?.id | slice:0:8 | uppercase }}</h3>
                 <button class="close-btn" (click)="cerrarModal()">
                     <lucide-icon name="x" [size]="20"></lucide-icon>
                 </button>
             </div>
 
-            <div class="modal-body-custom">
-                <div class="total-badge" style="background: var(--color-surface); padding: 1rem; border-radius: 8px; border: 1px solid var(--color-border); display: flex; justify-content: space-between; align-items: center;">
-                    <span class="lbl" style="font-size: 0.9rem; font-weight: 600; color: var(--color-text-secondary);">Subtotal Pedido:</span>
-                    <span class="val" style="font-size: 1.1rem; font-weight: 700;">{{ pedidoSeleccionado()?.subtotal | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
+            <div class="modal-body">
+                <div class="total-badge">
+                    <span class="lbl">Subtotal Pedido:</span>
+                    <span class="val">{{ pedidoSeleccionado()?.subtotal | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
                 </div>
 
-                <div class="tip-section mt-4 mb-4" style="background: var(--color-surface); padding: 1rem; border-radius: 8px; border: 1px solid var(--color-border);">
-                    <span class="section-hint" style="margin-bottom: 0.5rem; display: block; font-weight: 500;">Propina sugerida o voluntaria:</span>
-                    <div class="method-cards-grid" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.5rem;">
-                        <div class="method-card" style="padding: 0.5rem; min-height: unset; height: auto; text-align: center; border: 1px solid var(--color-border); border-radius: 6px; cursor: pointer;" [class.active]="tipoPropina() === 'NADA'" (click)="seleccionarTipoPropina('NADA')">
-                            <span style="font-size: 0.85rem;">$0</span>
+                <div class="tip-section mt-4 mb-4">
+                    <span class="section-hint">Propina sugerida o voluntaria:</span>
+                    <div class="method-cards-grid">
+                        <div class="method-card small"
+                            [class.active]="tipoPropina() === 'NADA'" (click)="seleccionarTipoPropina('NADA')">
+                            <span>$0</span>
                         </div>
-                        <div class="method-card" style="padding: 0.5rem; min-height: unset; height: auto; text-align: center; border: 1px solid var(--color-border); border-radius: 6px; cursor: pointer;" [class.active]="tipoPropina() === 'DIEZ_PORCIENTO'" (click)="seleccionarTipoPropina('DIEZ_PORCIENTO')">
-                            <span style="font-size: 0.85rem;">10% Sugerida</span>
+                        <div class="method-card small"
+                            [class.active]="tipoPropina() === 'DIEZ_PORCIENTO'"
+                            (click)="seleccionarTipoPropina('DIEZ_PORCIENTO')">
+                            <span>10% Sugerida</span>
                         </div>
-                        <div class="method-card" style="padding: 0.5rem; min-height: unset; height: auto; text-align: center; border: 1px solid var(--color-border); border-radius: 6px; cursor: pointer;" [class.active]="tipoPropina() === 'OTRO'" (click)="seleccionarTipoPropina('OTRO')">
-                            <span style="font-size: 0.85rem;">Otro valor</span>
+                        <div class="method-card small"
+                            [class.active]="tipoPropina() === 'OTRO'" (click)="seleccionarTipoPropina('OTRO')">
+                            <span>Otro valor</span>
                         </div>
                     </div>
 
                     @if (tipoPropina() === 'OTRO') {
-                        <div class="input-group mt-3" style="width: 100%;">
-                            <input
-                                type="number"
-                                class="form-control"
-                                placeholder="Monto exacto en pesos ($)"
-                                [value]="propinaManual() || ''"
-                                (input)="actualizarPropinaManual($event)"
-                                style="width: 100%; padding: 0.75rem; border-radius: 8px; border: 1px solid var(--color-border); font-size: 1rem; background: var(--color-background);"
-                            />
-                        </div>
+                    <div class="input-group mt-3">
+                        <input type="number" class="form-control" placeholder="Monto exacto en pesos ($)"
+                            [value]="propinaManual() || ''" (input)="actualizarPropinaManual($event)" />
+                    </div>
                     }
 
-                    <div class="total-badge mt-3" style="background: var(--color-primary-transparent); border: 1px solid var(--color-primary); padding: 1rem; border-radius: 8px; display: flex; justify-content: space-between; align-items: center;">
-                        <span class="lbl" style="color: var(--color-text); font-weight: 600;">Total Final a Cobrar:</span>
-                        <span class="val" style="color: var(--color-primary); font-size: 1.2rem; font-weight: 700;">{{ totalACobrar() | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
+                    <div class="total-badge primary mt-3">
+                        <span class="lbl">Total Final a Cobrar:</span>
+                        <span class="val">{{ totalACobrar() | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
                     </div>
                 </div>
 
-                <span class="section-hint" style="font-weight: 500; display: block; margin-bottom: 0.5rem;">Seleccione el método de pago:</span>
+                <span class="section-hint">Seleccione el método de pago:</span>
 
-                <div class="method-cards-grid" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.5rem;">
-                    <div class="method-card" style="padding: 1rem; text-align: center; border: 1px solid var(--color-border); border-radius: 8px; cursor: pointer; display: flex; flex-direction: column; align-items: center; gap: 0.5rem;" [class.active]="metodoSeleccionado() === 'EFECTIVO'" (click)="seleccionarMetodo('EFECTIVO')">
+                <div class="method-cards-grid">
+                    <div class="method-card"
+                        [class.active]="metodoSeleccionado() === 'EFECTIVO'" (click)="seleccionarMetodo('EFECTIVO')">
                         <lucide-icon name="banknote" [size]="24"></lucide-icon>
-                        <span style="font-size: 0.9rem;">Efectivo</span>
+                        <span>Efectivo</span>
                     </div>
-                    <div class="method-card" style="padding: 1rem; text-align: center; border: 1px solid var(--color-border); border-radius: 8px; cursor: pointer; display: flex; flex-direction: column; align-items: center; gap: 0.5rem;" [class.active]="metodoSeleccionado() === 'TARJETA'" (click)="seleccionarMetodo('TARJETA')">
+                    <div class="method-card"
+                        [class.active]="metodoSeleccionado() === 'TARJETA'" (click)="seleccionarMetodo('TARJETA')">
                         <lucide-icon name="credit-card" [size]="24"></lucide-icon>
-                        <span style="font-size: 0.9rem;">Tarjeta</span>
+                        <span>Tarjeta</span>
                     </div>
-                    <div class="method-card" style="padding: 1rem; text-align: center; border: 1px solid var(--color-border); border-radius: 8px; cursor: pointer; display: flex; flex-direction: column; align-items: center; gap: 0.5rem;" [class.active]="metodoSeleccionado() === 'TRANSFERENCIA'" (click)="seleccionarMetodo('TRANSFERENCIA')">
+                    <div class="method-card"
+                        [class.active]="metodoSeleccionado() === 'TRANSFERENCIA'"
+                        (click)="seleccionarMetodo('TRANSFERENCIA')">
                         <lucide-icon name="arrow-right-left" [size]="24"></lucide-icon>
-                        <span style="font-size: 0.9rem;">Transferencia</span>
+                        <span>Transferencia</span>
                     </div>
                 </div>
 
                 @if (metodoSeleccionado() === 'EFECTIVO') {
-                <div class="cash-calculator-box mt-4" style="background: var(--color-surface); padding: 1rem; border-radius: 8px; border: 1px solid var(--color-border);">
-                    <div class="form-group" style="margin-bottom: 1rem;">
-                        <label style="display: block; margin-bottom: 0.5rem; font-weight: 500;">Monto Recibido en Efectivo:</label>
-                        <input
-                                id="cashReceived"
-                                type="number"
-                                class="form-control"
-                                placeholder="¿Con cuánto paga?"
-                                [value]="montoRecibido() === 0 ? '' : montoRecibido()"
-                                (input)="actualizarMontoRecibido($event)"
-                                (keydown)="preventInvalidChars($event)"
-                                style="width: 100%; padding: 0.75rem; border-radius: 8px; border: 1px solid var(--color-border); font-size: 1rem;"
-                        />
+                <div class="cash-calculator-box mt-4">
+                    <div class="input-group">
+                        <label>Monto Recibido en Efectivo:</label>
+                        <input id="cashReceived" type="number" class="form-control" placeholder="¿Con cuánto paga?"
+                            [value]="montoRecibido() === 0 ? '' : montoRecibido()"
+                            (input)="actualizarMontoRecibido($event)" (keydown)="preventInvalidChars($event)" />
                     </div>
 
-                    <div class="change-row" style="display: flex; justify-content: space-between; align-items: center; padding-top: 1rem; border-top: 1px dashed var(--color-border);">
-                        <span class="change-lbl" style="font-weight: 600; color: var(--color-text-secondary);">Cambio / Devuelta:</span>
-                        <span class="change-val" style="font-size: 1.1rem; font-weight: 700;" [class.text-danger]="calcularDevuelta() < 0" [class.text-success]="calcularDevuelta() >= 0">
-                  {{ calcularDevuelta() | currency:'COP':'symbol-narrow':'1.0-0' }}
-                </span>
+                    <div class="change-row">
+                        <span class="change-lbl">Cambio / Devuelta:</span>
+                        <span class="change-val"
+                            [class.negative]="calcularDevuelta() < 0" [class.positive]="calcularDevuelta() >= 0">
+                            {{ calcularDevuelta() | currency:'COP':'symbol-narrow':'1.0-0' }}
+                        </span>
                     </div>
                 </div>
                 }
 
                 @if (metodoSeleccionado() === 'TARJETA' || metodoSeleccionado() === 'TRANSFERENCIA') {
-                <div class="alert alert-info mt-4" style="display: flex; gap: 0.5rem; align-items: center; padding: 1rem; border-radius: 8px; background: var(--color-surface-hover); color: var(--color-brand-primary); border: 1px solid var(--color-border);">
+                <div class="alert alert-info mt-4">
                     <lucide-icon name="info" [size]="16"></lucide-icon>
-                    <span style="font-size: 0.9rem;">Al confirmar, el sistema procesará la transacción electrónica de forma inmediata.</span>
+                    <span>Al confirmar, el sistema procesará la transacción electrónica de forma inmediata.</span>
                 </div>
                 }
             </div>
 
-            <div class="modal-actions">
+            <div class="modal-footer">
                 <restaurant-button variant="ghost" (click)="cerrarModal()">
                     <span>Cancelar</span>
                 </restaurant-button>
 
-                <restaurant-button
-                        variant="primary"
-                        [disabled]="!esPagoValido()"
-                        (click)="confirmarPago()"
-                >
-                    <div class="btn-content-centered" style="display: flex; gap: 0.5rem; align-items: center;">
+                <restaurant-button variant="primary" [disabled]="!esPagoValido()" (click)="confirmarPago()">
+                    <div class="btn-content-centered">
                         <lucide-icon name="check" [size]="18"></lucide-icon>
                         <span>Confirmar Pago</span>
                     </div>
@@ -170,14 +160,8 @@
     </div>
     }
 
-    <restaurant-confirm-dialog
-            [open]="alertDialog().open"
-            [title]="alertDialog().title"
-            [message]="alertDialog().message"
-            [confirmText]="alertDialog().confirmText || 'Aceptar'"
-            [cancelText]="alertDialog().cancelText || 'Cancelar'"
-            [showCancel]="alertDialog().type === 'confirm'"
-            (confirm)="confirmAlertDialog()"
-            (cancel)="cerrarAlertDialog()"
-    ></restaurant-confirm-dialog>
+    <restaurant-confirm-dialog [open]="alertDialog().open" [title]="alertDialog().title"
+        [message]="alertDialog().message" [confirmText]="alertDialog().confirmText || 'Aceptar'"
+        [cancelText]="alertDialog().cancelText || 'Cancelar'" [showCancel]="alertDialog().type === 'confirm'"
+        (confirm)="confirmAlertDialog()" (cancel)="cerrarAlertDialog()"></restaurant-confirm-dialog>
 </div>

--- a/libs/restaurante/restaurante/src/lib/pages/caja-pagar-page/caja-pagar-page.component.scss
+++ b/libs/restaurante/restaurante/src/lib/pages/caja-pagar-page/caja-pagar-page.component.scss
@@ -27,12 +27,45 @@
       box-shadow: var(--shadow-sm);
       transition: all 0.2s;
 
-      &:hover { background: var(--color-background-soft); }
+      &:hover {
+        background: var(--color-background-soft);
+      }
     }
-    restaurant-page-header { ::ng-deep .page-header { margin-bottom: 0; } }
+
+    restaurant-page-header {
+      ::ng-deep .page-header {
+        margin-bottom: 0;
+      }
+    }
   }
 
-  .main-content-block { width: 100%; }
+  .main-content-block {
+    width: 100%;
+  }
+
+  .data-table-wrapper {
+    display: block;
+  }
+
+  .subtitle {
+    display: block;
+    padding: 0 var(--space-6) var(--space-4) var(--space-6);
+    margin-top: calc(var(--space-2) * -1);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .amount-pending {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+  }
+
+  .cobrar-btn {
+    ::ng-deep button {
+      font-size: var(--font-size-sm);
+      padding: var(--space-1) var(--space-3);
+    }
+  }
 
   .card {
     background-color: var(--color-surface-primary);
@@ -51,18 +84,33 @@
     .title-group {
       display: flex;
       flex-direction: column;
-      h5 { margin: 0; font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); color: var(--color-text-heading); }
-      .subtitle { font-size: var(--font-size-sm); color: var(--color-text-secondary); }
+
+      h5 {
+        margin: 0;
+        font-size: var(--font-size-lg);
+        font-weight: var(--font-weight-semibold);
+        color: var(--color-text-heading);
+      }
+
+      .subtitle {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+      }
     }
   }
 
   /* ESTILOS INTERNOS DEL MODAL DE COBRO */
   .modal-overlay {
     position: fixed;
-    top: 0; left: 0; width: 100vw; height: 100vh;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
     background-color: rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(3px);
-    display: flex; align-items: center; justify-content: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     z-index: 9999;
   }
 
@@ -71,8 +119,10 @@
     border: 1px solid var(--color-border);
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-lg);
-    width: 100%; max-width: 500px;
-    display: flex; flex-direction: column;
+    width: 100%;
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
     animation: slideUp 0.2s ease-out;
   }
@@ -80,61 +130,245 @@
   .modal-header {
     padding: var(--space-4) var(--space-6);
     border-bottom: 1px solid var(--color-border);
-    display: flex; justify-content: space-between; align-items: center;
-    h6 { margin: 0; font-size: var(--font-size-md); font-weight: var(--font-weight-bold); color: var(--color-text-heading); }
-    .close-btn { background: transparent; border: none; color: var(--color-text-muted); cursor: pointer; &:hover { color: var(--color-text-primary); } }
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    h3 {
+      margin: 0;
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-bold);
+      color: var(--color-text-heading);
+    }
+
+    .close-btn {
+      background: transparent;
+      border: none;
+      color: var(--color-text-muted);
+      cursor: pointer;
+
+      &:hover {
+        color: var(--color-text-primary);
+      }
+    }
   }
 
-  .modal-body { padding: var(--space-6); display: flex; flex-direction: column; }
+  .modal-body {
+    padding: var(--space-6);
+    display: flex;
+    flex-direction: column;
+  }
 
   .total-badge {
     background-color: var(--color-surface-hover);
-    padding: var(--space-4); border-radius: var(--radius-md);
-    display: flex; justify-content: space-between; align-items: center;
-    margin-bottom: var(--space-4);
+    padding: var(--space-4);
+    border-radius: var(--radius-md);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     border: 1px solid var(--color-border);
-    .lbl { font-size: var(--font-size-sm); color: var(--color-text-secondary); font-weight: 500; }
-    .val { font-size: 1.4rem; font-weight: 800; color: var(--color-brand-primary); }
+
+    .lbl {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      font-weight: 500;
+    }
+
+    .val {
+      font-size: 1.4rem;
+      font-weight: 800;
+      color: var(--color-brand-primary);
+    }
+
+    &.primary {
+      background-color: transparent;
+      border-color: var(--color-brand-primary);
+      
+      .lbl {
+        color: var(--color-text-primary);
+      }
+      .val {
+        color: var(--color-brand-primary);
+      }
+    }
   }
 
-  .section-hint { font-size: var(--font-size-xs); color: var(--color-text-secondary); margin-bottom: var(--space-3); font-weight: 500; text-transform: uppercase; }
+  .tip-section {
+    background-color: var(--color-surface-secondary);
+    padding: var(--space-4);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+  }
+
+  .section-hint {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    margin-bottom: var(--space-3);
+    font-weight: 500;
+    text-transform: uppercase;
+    display: block;
+  }
 
   /* Cuadrícula de Métodos de Pago */
   .method-cards-grid {
-    display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-3);
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-3);
   }
-  .method-card {
-    border: 1px solid var(--color-border); border-radius: var(--radius-lg);
-    padding: var(--space-4) var(--space-2); display: flex; flex-direction: column;
-    align-items: center; gap: var(--space-2); cursor: pointer; transition: all 0.2s;
-    color: var(--color-text-secondary); font-size: var(--font-size-sm); font-weight: 500;
 
-    &:hover { border-color: var(--color-brand-primary); color: var(--color-brand-primary); background-color: var(--color-surface-hover); }
-    &.active { border-color: var(--color-brand-primary); background-color: var(--color-brand-primary-soft); color: var(--color-brand-primary); box-shadow: 0 0 0 1px var(--color-brand-primary); }
+  .method-card {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4) var(--space-2);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-2);
+    cursor: pointer;
+    transition: all 0.2s;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+
+    &:hover {
+      border-color: var(--color-brand-primary);
+      color: var(--color-brand-primary);
+      background-color: var(--color-surface-hover);
+    }
+
+    &.active {
+      border-color: var(--color-brand-primary);
+      background-color: transparent;
+      color: var(--color-brand-primary);
+      box-shadow: 0 0 0 1px var(--color-brand-primary);
+    }
+
+    &.small {
+      padding: var(--space-2);
+      min-height: unset;
+      height: auto;
+      
+      span {
+        font-size: var(--font-size-xs);
+      }
+    }
+  }
+
+  /* Formularios globales */
+  .input-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    width: 100%;
+
+    label {
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-medium);
+      color: var(--color-text-secondary);
+    }
+  }
+
+  .form-control {
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-md);
+    background-color: var(--color-background);
+    color: var(--color-text-primary);
+    outline: none;
+    width: 100%;
+
+    &:focus {
+      border-color: var(--color-brand-primary);
+    }
   }
 
   /* Caja del Calculador de Efectivo */
   .cash-calculator-box {
-    background-color: var(--color-surface-secondary); border: 1px dashed var(--color-border);
-    padding: var(--space-4); border-radius: var(--radius-lg);
-    .input-group { display: flex; flex-direction: column; gap: var(--space-2); label { font-size: var(--font-size-xs); font-weight: 600; color: var(--color-text-secondary); } }
-    .form-control { padding: var(--space-3); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--font-size-md); outline: none; width: 100%; &:focus { border-color: var(--color-brand-primary); } }
+    background-color: var(--color-surface-secondary);
+    border: 1px dashed var(--color-border);
+    padding: var(--space-4);
+    border-radius: var(--radius-lg);
 
     .change-row {
-      display: flex; justify-content: space-between; align-items: center;
-      .change-lbl { font-size: var(--font-size-sm); font-weight: 500; color: var(--color-text-heading); }
-      .change-val { font-size: 1.3rem; font-weight: 700; color: var(--color-success); &.negative { color: var(--color-danger); } }
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding-top: var(--space-4);
+      margin-top: var(--space-4);
+      border-top: 1px dashed var(--color-border);
+
+      .change-lbl {
+        font-size: var(--font-size-sm);
+        font-weight: 500;
+        color: var(--color-text-heading);
+      }
+
+      .change-val {
+        font-size: 1.3rem;
+        font-weight: 700;
+        
+        &.negative {
+          color: var(--color-danger);
+        }
+        &.positive {
+          color: var(--color-success);
+        }
+      }
     }
   }
 
   .alert {
-    padding: var(--space-3); border-radius: var(--radius-md); font-size: var(--font-size-xs); display: flex; align-items: center; gap: var(--space-2);
-    &.alert-info { background-color: var(--color-info-bg); color: var(--color-info-text); }
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-xs);
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+
+    &.alert-info {
+      background-color: var(--color-surface-hover);
+      color: var(--color-brand-primary);
+      border: 1px solid var(--color-border);
+    }
   }
 
-  .modal-footer { padding: var(--space-4) var(--space-6); border-top: 1px solid var(--color-border); display: flex; justify-content: flex-end; gap: var(--space-3); }
+  .modal-footer {
+    padding: var(--space-4) var(--space-6);
+    border-top: 1px solid var(--color-border);
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-3);
+  }
 
-  .mt-4 { margin-top: var(--space-4); }
+  .btn-content-centered {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    justify-content: center;
+  }
+
+  .mt-3 {
+    margin-top: var(--space-3);
+  }
+
+  .mt-4 {
+    margin-top: var(--space-4);
+  }
+  
+  .mb-4 {
+    margin-bottom: var(--space-4);
+  }
 }
 
-@keyframes slideUp { from { transform: translateY(20px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+@keyframes slideUp {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Descripción
Este PR soluciona los problemas de legibilidad y diseño en los modales de Registrar Pago / Cobrar dentro del dominio de restaurante. El modal ahora es 100% compatible con el sistema de temas (Claro / Oscuro) del proyecto.

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [x ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ x] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [x ] `nx affected:lint --base=develop` → 0 errores
- [x ] `nx affected:test --base=develop` → 0 fallos
- [ x] PR tiene menos de 400 líneas modificadas
- [x ] Un solo scope tocado
- [ x] Todo componente nuevo tiene su `.spec.ts`
- [ x] Sin `any` en TypeScript
- [ x] Sin estilos inline en templates
- [x ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales

Refactorización de HTML: Se eliminaron las etiquetas de estilos fijos (style="...") que forzaban colores estáticos en la página caja-pagar-page.component.html.
Implementación del Sistema de Diseño (Tokens): Se mapearon los colores de fondo, bordes y textos a las variables globales de _variables.scss (ej. var(--color-surface-primary), var(--color-text-secondary)) en caja-pagar-page.component.scss.
Mejora de UX en Modo Oscuro: Se eliminó el fondo verde opaco y brillante (--color-brand-primary-soft) en las tarjetas de propina y métodos de pago activos (.active / .primary). En su lugar, el estado de selección ahora se indica de forma minimalista únicamente con un borde var(--color-brand-primary), manteniendo un fondo transparente que respeta el tema actual y previene la fatiga visual.
