### PR TITLE
fix(reportes): enrutar /api/reportes al servicio reportes (8083)

### DIFF
--- a/apps/restaurant-app/proxy.conf.json
+++ b/apps/restaurant-app/proxy.conf.json
@@ -129,7 +129,7 @@
     "changeOrigin": true
   },
   "/api/reportes": {
-    "target": "http://localhost:8080",
+    "target": "http://localhost:8083",
     "secure": false,
     "changeOrigin": true
   },

--- a/nginx.conf
+++ b/nginx.conf
@@ -128,8 +128,11 @@ server {
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
     }
 
+    # ─── Reportes (ga-ms-reportes, 8083) ──────────────────────────────────────
+    # ga-ms-reportes ahora es un servicio del docker-compose ("reportes") en la
+    # red gastrosena-net. Antes apuntaba (mal) a restaurante:8080.
     location /api/reportes {
-        proxy_pass         http://restaurante:8080;
+        proxy_pass         http://reportes:8083;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;


### PR DESCRIPTION
proxy.conf.json (dev) y nginx.conf (prod) apuntaban /api/reportes a restaurante:8080. Se corrige a reportes:8083 (servicio del docker-compose).

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
