### PR TITLE
fix(inventario): quitar columna GIL de la tabla de paquetes y mapear fechaCreacion

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/legalization.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/legalization.api.ts
@@ -73,6 +73,7 @@ export interface PaqueteResponse {
   compromisoPresupuestalId?: string;
   titulo: string;
   expediente: string;
+  fechaCreacion?: string;   // ISO "yyyy-MM-dd" enviado por el backend
 }
 
 export interface PaquetesPageResponse {

--- a/libs/inventario/inventario/src/lib/data-access/mappers/legalization.mapper.ts
+++ b/libs/inventario/inventario/src/lib/data-access/mappers/legalization.mapper.ts
@@ -47,7 +47,7 @@ export function paqueteFromApi(dto: PaqueteResponse): PaqueteProbatorio {
     requisicionId: dto.requisicionId,
     registroAsistenciaAdjunto: dto.registroAsistenciaAdjunto,
     instructorId: dto.instructorId,
-    // fecha no está en la respuesta del backend
+    fecha: dto.fechaCreacion,
   };
 }
 

--- a/libs/inventario/inventario/src/lib/models/paquete.model.ts
+++ b/libs/inventario/inventario/src/lib/models/paquete.model.ts
@@ -18,7 +18,7 @@ export interface PaqueteProbatorio {
   requisicionId?: string;              // era: documentos[tipo='requisicion'].referencia
   registroAsistenciaAdjunto: boolean;  // era: documentos[tipo='asistencia'].vinculado
   instructorId: string;                // era: responsable
-  fecha?: string;                      // "15/04/2026" — no enviado por el backend
+  fecha?: string;                      // desde fechaCreacion del backend (ISO)
 }
 
 // ── Mock Data ──────────────────────────────────────────────────────────────

--- a/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-list/paquete-list.component.html
+++ b/libs/inventario/inventario/src/lib/pages/paquete-probatorio-page/paquete-list/paquete-list.component.html
@@ -65,7 +65,6 @@
         <th>ID Expediente</th>
         <th>Detalle / Ficha</th>
         <th class="text-center">Estado</th>
-        <th>GIL Vinculado</th>
         <th>Documentos Base</th>
         <th>Responsable</th>
         <th>Fecha</th>
@@ -97,11 +96,6 @@
               [label]="getEstadoLabel(paquete.estado)"
               [variant]="getEstadoVariant(paquete.estado)"
             ></restaurant-status-badge>
-          </td>
-
-          <!-- GIL Vinculado -->
-          <td>
-            <span class="paquete-table__gil">{{ paquete.gilId }}</span>
           </td>
 
           <!-- Documentos Base (Checklist) -->
@@ -171,7 +165,7 @@
         </tr>
       } @empty {
         <tr>
-          <td colspan="8">
+          <td colspan="7">
             <inventario-empty-state
               icon="folder"
               title="Sin paquetes"


### PR DESCRIPTION
## Resumen
- Elimina la columna **GIL Vinculado** de la tabla de paquetes probatorios (el paquete no se vincula con el GIL en el flujo real). `gilId` se mantiene en el modelo para trazabilidad/detalle.
- Ajusta el `colspan` del empty-state de 8 a 7 columnas.
- Mapea `fechaCreacion` del backend a `paquete.fecha` para que la columna **Fecha** deje de salir vacía una vez el backend exponga el campo (ver MR backend de expediente+fecha).

## Cambios
| Archivo | Cambio |
|---|---|
| `paquete-list.component.html` | Quita th/td de GIL; colspan 8→7 |
| `legalization.api.ts` | Agrega `fechaCreacion?` a `PaqueteResponse` |
| `legalization.mapper.ts` | Mapea `dto.fechaCreacion` → `fecha` |
| `paquete.model.ts` | Actualiza comentario del campo `fecha` |

## Verificación
- [x] `nx lint inventario` pasa
- [x] Revisión visual de la tabla