### PR TITLE
Feat/restaurante bar integracion

### DIFF
--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
@@ -108,8 +108,16 @@ export class RestauranteFacade {
         const todasLasRecetas = [...cocina, ...bar];
         const menuMapeado: ProductoMenu[] = todasLasRecetas.filter(r => r.activo !== false).map(r => {
           let cat = 'plato_fuerte';
+          let subcat: string | undefined = undefined;
           const catNombre = (r.nombreCategoria || '').toLowerCase();
-          if (catNombre.includes('bebida')) cat = 'bebidas';
+          
+          if (catNombre.includes('bebida')) {
+            cat = 'bebidas';
+            if (catNombre.includes('caliente')) subcat = 'calientes';
+            else if (catNombre.includes('fria') || catNombre.includes('fría')) subcat = 'frias';
+            else if (catNombre.includes('sin alcohol')) subcat = 'sin_alcohol';
+            else if (catNombre.includes('con alcohol') || catNombre.includes('licor')) subcat = 'con_alcohol';
+          }
           else if (catNombre.includes('entrada')) cat = 'entrada';
           else if (catNombre.includes('postre')) cat = 'postre';
 
@@ -120,7 +128,8 @@ export class RestauranteFacade {
             tiempoPreparacion: r.tiempoPreparacion,
             temperatura: r.temperatura,
             image: r.urlImagen || 'https://images.unsplash.com/photo-1546069901-ba9599a7e63c?w=300&q=80',
-            category: cat
+            category: cat,
+            subcategory: subcat
           };
         });
         this._productosMenu.set(menuMapeado);

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
@@ -100,9 +100,13 @@ export class RestauranteFacade {
   }
 
   cargarMenu(): void {
-    this.restauranteService.obtenerRecetas().subscribe({
-      next: (recetas) => {
-        const menuMapeado: ProductoMenu[] = recetas.filter(r => r.activo !== false).map(r => {
+    forkJoin({
+      cocina: this.restauranteService.obtenerRecetas().pipe(catchError(() => of([]))),
+      bar: this.restauranteService.obtenerRecetasBar().pipe(catchError(() => of([])))
+    }).subscribe({
+      next: ({ cocina, bar }) => {
+        const todasLasRecetas = [...cocina, ...bar];
+        const menuMapeado: ProductoMenu[] = todasLasRecetas.filter(r => r.activo !== false).map(r => {
           let cat = 'plato_fuerte';
           const catNombre = (r.nombreCategoria || '').toLowerCase();
           if (catNombre.includes('bebida')) cat = 'bebidas';
@@ -122,7 +126,7 @@ export class RestauranteFacade {
         this._productosMenu.set(menuMapeado);
       },
       error: (err) => {
-        console.error('[RestauranteFacade] Error al cargar menú (recetas):', err);
+        console.error('[RestauranteFacade] Error fatal al cargar menú:', err);
       }
     });
   }

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.service.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.service.ts
@@ -21,11 +21,16 @@ export class RestauranteService {
   private readonly cajaUrl = '/api/caja';
   private readonly facturasUrl = '/api/facturas';
   private readonly recetasUrl = 'http://localhost:8082/api/recetas';
+  private readonly barRecetasUrl = 'http://localhost:8086/api/barybarismo/recetas';
 
-  // ── Recetas (Cocina) ────────────────────────────────────────────────────────
+  // ── Recetas (Cocina y Bar) ──────────────────────────────────────────────────
 
   obtenerRecetas(): Observable<RecetaResponseDTO[]> {
     return this.http.get<RecetaResponseDTO[]>(this.recetasUrl);
+  }
+
+  obtenerRecetasBar(): Observable<RecetaResponseDTO[]> {
+    return this.http.get<RecetaResponseDTO[]>(this.barRecetasUrl);
   }
 
   // ── Mesas — lectura ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Descripción
Título: feat(restaurante): integrar recetas dinámicas de bar y barismo en el menú

Descripción General: Se completó la conexión del menú del módulo de Restaurante con el microservicio de Bar y Barismo, logrando mostrar en una misma vista tanto los platos de comida como las bebidas, y habilitando sus filtros correspondientes.

## Tipo de cambio
- [ x] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ x] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ x] `nx affected:lint --base=develop` → 0 errores
- [x ] `nx affected:test --base=develop` → 0 fallos
- [ x] PR tiene menos de 400 líneas modificadas
- [x ] Un solo scope tocado
- [x ] Todo componente nuevo tiene su `.spec.ts`
- [x ] Sin `any` en TypeScript
- [x ] Sin estilos inline en templates
- [ x] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
✨ Cambios Implementados:

Doble Conexión Concurrente: Se modificó restaurante.facade.ts implementando forkJoin para hacer solicitudes simultáneas a Cocina y a Bar (http://localhost:8086/api/barybarismo/recetas).
Resiliencia (catchError): Se añadió protección a las llamadas HTTP; si un microservicio (Cocina o Bar) está apagado, el otro sigue mostrando sus productos con normalidad sin romper la interfaz.
Mapeo de Filtros de Bebidas: Se configuró un filtro automático que lee el nombre de la categoría del backend (ej. "Bebidas Frías") y lo transforma en las subcategorías internas (frias, calientes, sin_alcohol, con_alcohol), haciendo que los botones de filtro de la UI funcionen perfectamente.
