### PR TITLE
feat(inventario): UI de nota crédito por sobre-facturación (Fase 4)

### DIFF
--- a/libs/inventario/inventario/src/lib/components/registrar-nota-credito-modal/registrar-nota-credito-modal.component.html
+++ b/libs/inventario/inventario/src/lib/components/registrar-nota-credito-modal/registrar-nota-credito-modal.component.html
@@ -1,0 +1,109 @@
+@if (isOpen) {
+  <div class="modal-backdrop" (click)="onCancelar()">
+    <div class="modal-container" (click)="$event.stopPropagation()">
+      <div class="modal-content nc-modal">
+
+        <div class="modal-icon-wrapper modal-icon-wrapper--warning">
+          <span class="material-symbols-outlined">receipt_long</span>
+        </div>
+
+        <h2 class="modal-title">Registrar Nota Crédito</h2>
+        <p class="modal-text">
+          Complete los datos de la nota crédito por
+          <strong>sobre-facturación</strong>.
+          Los valores se prellena con la diferencia detectada.
+        </p>
+
+        <div class="nc-form">
+
+          <!-- Motivo -->
+          <div class="nc-form__field">
+            <label class="nc-form__label" for="nc-motivo">Motivo</label>
+            <select
+              id="nc-motivo"
+              class="nc-form__select"
+              [value]="motivo()"
+              (change)="onMotivo($any($event.target).value)"
+            >
+              @for (m of motivosDisponibles; track m.valor) {
+                <option [value]="m.valor">{{ m.etiqueta }}</option>
+              }
+            </select>
+          </div>
+
+          <!-- Fecha de emisión -->
+          <div class="nc-form__field">
+            <label class="nc-form__label" for="nc-fecha">Fecha de emisión</label>
+            <input
+              id="nc-fecha"
+              type="date"
+              class="nc-form__input"
+              [value]="fechaEmision()"
+              (input)="onFecha($any($event.target).value)"
+            />
+          </div>
+
+          <!-- Línea: productoId -->
+          <div class="nc-form__field">
+            <label class="nc-form__label" for="nc-producto">Producto / Ítem GIL</label>
+            <input
+              id="nc-producto"
+              type="text"
+              class="nc-form__input"
+              readonly
+              [value]="productoId()"
+            />
+          </div>
+
+          <!-- Línea: cantidad y valor unitario -->
+          <div class="nc-form__row">
+            <div class="nc-form__field">
+              <label class="nc-form__label" for="nc-cantidad">Cantidad</label>
+              <input
+                id="nc-cantidad"
+                type="number"
+                min="0"
+                class="nc-form__input"
+                [value]="cantidad()"
+                (input)="onCantidad($any($event.target).value)"
+              />
+            </div>
+            <div class="nc-form__field">
+              <label class="nc-form__label" for="nc-precio">Valor unitario (COP)</label>
+              <input
+                id="nc-precio"
+                type="number"
+                min="0"
+                class="nc-form__input"
+                [value]="valorUnitario()"
+                (input)="onValorUnitario($any($event.target).value)"
+              />
+            </div>
+          </div>
+
+          <!-- Resumen -->
+          <div class="nc-summary">
+            <span class="nc-summary__label">Total nota crédito</span>
+            <span class="nc-summary__value">
+              {{ valorTotal() | currency:'COP':'symbol-narrow':'1.0-0' }}
+            </span>
+          </div>
+
+        </div>
+
+        <div class="modal-actions">
+          <button class="btn-cancel" type="button" (click)="onCancelar()">Cancelar</button>
+          <button
+            class="btn-confirm"
+            type="button"
+            [disabled]="!esValido()"
+            (click)="onConfirmar()"
+          >
+            Registrar nota crédito
+          </button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+}

