### PR TITLE
fix(restaurante): corregir colores de cabecera en modal de detalle de…

### DIFF
--- a/libs/restaurante/restaurante/src/lib/pages/caja-buscar-page/caja-buscar-page.component.html
+++ b/libs/restaurante/restaurante/src/lib/pages/caja-buscar-page/caja-buscar-page.component.html
@@ -136,7 +136,7 @@
   @if (mostrarModalDetalle() && facturaSeleccionada()) {
   <div class="modal-overlay" (click)="cerrarModal()">
     <div class="modal-content" (click)="$event.stopPropagation()">
-      <div class="modal-header-colored blue-bg">
+      <div class="modal-header-custom">
         <h3>Detalle de Factura</h3>
         <button class="close-btn" (click)="cerrarModal()">
           <lucide-icon name="x" [size]="20"></lucide-icon>

--- a/libs/restaurante/restaurante/src/lib/pages/caja-buscar-page/caja-buscar-page.component.scss
+++ b/libs/restaurante/restaurante/src/lib/pages/caja-buscar-page/caja-buscar-page.component.scss
@@ -168,19 +168,17 @@
     animation: slideUp 0.2s ease-out;
   }
 
-  .modal-header-colored {
-    margin: calc(var(--space-6) * -1) calc(var(--space-6) * -1) 0;
-    padding: var(--space-4) var(--space-6);
+  .modal-header-custom {
     display: flex; justify-content: space-between; align-items: center;
-    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-    color: var(--color-surface-primary);
-
-    &.blue-bg { background-color: var(--color-info); }
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: var(--space-4);
+    color: var(--color-text-primary);
 
     h3 { margin: 0; font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); }
     .close-btn {
-      background: none; border: none; color: inherit; cursor: pointer; opacity: 0.8;
-      &:hover { opacity: 1; }
+      background: none; border: none; color: inherit; cursor: pointer; opacity: 0.7;
+      display: flex; align-items: center; justify-content: center;
+      &:hover { opacity: 1; color: var(--color-danger); }
     }
   }
 


### PR DESCRIPTION

## Descripción
Este PR soluciona un problema visual (inconsistencia de UI) en el modal de detalle de facturas de la sección de Búsqueda de Caja, adaptando sus estilos para que respeten la paleta de colores oscuros del diseño global de Gastrosena.

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ x] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [x ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ x] `nx affected:lint --base=develop` → 0 errores
- [x ] `nx affected:test --base=develop` → 0 fallos
- [ x] PR tiene menos de 400 líneas modificadas
- [x ] Un solo scope tocado
- [ x] Todo componente nuevo tiene su `.spec.ts`
- [x ] Sin `any` en TypeScript
- [x ] Sin estilos inline en templates
- [x ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
Eliminación de colores invasivos: Se removió la clase blue-bg y su fondo de color azul sólido (--color-info) de la cabecera del modal, el cual desentonaba fuertemente con el tema oscuro general.
Estandarización de colores: La cabecera del modal ahora utiliza de fondo el color de superficie primario (--color-surface-primary) y el texto respeta el blanco/gris predeterminado del sistema (--color-text-primary).
Mejora en separación y usabilidad: Se reemplazó el color de fondo invasivo por un borde inferior sutil (--color-border) para enmarcar limpiamente el título del modal. Además, se afinaron los estilos del botón de "Cerrar" (X) para que reaccione con color de peligro (--color-danger) al pasar el ratón (hover), mejorando el feedback al usuario.