### PR TITLE
fix(docker): enrutar todo /api al API Gateway y reenviar Authorization

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,156 +5,37 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # ─── Inventario (8081) — /api/v1/* ────────────────────────────────────────
-    # NOTA: proxy.conf.json tenía estos paths apuntando a 8080 (error).
-    # El dueño real de /api/v1/* es el ms-inventario en 8081.
-    location /api/v1/ {
-        proxy_pass         http://inventario:8081;
+    # ─── API Gateway (único punto de entrada) ─────────────────────────────────
+    # Arquitectura gateway-trust: los microservicios NO se exponen al host y solo
+    # confían en el gateway (valida el JWT e inyecta X-User-* hacia adentro).
+    # Por eso TODO el tráfico de API se enruta a gateway:8088 y se reenvía el
+    # header Authorization para que el gateway pueda validar el token.
+    # El gateway ya conoce las rutas de cada micro (usuarios, inventario,
+    # restaurante, cocina, barbarismo, reportes), así que no se repiten acá.
+    location /api/ {
+        proxy_pass         http://gateway:8088;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   Authorization     $http_authorization;
     }
 
-    # ─── Barbarismo (8086) ────────────────────────────────────────────────────
-    location /api/barybarismo {
-        proxy_pass         http://barbarismo:8086;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    location /api/alertas {
-        proxy_pass         http://barbarismo:8086;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    # ─── Cocina (8082) ────────────────────────────────────────────────────────
-    location /api/cocina {
-        proxy_pass         http://cocina:8082;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    location /api/actividades {
-        proxy_pass         http://cocina:8082;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    location /api/ingredientes {
-        proxy_pass         http://cocina:8082;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    location /api/pasos {
-        proxy_pass         http://cocina:8082;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    # AMBIGÜEDAD: /api/recetas existe en cocina Y en barbarismo.
-    # Actualmente ruteado a cocina. Si barbarismo también lo necesita,
-    # hay que diferenciar los paths a nivel de backend (e.g. /api/cocina/recetas).
-    location /api/recetas {
-        proxy_pass         http://cocina:8082;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    # AMBIGÜEDAD: /api/categorias existe en cocina Y proxy apuntaba a 8080.
-    # Ruteado a cocina (dueño real del CategoriaRecetaController).
-    location /api/categorias {
-        proxy_pass         http://cocina:8082;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    # ─── Restaurante / Gastrosena (8080) ──────────────────────────────────────
-    location /api/pedidos {
-        proxy_pass         http://restaurante:8080;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    location /api/mesas {
-        proxy_pass         http://restaurante:8080;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    location /api/caja {
-        proxy_pass         http://restaurante:8080;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    location /api/bar {
-        proxy_pass         http://restaurante:8080;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
+    # Rutas fuera de /api/ que usa el frontend (restaurante). Se mandan también al
+    # gateway; requiere que el gateway tenga estas rutas configuradas.
     location /sesion {
-        proxy_pass         http://restaurante:8080;
+        proxy_pass         http://gateway:8088;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   Authorization     $http_authorization;
     }
 
     location /facturar {
-        proxy_pass         http://restaurante:8080;
+        proxy_pass         http://gateway:8088;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    location /api/facturas {
-        proxy_pass         http://restaurante:8080;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    # ─── Reportes (ga-ms-reportes, 8083) ──────────────────────────────────────
-    # ga-ms-reportes ahora es un servicio del docker-compose ("reportes") en la
-    # red gastrosena-net. Antes apuntaba (mal) a restaurante:8080.
-    location /api/reportes {
-        proxy_pass         http://reportes:8083;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    # ─── Usuarios (8081 interno) ──────────────────────────────────────────────
-    # Host port es 8087 para evitar conflicto con inventario, pero dentro de
-    # la red Docker el contenedor escucha en 8081.
-    # IMPORTANTE: /api/auth — no /auth — para que Angular maneje /auth/* como SPA.
-    location /api/auth {
-        proxy_pass         http://usuarios:8081;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    }
-
-    # Catch-all /api → usuarios (auth, fichas, roles, perfil, notificaciones, etc.)
-    location /api {
-        proxy_pass         http://usuarios:8081;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   Authorization     $http_authorization;
     }
 
     # ─── Angular routing ──────────────────────────────────────────────────────


### PR DESCRIPTION
El nginx ruteaba directo a cada microservicio sin reenviar el token. Con el backend en modo gateway-trust esas llamadas fallaban (401/403/500). Se consolida todo /api (y /sesion, /facturar) hacia gateway:8088 reenviando Authorization.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
