### PR TITLE
feat(inventario): wizard importación FEL + fixes UI (contrato, overflow bienes)

### DIFF
--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.html
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.html
@@ -7,6 +7,30 @@
     </div>
   </header>
 
+  <!-- Stepper -->
+  <nav class="wizard-steps" aria-label="Pasos de importación">
+    @for (p of pasos; track p.n) {
+      <button
+        type="button"
+        class="wizard-step"
+        [class.wizard-step--active]="paso() === p.n"
+        [class.wizard-step--done]="paso() > p.n"
+        [disabled]="!puedeAvanzar(p.n)"
+        (click)="irAPaso(p.n)"
+      >
+        <span class="wizard-step__num">
+          @if (paso() > p.n) {
+            <span class="material-symbols-outlined">check</span>
+          } @else {
+            {{ p.n }}
+          }
+        </span>
+        <span class="wizard-step__label">{{ p.label }}</span>
+      </button>
+    }
+  </nav>
+
+  <!-- Alertas globales (estado de importación / conciliación) -->
   @if (importStatus() !== 'idle') {
     <div class="alerts-container">
       @if (importStatus() === 'loading') {
@@ -15,7 +39,6 @@
           <span class="alert__text font-medium">Procesando {{ fileName() }}…</span>
         </div>
       }
-
       @if (importStatus() === 'error') {
         <div class="alert alert--error">
           <span class="material-symbols-outlined">error</span>
@@ -25,7 +48,6 @@
           </div>
         </div>
       }
-
       @if (importStatus() === 'success') {
         <div class="alert alert--success">
           <span class="material-symbols-outlined">check_circle</span>
@@ -35,75 +57,69 @@
     </div>
   }
 
-  <div class="import-grid">
-    <div class="upload-zone-wrapper">
-      <div class="field-group gil-vincular-field">
-        <label class="field-label">GIL a vincular (opcional)</label>
-        <select
-          class="field-input"
-          [value]="gilId()"
-          (change)="onGilSelect($event)"
-        >
-          <option value="">Sin GIL</option>
-          @for (gil of gilesDisponibles(); track gil.id) {
-            <option [value]="gil.id">{{ gil.numeroGil }} — {{ gil.destino }}</option>
-          }
-        </select>
-      </div>
-
-      <div
-        class="upload-zone"
-        [class.upload-zone--active]="isDragOver()"
-        (dragover)="onDragOver($event)"
-        (dragleave)="onDragLeave()"
-        (drop)="onDrop($event)"
-        (click)="fileInput.click()"
-      >
-        <div class="upload-zone__icon-wrapper">
-          <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1">
-            code
-          </span>
+  <!-- ══════════════════ PASO 1 · Subir XML ══════════════════ -->
+  @if (paso() === 1) {
+    <div class="import-grid">
+      <div class="upload-zone-wrapper">
+        <div class="field-group gil-vincular-field">
+          <label class="field-label">GIL a vincular (opcional)</label>
+          <select class="field-input" [value]="gilId()" (change)="onGilSelect($event)">
+            <option value="">Sin GIL</option>
+            @for (gil of gilesDisponibles(); track gil.id) {
+              <option [value]="gil.id">{{ gil.numeroGil }} — {{ gil.destino }}</option>
+            }
+          </select>
         </div>
-        <h3 class="upload-zone__title">Arrastrá el XML UBL 2.1 acá</h3>
-        <p class="upload-zone__subtitle">Solo archivos .xml · máximo 10 MB</p>
 
-        <button class="btn btn--primary" (click)="fileInput.click(); $event.stopPropagation()">
-          Seleccionar archivo
-        </button>
-
-        <input
-          #fileInput
-          type="file"
-          accept=".xml"
-          hidden
-          (change)="onFileInput($event)"
+        <div
+          class="upload-zone"
+          [class.upload-zone--active]="isDragOver()"
+          (dragover)="onDragOver($event)"
+          (dragleave)="onDragLeave()"
+          (drop)="onDrop($event)"
+          (click)="fileInput.click()"
         >
+          <div class="upload-zone__icon-wrapper">
+            <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1">code</span>
+          </div>
+          <h3 class="upload-zone__title">Arrastrá el XML UBL 2.1 acá</h3>
+          <p class="upload-zone__subtitle">Solo archivos .xml · máximo 10 MB</p>
+          <button class="btn btn--primary" (click)="fileInput.click(); $event.stopPropagation()">
+            Seleccionar archivo
+          </button>
+          <input #fileInput type="file" accept=".xml" hidden (change)="onFileInput($event)">
+        </div>
+      </div>
+
+      <div class="instructions-card">
+        <h3 class="instructions-card__title">
+          <span class="material-symbols-outlined">help</span>
+          ¿Cómo funciona?
+        </h3>
+        <ul class="instructions-list">
+          <li>
+            <div class="step-badge">1</div>
+            <p>Subí el XML de la factura electrónica original. El sistema extrae automáticamente los datos del documento.</p>
+          </li>
+          <li>
+            <div class="step-badge">2</div>
+            <p>Revisás los datos extraídos antes de continuar.</p>
+          </li>
+          <li>
+            <div class="step-badge">3</div>
+            <p>Vinculás un GIL y cruzás los ítems recibidos contra lo solicitado.</p>
+          </li>
+          <li>
+            <div class="step-badge">4</div>
+            <p>Confirmás el resultado del cruce y registrás la factura.</p>
+          </li>
+        </ul>
       </div>
     </div>
+  }
 
-    <div class="instructions-card">
-      <h3 class="instructions-card__title">
-        <span class="material-symbols-outlined">help</span>
-        ¿Cómo funciona?
-      </h3>
-      <ul class="instructions-list">
-        <li>
-          <div class="step-badge">1</div>
-          <p>Subí el XML de la factura electrónica original. El sistema extrae automáticamente los datos del documento.</p>
-        </li>
-        <li>
-          <div class="step-badge">2</div>
-          <p>Si ingresás un GIL, la factura quedará vinculada a esa gestión de inventario automáticamente.</p>
-        </li>
-        <li>
-          <div class="step-badge">3</div>
-          <p>Una vez procesada, podés revisar los datos extraídos antes de continuar.</p>
-        </li>
-      </ul>
-    </div>
-  </div>
-
-  @if (fileLoaded()) {
+  <!-- ══════════════════ PASO 2 · Revisar datos ══════════════════ -->
+  @if (paso() === 2 && facturaImportada()) {
     <div class="review-section">
       <h2 class="review-section__title">Datos de la factura importada</h2>
 
@@ -117,7 +133,6 @@
             <label class="field-label">CUFE</label>
             <input class="field-input field-input--readonly" readonly type="text" [value]="facturaImportada()?.cufe ?? ''"/>
           </div>
-
           <div class="field-group">
             <label class="field-label">Proveedor NIT</label>
             <input class="field-input field-input--readonly" readonly type="text" [value]="facturaImportada()?.proveedorNit ?? ''"/>
@@ -126,7 +141,6 @@
             <label class="field-label">Proveedor Nombre</label>
             <input class="field-input field-input--readonly" readonly type="text" [value]="facturaImportada()?.proveedorNombre ?? ''"/>
           </div>
-
           <div class="field-group">
             <label class="field-label">Fecha Emisión</label>
             <input class="field-input field-input--readonly" readonly type="text" [value]="facturaImportada()?.fechaEmision ?? ''"/>
@@ -139,7 +153,6 @@
             <label class="field-label">Estado</label>
             <input class="field-input field-input--readonly" readonly type="text" [value]="facturaImportada()?.estado ?? ''"/>
           </div>
-
           <div class="field-group">
             <label class="field-label">Orden de Compra</label>
             <input class="field-input field-input--readonly" readonly type="text" [value]="facturaImportada()?.ordenCompra ?? 'No reportada'"/>
@@ -152,7 +165,6 @@
             <label class="field-label">ZESE</label>
             <input class="field-input field-input--readonly" readonly type="text" [value]="facturaImportada()?.proveedorBeneficiarioZese ? 'Sí' : 'No'"/>
           </div>
-
           <div class="field-group">
             <label class="field-label">Banco</label>
             <input class="field-input field-input--readonly" readonly type="text" [value]="facturaImportada()?.infoBancariaBanco ?? 'No reportado'"/>
@@ -211,18 +223,14 @@
               <span class="summary-label">Subtotal</span>
               <span class="summary-value">{{ formatMoney(facturaImportada()?.subtotal) }}</span>
             </div>
-
             <div class="summary-divider"></div>
-
             @for (item of totalIvaPorTarifa(); track item.porcentaje) {
               <div class="summary-row summary-row--sm">
                 <span class="summary-label">IVA ({{ item.porcentaje }}%)</span>
                 <span class="summary-value">{{ formatMoney(item.valor) }}</span>
               </div>
             }
-
             <div class="summary-divider"></div>
-
             <div class="summary-row summary-row--sm">
               <span class="summary-label">Total IVA</span>
               <span class="summary-value">{{ formatMoney(facturaImportada()?.totalIva) }}</span>
@@ -232,7 +240,6 @@
               <span class="summary-value text-tertiary">-{{ formatMoney(facturaImportada()?.valorRetencionZese) }}</span>
             </div>
           </div>
-
           <div class="summary-card__footer">
             <span class="total-label">Total a Pagar</span>
             <span class="total-value">{{ formatMoney(facturaImportada()?.total) }}</span>
@@ -242,105 +249,130 @@
     </div>
   }
 
-  @if (showManualMapping()) {
-    <div class="matching-section">
-      <div class="matching-header">
-        <div>
-          <h2 class="matching-header__title">Cruce manual de ítems</h2>
-          <p class="matching-header__subtitle">
-            Verificá que cada ítem del GIL esté asignado al ítem correcto de la factura.
-            El sistema hace una asignación automática por descripción — podés corregirla.
-          </p>
-        </div>
-        <div class="matching-legend">
-          <span class="badge badge--green">Coincide</span>
-          <span class="badge badge--orange">Diferencia</span>
-          <span class="badge badge--gray">Sin asignar</span>
+  <!-- ══════════════════ PASO 3 · Vincular GIL y cruzar ══════════════════ -->
+  @if (paso() === 3 && facturaImportada()) {
+    <div class="review-section">
+      <h2 class="review-section__title">Vincular GIL y cruzar ítems</h2>
+
+      <div class="data-card">
+        <div class="field-group gil-vincular-field">
+          <label class="field-label">GIL a vincular</label>
+          <select class="field-input" [value]="gilId()" (change)="onGilSelect($event)">
+            <option value="">Sin GIL — registrar sin conciliar</option>
+            @for (gil of gilesDisponibles(); track gil.id) {
+              <option [value]="gil.id">{{ gil.numeroGil }} — {{ gil.destino }}</option>
+            }
+          </select>
         </div>
       </div>
 
-      <div class="table-card">
-        <div class="table-wrapper">
-          <table class="matching-table">
-            <thead>
-              <tr>
-                <th>Ítem GIL solicitado</th>
-                <th class="text-right">Cant. solicitada</th>
-                <th class="text-right">V. Unit. GIL</th>
-                <th>Ítem FEL recibido</th>
-                <th class="text-right">Cant. recibida</th>
-                <th class="text-right">V. Unit. FEL</th>
-                <th class="text-center">Estado</th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (bien of gilBienes(); track $index; let i = $index) {
-                <tr [class]="matchRowClass(i)">
-                  <td>
-                    <div class="item-cell">
-                      <span class="item-code">{{ bien.codigoSena }}</span>
-                      <span class="item-name">{{ bien.descripcion }}</span>
-                    </div>
-                  </td>
-                  <td class="text-right text-secondary">
-                    {{ bien.cantidad }} {{ bien.unidadMedida }}
-                  </td>
-                  <td class="text-right text-secondary">{{ formatMoney(bien.valorUnitario) }}</td>
-                  <td>
-                    <select
-                      class="field-input field-input--sm"
-                      [value]="manualLinks()[i] ?? ''"
-                      (change)="onLinkChange(i, $event)"
-                      (click)="$event.stopPropagation()"
-                    >
-                      <option value="" [selected]="manualLinks()[i] === null || manualLinks()[i] === undefined">— Sin asignar —</option>
-                      @for (linea of facturaImportada()?.lineas ?? []; track $index; let fi = $index) {
-                        <option [value]="fi" [selected]="manualLinks()[i] === fi">{{ fi + 1 }}. {{ linea.descripcion }}</option>
-                      }
-                    </select>
-                  </td>
-                  <td class="text-right">
-                    <input
-                      type="number"
-                      min="0"
-                      class="field-input field-input--sm count-input"
-                      [value]="cantidadesRecibidas()[i] ?? ''"
-                      (input)="onCantidadRecibidaChange(i, $event)"
-                      (click)="$event.stopPropagation()"
-                    />
-                  </td>
-                  <td class="text-right font-bold">
-                    @if (manualLinks()[i] !== null && manualLinks()[i] !== undefined) {
-                      <span [class.text-diferencia]="(getLinea(manualLinks()[i]!)?.precioUnitario ?? 0) !== bien.valorUnitario">
-                        {{ formatMoney(getLinea(manualLinks()[i]!)?.precioUnitario) }}
-                      </span>
-                    } @else {
-                      <span class="text-secondary">—</span>
-                    }
-                  </td>
-                  <td class="text-center">
-                    <span [class]="matchStatusClass(i)">{{ matchStatusLabel(i) }}</span>
-                  </td>
-                </tr>
-              }
-            </tbody>
-          </table>
+      @if (!gilId()) {
+        <div class="alert alert--info">
+          <span class="material-symbols-outlined">info</span>
+          <span class="alert__text">Seleccioná un GIL para cruzar los ítems recibidos, o finalizá sin conciliar para solo registrar la factura.</span>
         </div>
-      </div>
+      }
+
+      @if (showManualMapping()) {
+        <div class="matching-section">
+          <div class="matching-header">
+            <div>
+              <h2 class="matching-header__title">Cruce de ítems</h2>
+              <p class="matching-header__subtitle">
+                Verificá que cada ítem del GIL esté asignado al ítem correcto de la factura y ajustá la cantidad recibida.
+                El sistema hace una asignación automática por descripción — podés corregirla.
+              </p>
+            </div>
+            <div class="matching-legend">
+              <span class="badge badge--green">Coincide</span>
+              <span class="badge badge--orange">Diferencia</span>
+              <span class="badge badge--gray">Sin asignar</span>
+            </div>
+          </div>
+
+          <div class="table-card">
+            <div class="table-wrapper">
+              <table class="matching-table">
+                <thead>
+                  <tr>
+                    <th>Ítem GIL solicitado</th>
+                    <th class="text-right">Cant. solicitada</th>
+                    <th class="text-right">V. Unit. GIL</th>
+                    <th>Ítem FEL recibido</th>
+                    <th class="text-right">Cant. recibida</th>
+                    <th class="text-right">V. Unit. FEL</th>
+                    <th class="text-center">Estado</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (bien of gilBienes(); track $index; let i = $index) {
+                    <tr [class]="matchRowClass(i)">
+                      <td>
+                        <div class="item-cell">
+                          <span class="item-code">{{ bien.codigoSena }}</span>
+                          <span class="item-name">{{ bien.descripcion }}</span>
+                        </div>
+                      </td>
+                      <td class="text-right text-secondary">{{ bien.cantidad }} {{ bien.unidadMedida }}</td>
+                      <td class="text-right text-secondary">{{ formatMoney(bien.valorUnitario) }}</td>
+                      <td>
+                        <select
+                          class="field-input field-input--sm"
+                          [value]="manualLinks()[i] ?? ''"
+                          (change)="onLinkChange(i, $event)"
+                          (click)="$event.stopPropagation()"
+                        >
+                          <option value="" [selected]="manualLinks()[i] === null || manualLinks()[i] === undefined">— Sin asignar —</option>
+                          @for (linea of facturaImportada()?.lineas ?? []; track $index; let fi = $index) {
+                            <option [value]="fi" [selected]="manualLinks()[i] === fi">{{ fi + 1 }}. {{ linea.descripcion }}</option>
+                          }
+                        </select>
+                      </td>
+                      <td class="text-right">
+                        <input
+                          type="number"
+                          min="0"
+                          class="field-input field-input--sm count-input"
+                          [value]="cantidadesRecibidas()[i] ?? ''"
+                          (input)="onCantidadRecibidaChange(i, $event)"
+                          (click)="$event.stopPropagation()"
+                        />
+                      </td>
+                      <td class="text-right font-bold">
+                        @if (manualLinks()[i] !== null && manualLinks()[i] !== undefined) {
+                          <span [class.text-diferencia]="(getLinea(manualLinks()[i]!)?.precioUnitario ?? 0) !== bien.valorUnitario">
+                            {{ formatMoney(getLinea(manualLinks()[i]!)?.precioUnitario) }}
+                          </span>
+                        } @else {
+                          <span class="text-secondary">—</span>
+                        }
+                      </td>
+                      <td class="text-center">
+                        <span [class]="matchStatusClass(i)">{{ matchStatusLabel(i) }}</span>
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      }
+
+      @if (conciliacionError()) {
+        <div class="alert alert--error">
+          <span class="material-symbols-outlined">error</span>
+          <div class="alert__content">
+            <h4 class="alert__title">No se pudo conciliar con el GIL</h4>
+            <p class="alert__text">{{ conciliacionError() }}</p>
+          </div>
+        </div>
+      }
     </div>
   }
 
-  @if (conciliacionError()) {
-    <div class="alert alert--error">
-      <span class="material-symbols-outlined">error</span>
-      <div class="alert__content">
-        <h4 class="alert__title">No se pudo conciliar con el GIL</h4>
-        <p class="alert__text">{{ conciliacionError() }}</p>
-      </div>
-    </div>
-  }
-
-  @if (conciliacionImportacion(); as conciliacion) {
+  <!-- ══════════════════ PASO 4 · Resultado ══════════════════ -->
+  @if (paso() === 4 && conciliacionImportacion(); as conciliacion) {
     <div class="review-section">
       <div class="conciliacion-header">
         <h2 class="review-section__title">Resultado del cruce con GIL</h2>
@@ -374,9 +406,7 @@
                     <td class="text-right">{{ dif.cantidadRecibida ?? '—' }}</td>
                     <td class="text-right">{{ formatMoney(dif.precioUnitarioGil) }}</td>
                     <td class="text-right">{{ formatMoney(dif.precioUnitarioFactura) }}</td>
-                    <td class="text-right" [class.text-tertiary]="dif.diferencia !== 0">
-                      {{ formatMoney(dif.diferencia) }}
-                    </td>
+                    <td class="text-right" [class.text-tertiary]="dif.diferencia !== 0">{{ formatMoney(dif.diferencia) }}</td>
                     <td class="text-center">
                       <span class="badge" [class.badge--green]="dif.resuelta" [class.badge--gray]="!dif.resuelta">
                         {{ dif.resuelta ? 'Sí' : 'No' }}
@@ -395,18 +425,34 @@
   }
 </div>
 
+<!-- Footer contextual por paso -->
 <div class="sticky-footer">
   <button class="btn btn--ghost" (click)="goBack()">Cancelar</button>
+
   <div class="footer-actions">
-    @if (fileLoaded()) {
-      <button class="btn btn--outline" (click)="resetImport()">Importar otra factura</button>
-    }
-    @if (canConciliar()) {
-      @if (missingCounts()) {
-        <p class="count-warning">Hay ítems sin conteo físico. Podés conciliar igual, pero la verificación de la factura lo exigirá.</p>
+    @switch (paso()) {
+      @case (1) {
+        <!-- el avance es automático al importar el XML -->
       }
-      <button class="btn btn--secondary" [disabled]="loading()" (click)="onConciliar()">Conciliar con GIL</button>
+      @case (2) {
+        <button class="btn btn--outline" (click)="resetImport()">Importar otra</button>
+        <button class="btn btn--primary" (click)="siguiente()">Continuar</button>
+      }
+      @case (3) {
+        <button class="btn btn--outline" (click)="atras()">Atrás</button>
+        @if (canConciliar()) {
+          @if (missingCounts()) {
+            <p class="count-warning">Hay ítems sin conteo físico. Podés conciliar igual, pero la verificación lo exigirá.</p>
+          }
+          <button class="btn btn--primary" [disabled]="loading()" (click)="onConciliar()">Conciliar con GIL</button>
+        } @else {
+          <button class="btn btn--primary" [disabled]="!facturaImportada()" (click)="viewImportedFactura()">Finalizar sin conciliar</button>
+        }
+      }
+      @case (4) {
+        <button class="btn btn--outline" (click)="resetImport()">Importar otra</button>
+        <button class="btn btn--primary" [disabled]="!facturaImportada()" (click)="viewImportedFactura()">Ver factura registrada</button>
+      }
     }
-    <button class="btn btn--primary" [disabled]="!facturaImportada()" (click)="viewImportedFactura()">Ver factura registrada</button>
   </div>
 </div>

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.scss
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.scss
@@ -37,6 +37,87 @@
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Wizard Stepper
+// ─────────────────────────────────────────────────────────────────────────────
+.wizard-steps {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.wizard-step {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.625rem 1rem;
+  background: transparent;
+  border: none;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  font-family: var(--font-family-base);
+  transition: background-color 0.2s;
+
+  &:not(:last-child)::after {
+    content: '';
+    width: 1.5rem;
+    height: 2px;
+    background-color: var(--color-superficie-variante);
+    margin-left: 0.25rem;
+  }
+
+  &__num {
+    width: 1.75rem;
+    height: 1.75rem;
+    flex-shrink: 0;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    background-color: var(--color-superficie-contenedor-alto);
+    color: var(--color-text-muted);
+    transition: all 0.2s;
+
+    .material-symbols-outlined { font-size: 1.125rem; }
+  }
+
+  &__label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    white-space: nowrap;
+  }
+
+  &--active {
+    background-color: var(--color-superficie-contenedor);
+
+    .wizard-step__num {
+      background-color: var(--color-primario);
+      color: #fff;
+    }
+    .wizard-step__label { color: var(--color-en-superficie); }
+  }
+
+  &--done {
+    .wizard-step__num {
+      background-color: rgba(0, 110, 37, 0.12);
+      color: var(--color-primario);
+    }
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  &:not(:disabled):not(.wizard-step--active):hover {
+    background-color: var(--color-superficie-contenedor-bajo);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Alerts
 // ─────────────────────────────────────────────────────────────────────────────
 .alerts-container {

--- a/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.ts
+++ b/libs/inventario/inventario/src/lib/pages/facturas-page/factura-import/factura-import.component.ts
@@ -50,7 +50,47 @@ export class FacturaImportPageComponent implements OnInit {
     this.gilBienes().some((_, i) => this.cantidadesRecibidas()[i] === null)
   );
 
+  // ── Wizard de pasos ─────────────────────────────────────────────────────────
+  readonly pasos = [
+    { n: 1, label: 'Subir XML' },
+    { n: 2, label: 'Revisar datos' },
+    { n: 3, label: 'Vincular y cruzar' },
+    { n: 4, label: 'Resultado' },
+  ];
+  paso = signal(1);
+  // Latches: el auto-avance ocurre UNA sola vez por hito, así "Atrás" no rebota.
+  private latchImport = false;
+  private latchConciliar = false;
+
+  /** Un paso es alcanzable solo si su precondición de datos se cumple. */
+  puedeAvanzar(n: number): boolean {
+    if (n <= 1) return true;
+    if (n === 2 || n === 3) return !!this.facturaImportada();
+    if (n === 4) return !!this.conciliacionImportacion();
+    return false;
+  }
+
+  irAPaso(n: number): void {
+    if (n >= 1 && n <= this.pasos.length && this.puedeAvanzar(n)) this.paso.set(n);
+  }
+  siguiente(): void { this.irAPaso(this.paso() + 1); }
+  atras(): void { this.paso.update(p => Math.max(1, p - 1)); }
+
   constructor() {
+    // Auto-avance guiado: al importar → paso 2; al conciliar → paso 4.
+    effect(() => {
+      const factura = this.facturaImportada();
+      const conciliacion = this.conciliacionImportacion();
+      if (factura && !this.latchImport) {
+        this.latchImport = true;
+        this.paso.set(2);
+      }
+      if (conciliacion && !this.latchConciliar) {
+        this.latchConciliar = true;
+        this.paso.set(4);
+      }
+    });
+
     effect(() => {
       const bienes = this.gilBienes();
       const factura = this.facturaImportada();
@@ -215,6 +255,9 @@ export class FacturaImportPageComponent implements OnInit {
     this.fileName.set('');
     this.gilId.set('');
     this.localError.set(null);
+    this.latchImport = false;
+    this.latchConciliar = false;
+    this.paso.set(1);
     this.facade.limpiarImportacionFactura();
   }
 

--- a/libs/inventario/inventario/src/lib/ui/modals/contrato-detalle/contrato-detalle.component.html
+++ b/libs/inventario/inventario/src/lib/ui/modals/contrato-detalle/contrato-detalle.component.html
@@ -70,7 +70,6 @@
                   <th>Ref. Artículo</th>
                   <th>Descripción</th>
                   <th class="text-center">Unidad</th>
-                  <th class="text-right">Cantidad</th>
                   <th class="text-right">Vlr. Adjudicado</th>
                   <th class="text-right">Vlr. Antes</th>
                   <th class="text-right">IVA</th>
@@ -82,14 +81,13 @@
                     <td><span class="code-mono">{{ item.refArticulo }}</span></td>
                     <td><span class="item-desc">{{ item.descripcion }}</span></td>
                     <td class="text-center">{{ item.unidadMedida ?? '—' }}</td>
-                    <td class="text-right">{{ item.cantidad ?? '—' }}</td>
                     <td class="text-right">{{ formatCurrency(item.vrlAdjudicado) }}</td>
                     <td class="text-right">{{ formatCurrency(item.vrlAntes) }}</td>
                     <td class="text-right">{{ formatPorcentaje(item.ivaPorcentaje) }}</td>
                   </tr>
                 } @empty {
                   <tr>
-                    <td colspan="7" class="empty-row">Sin ítems registrados</td>
+                    <td colspan="6" class="empty-row">Sin ítems registrados</td>
                   </tr>
                 }
               </tbody>

--- a/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.scss
+++ b/libs/inventario/inventario/src/lib/ui/pages/bienes-list/bienes-list.component.scss
@@ -129,6 +129,8 @@
   font-size: 0.75rem;
   font-weight: 700;
   color: var(--color-pizarra-400);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .bien-desc {
@@ -140,7 +142,8 @@
 /* ── Anchos de columna — prioridad a Descripción ──────────────────────────── */
 thead th,
 tbody .table-row td {
-  &:nth-child(1) { width: 6.5rem; white-space: nowrap; }  /* CÓD. SENA  */
+  /* CÓD. SENA — ancho acotado; los códigos largos envuelven (no se desbordan). */
+  &:nth-child(1) { width: 6.5rem; overflow-wrap: anywhere; word-break: break-word; }
   &:nth-child(2) { width: auto;   min-width: 18rem;     }  /* Descripción (absorbe el resto) */
   &:nth-child(3) { width: 5rem;   white-space: nowrap; }  /* Stock      */
   &:nth-child(4) { width: 6rem;   white-space: nowrap; }  /* Stock Mín. */


### PR DESCRIPTION
Trabajo de UX que quedó pendiente de commitear en la sesión.

## Cambios
- **Wizard de importación FEL**: la pantalla de importar factura pasa de scroll único a 4 pasos guiados (Subir XML → Revisar datos → Vincular GIL y cruzar → Resultado), con stepper y footer contextual de un solo botón primario por paso. Toda la lógica de negocio intacta.
- **Contrato (detalle)**: quitada la columna 'Cantidad' (era cantidad adjudicada/licitada, ambigua — inducía a pensar que era stock disponible; el contrato es catálogo de precios).
- **Bienes (listado)**: fix de overflow del código SENA largo (envuelve dentro de la celda en vez de desbordarse).

## Validación
`nx lint inventario` ✅ · `tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)