### PR TITLE
fix(restaurante): corregir redireccion de login de cajero leyendo rol…

### DIFF
--- a/libs/restaurante/restaurante/src/lib/data-access/auth.service.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/auth.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { currentUserSignal } from '@restaurant/shared/auth';
 
 @Injectable({
   providedIn: 'root'
@@ -85,6 +86,20 @@ export class AuthService {
 
   getRoles(): string[] {
     try {
+      // 0. Intentar extraer del shared signal (fuente principal de verdad)
+      try {
+        const signalUser = currentUserSignal();
+        if (signalUser) {
+          let rolesAndPerms = [...(signalUser.permisos || [])];
+          if (signalUser.rol) {
+            rolesAndPerms.push(signalUser.rol);
+          }
+          if (rolesAndPerms.length > 0) {
+            return rolesAndPerms.map((r: string) => r.toUpperCase());
+          }
+        }
+      } catch (e) {}
+
       // 1. Intentar leer desde el objeto 'user' del localStorage (usado por ga-web-inicio-general y mocks)
       const userStr = localStorage.getItem('user');
       if (userStr) {
@@ -110,6 +125,7 @@ export class AuthService {
             if (jsonPayload.role) roles.push(jsonPayload.role);
             if (jsonPayload.realm_access?.roles) roles = roles.concat(jsonPayload.realm_access.roles);
             if (jsonPayload.rol) roles.push(jsonPayload.rol);
+            if (jsonPayload.nombreRol) roles.push(jsonPayload.nombreRol);
           } catch(e) {}
         }
       }


### PR DESCRIPTION

## Descripción

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [x ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [x ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ x] `nx affected:lint --base=develop` → 0 errores
- [ x] `nx affected:test --base=develop` → 0 fallos
- [ x] PR tiene menos de 400 líneas modificadas
- [ x] Un solo scope tocado
- [x ] Todo componente nuevo tiene su `.spec.ts`
- [ x] Sin `any` en TypeScript
- [ x] Sin estilos inline en templates
- [ x] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
Se actualizó exclusivamente el archivo libs/restaurante/restaurante/src/lib/data-access/auth.service.ts respetando el flujo de dependencias (feature → shared).

Fuente de verdad: Se integró currentUserSignal (proveniente de @restaurant/shared/auth) como fuente principal y reactiva para leer el rol exacto asignado desde el momento del login.
Fallback para F5 (Recarga): Se incluyó la verificación de la propiedad correcta (nombreRol) desde el token decodificado para mantener la estabilidad de la sesión si el usuario recarga la página de manera abrupta en el navegador.