### PR TITLE
fix(inventario): resolver numero de GIL comprometido en afectaciones

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/procurement.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/procurement.api.ts
@@ -21,8 +21,8 @@ export interface CuentadanteGilResponse {
   cedula: string;
 }
 
-/** GilResponse — estado: BORRADOR | EMITIDO | ENVIADO_PROVEEDOR | VERIFICADO | CERRADO */
-export type EstadoGil = 'BORRADOR' | 'EMITIDO' | 'ENVIADO_PROVEEDOR' | 'VERIFICADO' | 'CERRADO';
+/** GilResponse — estado: BORRADOR | EMITIDO | ENVIADO_PROVEEDOR | VERIFICADO | COMPROMETIDO | CERRADO */
+export type EstadoGil = 'BORRADOR' | 'EMITIDO' | 'ENVIADO_PROVEEDOR' | 'VERIFICADO' | 'COMPROMETIDO' | 'CERRADO';
 
 export interface GilResponse {
   id:                      string;

--- a/libs/inventario/inventario/src/lib/models/solicitudes-gil.model.ts
+++ b/libs/inventario/inventario/src/lib/models/solicitudes-gil.model.ts
@@ -1,4 +1,4 @@
-export type EstadoGil = 'BORRADOR' | 'EMITIDO' | 'ENVIADO_PROVEEDOR' | 'VERIFICADO' | 'CERRADO';
+export type EstadoGil = 'BORRADOR' | 'EMITIDO' | 'ENVIADO_PROVEEDOR' | 'VERIFICADO' | 'COMPROMETIDO' | 'CERRADO';
 
 export interface CuentadanteGil {
   id?: string | number;

--- a/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/presupuesto-page/presupuesto-dashboard/presupuesto-dashboard.component.ts
@@ -139,13 +139,14 @@ export class PresupuestoDashboardComponent implements OnInit {
   ngOnInit(): void {
     this.facade.loadAll();
     // Para mostrar el número de GIL (no el UUID) en la tabla de afectaciones.
-    // Un GIL comprometido está en estado VERIFICADO o CERRADO (ya pasó conciliación);
-    // el GET sin estado no garantiza traerlos, así que se piden ambos explícitamente.
+    // Toda afectación nace de comprometer presupuesto, lo que deja el GIL en estado
+    // COMPROMETIDO; su única transición posterior es a CERRADO (al legalizar). Por eso
+    // se piden esos dos estados — nunca VERIFICADO, que no tiene compromiso asociado.
     forkJoin({
-      verificados: this.gilesService.getGiles({ estado: 'VERIFICADO', size: 200 }),
-      cerrados:    this.gilesService.getGiles({ estado: 'CERRADO', size: 200 }),
-    }).subscribe(({ verificados, cerrados }) =>
-      this.giles.set([...(verificados.content ?? []), ...(cerrados.content ?? [])]),
+      comprometidos: this.gilesService.getGiles({ estado: 'COMPROMETIDO', size: 200 }),
+      cerrados:      this.gilesService.getGiles({ estado: 'CERRADO', size: 200 }),
+    }).subscribe(({ comprometidos, cerrados }) =>
+      this.giles.set([...(comprometidos.content ?? []), ...(cerrados.content ?? [])]),
     );
   }
 


### PR DESCRIPTION
La columna GIL mostraba el UUID porque el dashboard cargaba los GILs en estado VERIFICADO/CERRADO, pero al comprometer presupuesto el GIL pasa a COMPROMETIDO (GilSolicitud.comprometer), estado que no se pedia. Ahora se cargan COMPROMETIDO y CERRADO (unicos estados con afectacion) y se agrega COMPROMETIDO al tipo EstadoGil, que faltaba en el frontend.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