--- a/libs/inventario/inventario/src/lib/components/registrar-nota-credito-modal/registrar-nota-credito-modal.component.scss
+++ b/libs/inventario/inventario/src/lib/components/registrar-nota-credito-modal/registrar-nota-credito-modal.component.scss
@@ -1,0 +1,75 @@
+.nc-modal {
+  width: 100%;
+  max-width: 480px;
+}
+
+.nc-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1.25rem;
+  text-align: left;
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  &__row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+  }
+
+  &__label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text-secondary, #6b7280);
+  }
+
+  &__input,
+  &__select {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: 0.5rem;
+    font-size: 0.9375rem;
+    background: var(--color-surface, #fff);
+    color: var(--color-text, #111827);
+    outline: none;
+    transition: border-color 0.15s;
+
+    &:focus {
+      border-color: var(--color-primary, #4f46e5);
+    }
+
+    &[readonly] {
+      background: var(--color-surface-alt, #f9fafb);
+      color: var(--color-text-secondary, #6b7280);
+      cursor: not-allowed;
+    }
+  }
+}
+
+.nc-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: var(--color-surface-alt, #f9fafb);
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  margin-top: 0.25rem;
+
+  &__label {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary, #6b7280);
+    font-weight: 500;
+  }
+
+  &__value {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: var(--color-primary, #4f46e5);
+  }
+}

--- a/libs/inventario/inventario/src/lib/components/registrar-nota-credito-modal/registrar-nota-credito-modal.component.ts
+++ b/libs/inventario/inventario/src/lib/components/registrar-nota-credito-modal/registrar-nota-credito-modal.component.ts
@@ -1,0 +1,114 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ConciliacionGilDiferencia, Factura, MotivoNotaCredito, RegistrarNotaCreditoRequest } from '../../models/facturas.model';
+
+@Component({
+  selector: 'inventario-registrar-nota-credito-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './registrar-nota-credito-modal.component.html',
+  styleUrl: './registrar-nota-credito-modal.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RegistrarNotaCreditoModalComponent implements OnChanges {
+  @Input() isOpen = false;
+  @Input() factura: Factura | null = null;
+  /** Diferencia SOBREFACTURACION que origina la nota crédito */
+  @Input() diferencia: ConciliacionGilDiferencia | null = null;
+
+  @Output() confirmar = new EventEmitter<RegistrarNotaCreditoRequest>();
+  @Output() cancelar  = new EventEmitter<void>();
+
+  readonly motivosDisponibles: Array<{ valor: MotivoNotaCredito; etiqueta: string }> = [
+    { valor: 'SOBREFACTURACION',  etiqueta: 'Sobre-facturación' },
+    { valor: 'DEVOLUCION',        etiqueta: 'Devolución' },
+    { valor: 'DESCUENTO',         etiqueta: 'Descuento' },
+    { valor: 'ANULACION_PARCIAL', etiqueta: 'Anulación parcial' },
+  ];
+
+  motivo        = signal<MotivoNotaCredito>('SOBREFACTURACION');
+  fechaEmision  = signal<string>(this.hoy());
+  productoId    = signal<string>('');
+  cantidad      = signal<number>(0);
+  valorUnitario = signal<number>(0);
+
+  valorTotal = computed(() => this.cantidad() * this.valorUnitario());
+
+  ngOnChanges(): void {
+    if (this.isOpen && this.diferencia) {
+      const dif = this.diferencia;
+      const cantidadSobrefacturada = dif.cantidadFactura - (dif.cantidadRecibida ?? dif.cantidadGil);
+      this.motivo.set('SOBREFACTURACION');
+      this.fechaEmision.set(this.hoy());
+      this.productoId.set(dif.gilItemId);
+      this.cantidad.set(Math.max(0, cantidadSobrefacturada));
+      this.valorUnitario.set(dif.precioUnitarioFactura);
+    }
+  }
+
+  onMotivo(valor: string): void {
+    this.motivo.set(valor as MotivoNotaCredito);
+  }
+
+  onFecha(valor: string): void {
+    this.fechaEmision.set(valor);
+  }
+
+  onCantidad(valor: string): void {
+    const n = parseFloat(valor);
+    this.cantidad.set(isNaN(n) || n < 0 ? 0 : n);
+  }
+
+  onValorUnitario(valor: string): void {
+    const n = parseFloat(valor);
+    this.valorUnitario.set(isNaN(n) || n < 0 ? 0 : n);
+  }
+
+  esValido(): boolean {
+    return !!(
+      this.factura &&
+      this.productoId().trim() &&
+      this.cantidad() > 0 &&
+      this.valorUnitario() > 0 &&
+      this.fechaEmision()
+    );
+  }
+
+  onConfirmar(): void {
+    const f = this.factura;
+    if (!f || !this.esValido()) return;
+
+    const req: RegistrarNotaCreditoRequest = {
+      facturaId:    String(f.id),
+      cufeOrigen:   f.cufe,
+      motivo:       this.motivo(),
+      fechaEmision: this.fechaEmision(),
+      lineas: [
+        {
+          productoId:    this.productoId(),
+          cantidad:      this.cantidad(),
+          valorUnitario: this.valorUnitario(),
+        },
+      ],
+    };
+    this.confirmar.emit(req);
+  }
+
+  onCancelar(): void {
+    this.cancelar.emit();
+  }
+
+  private hoy(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+}

--- a/libs/inventario/inventario/src/lib/data-access/api/sourcing.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/sourcing.api.ts
@@ -15,6 +15,45 @@ export interface FacturaLineaResponse {
   total: number;
 }
 
+export interface NotaCreditoLineaResponse {
+  productoId:    string;
+  cantidad:      number;
+  valorUnitario: number;
+  valorTotal:    number;
+}
+
+export interface NotaCreditoResponse {
+  id:           string;
+  facturaId:    string;
+  cufeOrigen:   string;
+  motivo:       string;
+  fechaEmision: string;
+  estado:       string;
+  valorTotal:   number;
+  lineas:       NotaCreditoLineaResponse[];
+}
+
+export interface RegistrarNotaCreditoApiRequest {
+  facturaId:    string;
+  cufeOrigen:   string;
+  motivo:       string;
+  fechaEmision: string;
+  lineas: Array<{
+    productoId:    string;
+    cantidad:      number;
+    valorUnitario: number;
+  }>;
+}
+
+export interface ResolverNotaCreditoRequest {
+  notaCreditoIds: string[];
+}
+
+export interface ResolverNotaCreditoResponse {
+  conciliacionId: string;
+  estado:         string;
+}
+
 export interface FacturaResponse {
   id: string;
   numeroFactura: string;
@@ -36,6 +75,7 @@ export interface FacturaResponse {
   total: number;
   instructorId?: string;
   motivoAnulacion?: string | null;
+  valorNetoAPagar?: number;
 }
 
 export interface FacturaPagedResponse {

--- a/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/facturas.facade.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
-import { finalize, catchError, of } from 'rxjs';
-import { Factura, FacturaFiltros, FacturaKpis, FacturaPaginacion, SolicitudGIL, ConciliacionGil, FacturaFormDto, GilPickerItem } from '../models/facturas.model';
+import { finalize, catchError, of, Observable } from 'rxjs';
+import { Factura, FacturaFiltros, FacturaKpis, FacturaPaginacion, SolicitudGIL, ConciliacionGil, FacturaFormDto, GilPickerItem, NotaCredito, RegistrarNotaCreditoRequest } from '../models/facturas.model';
 import { FacturasService } from './services/facturas.service';
 import { KardexFacade } from './kardex.facade';
 import { ActualizarFacturaRequest } from './api/sourcing.api';
@@ -375,6 +375,42 @@ export class FacturasFacade {
         finalize(() => this._loading.set(false))
       )
       .subscribe(res => { if (res !== null) this._conciliacionGil.set(res); });
+  }
+
+  registrarNotaCredito(req: RegistrarNotaCreditoRequest): Observable<NotaCredito> {
+    return this.svc.registrarNotaCredito(req).pipe(
+      catchError(() => {
+        this._error.set('Error al registrar la nota crédito');
+        return of(null as unknown as NotaCredito);
+      }),
+    );
+  }
+
+  resolverConNotaCredito(
+    conciliacionId: string,
+    gilItemId:      string,
+    notaCreditoIds: string[],
+  ): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.svc.resolverConNotaCredito(conciliacionId, gilItemId, notaCreditoIds)
+      .pipe(
+        catchError(() => {
+          this._error.set('Error al resolver la diferencia con nota crédito');
+          return of(null);
+        }),
+        finalize(() => this._loading.set(false)),
+      )
+      .subscribe(res => {
+        if (res !== null) {
+          // Reload both factura and conciliacion to reflect valorNetoAPagar and resuelta state
+          const factura = this._facturaSeleccionada();
+          if (factura) {
+            this.cargarFactura(String(factura.id));
+            this.intentarCargarConciliacion(String(factura.id));
+          }
+        }
+      });
   }
 
   vincularInstructorOrden(ordenCompra: string, instructorId: string): void {

--- a/libs/inventario/inventario/src/lib/data-access/mappers/sourcing.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/sourcing.mapper.ts
@@ -1,6 +1,6 @@
-import { Factura, FacturaFormDto, ConciliacionGil } from '../../models/facturas.model';
+import { Factura, FacturaFormDto, ConciliacionGil, NotaCredito, MotivoNotaCredito } from '../../models/facturas.model';
 import { SolicitudGil, BienSolicitud, CuentadanteGil } from '../../models/solicitudes-gil.model';
-import { BackendDateArray, FacturaLineaResponse, FacturaResponse, GilResponse, RegistrarFacturaRequest, ConciliacionGilResponse, DetalleGilResponse } from '../api/sourcing.api';
+import { BackendDateArray, FacturaLineaResponse, FacturaResponse, GilResponse, RegistrarFacturaRequest, ConciliacionGilResponse, DetalleGilResponse, NotaCreditoResponse } from '../api/sourcing.api';
 
 function backendDateToIso(date: BackendDateArray | string | undefined | null): string {
   if (!date) return '';
@@ -48,6 +48,25 @@ export function facturaFromApi(dto: FacturaResponse): Factura {
     infoBancariaBanco: dto.infoBancariaBanco ?? undefined,
     infoBancariaCuenta: dto.infoBancariaCuenta ?? undefined,
     infoBancariaTipo: dto.infoBancariaTipo ?? undefined,
+    valorNetoAPagar: dto.valorNetoAPagar,
+  };
+}
+
+export function notaCreditoFromApi(dto: NotaCreditoResponse): NotaCredito {
+  return {
+    id:           dto.id,
+    facturaId:    dto.facturaId,
+    cufeOrigen:   dto.cufeOrigen,
+    motivo:       dto.motivo as MotivoNotaCredito,
+    fechaEmision: dto.fechaEmision,
+    estado:       dto.estado,
+    valorTotal:   dto.valorTotal,
+    lineas: dto.lineas.map(l => ({
+      productoId:    l.productoId,
+      cantidad:      l.cantidad,
+      valorUnitario: l.valorUnitario,
+      valorTotal:    l.valorTotal,
+    })),
   };
 }
 

--- a/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/facturas.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { forkJoin, Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { Factura, FacturaFiltros, FacturaKpis, FacturaPaginacion, SolicitudGIL, EstadoGIL, ConciliacionGil, FacturaFormDto, GilPickerItem } from '../../models/facturas.model';
+import { Factura, FacturaFiltros, FacturaKpis, FacturaPaginacion, SolicitudGIL, EstadoGIL, ConciliacionGil, FacturaFormDto, GilPickerItem, NotaCredito, RegistrarNotaCreditoRequest } from '../../models/facturas.model';
 import {
   ActualizarFacturaRequest,
   AnularFacturaRequest,
@@ -13,9 +13,13 @@ import {
   ConciliarRequest,
   ResolverDiferenciaGilRequest,
   VincularInstructorRequest,
+  NotaCreditoResponse,
+  RegistrarNotaCreditoApiRequest,
+  ResolverNotaCreditoRequest,
+  ResolverNotaCreditoResponse,
 } from '../api/sourcing.api';
 import { BienGilResponse, GilResponse } from '../api/procurement.api';
-import { facturaFromApi, conciliacionGilFromApi, facturaFormToRequest } from '../mappers/sourcing.mapper';
+import { facturaFromApi, conciliacionGilFromApi, facturaFormToRequest, notaCreditoFromApi } from '../mappers/sourcing.mapper';
 
 const API = '/api/v1';
 
@@ -249,6 +253,38 @@ export class FacturasService {
       }),
       catchError(err => throwError(() => err))
     );
+  }
+
+  /** POST /api/v1/notas-credito — registra una nota crédito por sobre-facturación */
+  registrarNotaCredito(req: RegistrarNotaCreditoRequest): Observable<NotaCredito> {
+    const body: RegistrarNotaCreditoApiRequest = {
+      facturaId:    req.facturaId,
+      cufeOrigen:   req.cufeOrigen,
+      motivo:       req.motivo,
+      fechaEmision: req.fechaEmision,
+      lineas:       req.lineas,
+    };
+    return this.http
+      .post<NotaCreditoResponse>(`${API}/notas-credito`, body)
+      .pipe(
+        map(notaCreditoFromApi),
+        catchError(err => throwError(() => err)),
+      );
+  }
+
+  /** POST /api/v1/conciliaciones/{conciliacionId}/detalles/{gilItemId}/resolver-nota-credito */
+  resolverConNotaCredito(
+    conciliacionId: string,
+    gilItemId:      string,
+    notaCreditoIds: string[],
+  ): Observable<ResolverNotaCreditoResponse> {
+    const body: ResolverNotaCreditoRequest = { notaCreditoIds };
+    return this.http
+      .post<ResolverNotaCreditoResponse>(
+        `${API}/conciliaciones/${conciliacionId}/detalles/${gilItemId}/resolver-nota-credito`,
+        body,
+      )
+      .pipe(catchError(err => throwError(() => err)));
   }
 
   /** Mapea GilResponse al tipo SolicitudGIL que usa la FacturasFacade.

--- a/libs/inventario/inventario/src/lib/models/facturas.model.ts
+++ b/libs/inventario/inventario/src/lib/models/facturas.model.ts
@@ -51,6 +51,7 @@ export interface Factura {
   valorRetencionZese?: number;
   motivoAnulacion?: string;
   proveedorBeneficiarioZese?: boolean;
+  valorNetoAPagar?: number;
   infoBancariaBanco?: string;
   infoBancariaCuenta?: string;
   infoBancariaTipo?: InfoBancariaTipo;
@@ -111,6 +112,44 @@ export interface FacturaFormDto {
     cantidad: number;
     precioUnitario: number;
     porcentajeIva: number;
+  }>;
+}
+
+// ─── Nota Crédito ────────────────────────────────────────────────────────────
+
+export type MotivoNotaCredito =
+  | 'SOBREFACTURACION'
+  | 'DEVOLUCION'
+  | 'DESCUENTO'
+  | 'ANULACION_PARCIAL';
+
+export interface LineaNotaCredito {
+  productoId:    string;
+  cantidad:      number;
+  valorUnitario: number;
+  valorTotal:    number;
+}
+
+export interface NotaCredito {
+  id:            string;
+  facturaId:     string;
+  cufeOrigen:    string;
+  motivo:        MotivoNotaCredito;
+  fechaEmision:  string;
+  estado:        string;
+  valorTotal:    number;
+  lineas:        LineaNotaCredito[];
+}
+
+export interface RegistrarNotaCreditoRequest {
+  facturaId:    string;
+  cufeOrigen:   string;
+  motivo:       MotivoNotaCredito;
+  fechaEmision: string;
+  lineas: Array<{
+    productoId:    string;
+    cantidad:      number;
+    valorUnitario: number;
   }>;
 }
 

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.html
@@ -222,10 +222,28 @@
             </div>
           </div>
 
+          @if (f.valorNetoAPagar !== null && f.valorNetoAPagar !== undefined && f.valorNetoAPagar < f.total) {
+            <div class="summary__body summary__body--nc">
+              <div class="summary-row">
+                <span class="summary-row__label">Total FEL</span>
+                <span class="summary-row__value font-medium">{{ f.total | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
+              </div>
+              <div class="summary-row summary-row--deduction">
+                <span class="summary-row__label">
+                  <span class="material-symbols-outlined summary-row__icon">remove_circle</span>
+                  Notas crédito
+                </span>
+                <span class="summary-row__value font-medium text-danger">
+                  − {{ (f.total - f.valorNetoAPagar) | currency:'COP':'symbol-narrow':'1.0-0' }}
+                </span>
+              </div>
+            </div>
+          }
+
           <div class="summary__footer">
-            <span class="summary__footer-label">Total a Pagar</span>
+            <span class="summary__footer-label">{{ f.valorNetoAPagar !== null && f.valorNetoAPagar !== undefined && f.valorNetoAPagar < f.total ? 'Neto a pagar' : 'Total a Pagar' }}</span>
             <div class="text-right">
-              <span class="summary__footer-total">{{ f.total | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
+              <span class="summary__footer-total">{{ (f.valorNetoAPagar ?? f.total) | currency:'COP':'symbol-narrow':'1.0-0' }}</span>
               <p class="summary__footer-currency">COP • Pesos Colombianos</p>
             </div>
           </div>
@@ -247,14 +265,68 @@
           </div>
 
           @if (f.estado === 'REGISTRADA') {
-            <div class="gil-reconciliar-row">
-              <p class="gil-reconciliar-hint">
-                ¿Faltó el conteo físico? Rehacé la conciliación: el conteo se carga con lo facturado y podés ajustarlo.
-              </p>
-              <restaurant-button variant="surface" [disabled]="loading()" (click)="reconciliar()">
-                Rehacer conciliación (con conteo)
-              </restaurant-button>
-            </div>
+            @if (!mostrarConteo()) {
+              <div class="gil-reconciliar-row">
+                <p class="gil-reconciliar-hint">
+                  ¿Lo recibido no coincide con lo facturado? Ajustá el conteo físico y volvé a conciliar.
+                </p>
+                <restaurant-button variant="surface" icon="checklist" (click)="abrirConteo()">
+                  Ajustar conteo físico
+                </restaurant-button>
+              </div>
+            } @else {
+              <div class="conteo-editor">
+                <div class="conteo-editor__head">
+                  <h5 class="conteo-editor__title">Conteo físico recibido</h5>
+                  <p class="conteo-editor__hint">
+                    Editá la cantidad realmente recibida por ítem. Se precargó con lo facturado.
+                  </p>
+                </div>
+
+                <div class="gil-table-wrapper">
+                  <table class="gil-table">
+                    <thead>
+                      <tr>
+                        <th>Ítem</th>
+                        <th class="text-right">Cant. solicitada (GIL)</th>
+                        <th class="text-right">Cant. recibida</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      @for (b of gilBienes(); track $index) {
+                        <tr>
+                          <td>
+                            <span class="conteo-item-code">{{ b.codigoSena }}</span>
+                            <span class="conteo-item-name">{{ b.descripcion }}</span>
+                          </td>
+                          <td class="text-right text-secondary">{{ b.cantidad }} {{ b.unidadMedida }}</td>
+                          <td class="text-right">
+                            @if (b.productoId; as pid) {
+                              <input
+                                type="number"
+                                min="0"
+                                class="gil-obs-input conteo-input"
+                                [value]="conteoRecibido()[pid] ?? ''"
+                                (input)="setConteo(pid, $event)"
+                              />
+                            } @else {
+                              <span class="text-secondary">Sin producto vinculado</span>
+                            }
+                          </td>
+                        </tr>
+                      }
+                    </tbody>
+                  </table>
+                </div>
+
+                <div class="conteo-editor__actions">
+                  <button class="btn-cancel" type="button" (click)="cerrarConteo()">Cancelar</button>
+                  <button class="gil-resolve-btn" type="button" [disabled]="loading()" (click)="confirmarConteoYConciliar()">
+                    Confirmar conteo y conciliar
+                  </button>
+                </div>
+              </div>
+            }
           }
 
           @if (c.diferencias.length === 0) {
@@ -289,12 +361,24 @@
                         @if (dif.resuelta) {
                           <span class="badge badge--success-soft">Resuelta</span>
                         } @else {
-                          <span class="badge badge--tertiary">Pendiente</span>
+                          <span class="badge" [ngClass]="tipoDiferencia(dif).clase" [title]="dif.observacion || ''">
+                            {{ tipoDiferencia(dif).label }}
+                          </span>
                         }
                       </td>
                       <td>
                         @if (dif.resuelta) {
                           <span class="gil-obs-text">{{ dif.observacion || '—' }}</span>
+                        } @else if (esSobrefacturacion(dif)) {
+                          <button
+                            class="gil-resolve-btn gil-resolve-btn--nc"
+                            type="button"
+                            [disabled]="loading()"
+                            (click)="abrirNotaCreditoModal(dif)"
+                          >
+                            <span class="material-symbols-outlined">receipt_long</span>
+                            Registrar nota crédito
+                          </button>
                         } @else {
                           <div class="gil-resolve-row">
                             <input
@@ -443,6 +527,15 @@
     </div>
   </div>
 }
+
+<!-- ── Modal: Registrar nota crédito ───────────────────────────────────── -->
+<inventario-registrar-nota-credito-modal
+  [isOpen]="notaCreditoModalAbierto()"
+  [factura]="factura()"
+  [diferencia]="diferenciaNotaCredito()"
+  (confirmar)="onConfirmarNotaCredito($event)"
+  (cancelar)="cerrarNotaCreditoModal()"
+/>
 
 <!-- ── Buscador de bien para asociar línea pendiente ───────────────────── -->
 @if (buscadorBienAbierto()) {

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.scss
@@ -870,6 +870,76 @@
   &:not(:disabled):hover { opacity: 0.85; }
 }
 
+// ── Rehacer conciliación / editor de conteo físico ──────────────────────────
+.gil-reconciliar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 0.75rem 1rem;
+  background: var(--color-superficie-contenedor-bajo);
+  border-radius: 0.75rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.gil-reconciliar-hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  flex: 1;
+  min-width: 16rem;
+}
+
+.conteo-editor {
+  border: 1px solid var(--color-contorno-variante, #bdcab9);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin: 0.5rem 0 1rem;
+  background: var(--color-superficie);
+
+  &__head { margin-bottom: 0.75rem; }
+
+  &__title {
+    margin: 0 0 0.25rem;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: var(--color-en-superficie);
+  }
+
+  &__hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+}
+
+.conteo-item-code {
+  display: block;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: var(--color-primario);
+  letter-spacing: 0.03em;
+}
+
+.conteo-item-name {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--color-en-superficie);
+}
+
+.conteo-input {
+  max-width: 6rem;
+  text-align: right;
+}
+
 .tooltip-container {
   position: relative;
   cursor: help;
@@ -1131,4 +1201,39 @@
     color: var(--color-terciario);
     font-size: var(--font-size-sm);
   }
+}
+
+// ── Nota crédito — botón en tabla de conciliación ───────────────────────────
+.gil-resolve-btn--nc {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: var(--color-terciario, #6d28d9);
+
+  .material-symbols-outlined {
+    font-size: 1rem;
+  }
+}
+
+// ── Resumen Fiscal — filas de notas crédito ──────────────────────────────────
+.summary__body--nc {
+  margin-bottom: 0.5rem;
+}
+
+.summary-row--deduction {
+  .summary-row__label {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--color-error, #dc2626);
+  }
+}
+
+.summary-row__icon {
+  font-size: 1rem;
+  vertical-align: middle;
+}
+
+.text-danger {
+  color: var(--color-error, #dc2626);
 }

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-detail/factura-detail.component.ts
@@ -4,9 +4,10 @@ import { FormsModule } from '@angular/forms';
 import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { ButtonComponent, DataTableComponent } from '@restaurant/shared/ui';
 import { BackButtonComponent } from '../../../components/back-button/back-button.component';
+import { RegistrarNotaCreditoModalComponent } from '../../../components/registrar-nota-credito-modal/registrar-nota-credito-modal.component';
 import { FacturasFacade } from '../../../data-access/facturas.facade';
 import { InventarioFacade } from '../../../data-access/inventario.facade';
-import { ConciliacionGilDiferencia, FacturaLinea } from '../../../models/facturas.model';
+import { ConciliacionGilDiferencia, FacturaLinea, RegistrarNotaCreditoRequest } from '../../../models/facturas.model';
 import { Bien } from '../../../models/inventario.model';
 
 /** Sentinel del backend para líneas de factura sin bien de catálogo asignado. */
@@ -15,7 +16,7 @@ const PRODUCTO_PENDIENTE = 'PENDIENTE-CATALOGO';
 @Component({
   selector: 'restaurant-factura-detail',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterModule, ButtonComponent, DataTableComponent, BackButtonComponent],
+  imports: [CommonModule, FormsModule, RouterModule, ButtonComponent, DataTableComponent, BackButtonComponent, RegistrarNotaCreditoModalComponent],
   templateUrl: './factura-detail.component.html',
   styleUrl: './factura-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -36,6 +37,11 @@ export class FacturaDetailPageComponent implements OnInit {
   observaciones   = signal<Record<string, string>>({});
   gilParaVincular = signal('');
 
+  // ── Editor de conteo físico (rehacer conciliación con cantidades reales) ──
+  mostrarConteo  = signal(false);
+  /** Conteo recibido editable, keyed por productoId. Pre-cargado con lo facturado. */
+  conteoRecibido = signal<Record<string, number | null>>({});
+
   constructor() {
     // Cargar los ítems del GIL conciliado para poder re-conciliar con conteo físico.
     effect(() => {
@@ -55,6 +61,10 @@ export class FacturaDetailPageComponent implements OnInit {
 
   showConfirmVerificar  = signal(false);
   showConfirmPagada     = signal(false);
+
+  // ── Nota crédito modal ────────────────────────────────────────────────────
+  notaCreditoModalAbierto  = signal(false);
+  diferenciaNotaCredito    = signal<ConciliacionGilDiferencia | null>(null);
 
   // ── Buscador de bien para asociar líneas pendientes ──
   buscadorBienAbierto  = signal(false);
@@ -148,20 +158,87 @@ export class FacturaDetailPageComponent implements OnInit {
     this.gilParaVincular.set('');
   }
 
-  /** Re-concilia la factura con su GIL actual, enviando el conteo (default = facturado). */
-  reconciliar(): void {
+  /** Abre el editor de conteo físico, precargando cada ítem con lo facturado (editable). */
+  abrirConteo(): void {
+    const init: Record<string, number | null> = {};
+    this.gilBienes().forEach(b => { if (b.productoId) init[b.productoId] = b.cantidad; });
+    this.conteoRecibido.set(init);
+    this.mostrarConteo.set(true);
+  }
+
+  cerrarConteo(): void {
+    this.mostrarConteo.set(false);
+  }
+
+  setConteo(productoId: string, event: Event): void {
+    const raw = (event.target as HTMLInputElement).value;
+    const num = raw === '' ? null : Number(raw);
+    const val = num === null || Number.isNaN(num) || num < 0 ? null : num;
+    this.conteoRecibido.update(c => ({ ...c, [productoId]: val }));
+  }
+
+  /** Re-concilia la factura con su GIL actual usando el conteo físico editado. */
+  confirmarConteoYConciliar(): void {
     const factura = this.factura();
     const c = this.conciliacionGil();
     if (!factura || !c?.gilId) return;
-    this.facade.conciliarFacturaGil(String(factura.id), c.gilId, this.buildConteoMap());
+    const map: Record<string, number> = {};
+    for (const [productoId, val] of Object.entries(this.conteoRecibido())) {
+      if (val !== null) map[productoId] = val;
+    }
+    this.facade.conciliarFacturaGil(String(factura.id), c.gilId, map);
+    this.mostrarConteo.set(false);
   }
 
   estaConciliada(diferencias: ConciliacionGilDiferencia[]): boolean {
     return diferencias.length === 0 || diferencias.every(d => d.resuelta);
   }
 
+  /**
+   * Clasifica el tipo de diferencia para mostrarlo como badge.
+   * Espeja el orden de ramas del backend (DetalleConciliacion.comparar).
+   */
+  tipoDiferencia(dif: ConciliacionGilDiferencia): { label: string; clase: string } {
+    if (dif.cantidadRecibida === null)              return { label: 'Falta conteo',      clase: 'badge--surface' };
+    if (dif.cantidadGil === 0 && dif.cantidadRecibida > 0) return { label: 'No solicitado', clase: 'badge--tertiary' };
+    if (dif.cantidadRecibida > dif.cantidadFactura) return { label: 'Exceso recepción',  clase: 'badge--orange' };
+    if (dif.cantidadRecibida < dif.cantidadFactura) return { label: 'Sobre-facturación', clase: 'badge--tertiary' };
+    if (dif.cantidadRecibida < dif.cantidadGil)     return { label: 'Entrega corta',     clase: 'badge--orange' };
+    return { label: 'Dif. precio/IVA', clase: 'badge--surface' };
+  }
+
   countPendientes(diferencias: ConciliacionGilDiferencia[]): number {
     return diferencias.filter(d => !d.resuelta).length;
+  }
+
+  esSobrefacturacion(dif: ConciliacionGilDiferencia): boolean {
+    return (
+      dif.cantidadRecibida !== null &&
+      dif.cantidadRecibida < dif.cantidadFactura
+    );
+  }
+
+  abrirNotaCreditoModal(dif: ConciliacionGilDiferencia): void {
+    this.diferenciaNotaCredito.set(dif);
+    this.notaCreditoModalAbierto.set(true);
+  }
+
+  cerrarNotaCreditoModal(): void {
+    this.notaCreditoModalAbierto.set(false);
+    this.diferenciaNotaCredito.set(null);
+  }
+
+  onConfirmarNotaCredito(req: RegistrarNotaCreditoRequest): void {
+    const c = this.conciliacionGil();
+    const dif = this.diferenciaNotaCredito();
+    if (!c || !dif) return;
+
+    this.cerrarNotaCreditoModal();
+    this.facade.registrarNotaCredito(req).subscribe(nc => {
+      if (nc?.id) {
+        this.facade.resolverConNotaCredito(c.id, dif.gilItemId, [nc.id]);
+      }
+    });
   }
 
   confirmarVerificar(): void {


### PR DESCRIPTION
Frontend de la nota crédito (Fase 4 del roadmap de sobre-facturación). Consume los endpoints backend ya mergeados.

## Cambios
- **Modelo/API/mapper**: `NotaCredito`, `LineaNotaCredito`, `MotivoNotaCredito`, `RegistrarNotaCreditoRequest`; `valorNetoAPagar` en factura.
- **Service/facade**: `registrarNotaCredito` (POST /api/v1/notas-credito) + `resolverConNotaCredito` (POST /api/v1/conciliaciones/{id}/detalles/{gilItemId}/resolver-nota-credito).
- **Modal** `registrar-nota-credito-modal`: precarga cantidad = facturada − recibida, precio = precioUnitarioFactura.
- **factura-detail**: diferencias SOBREFACTURACION muestran botón 'Registrar nota crédito' (en vez del input de observación). Al confirmar: registra NC → resuelve la diferencia → recarga.
- **Resumen Fiscal**: Total FEL / (−) Notas crédito / = Neto a pagar.

## Validación
`nx lint inventario` ✅ · `tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)