### PR TITLE
fix(cocina): usar rutas relativas para pasar por el API Gateway

### DIFF
--- a/libs/cocina/cocina/src/lib/data-access/actividad.service.ts
+++ b/libs/cocina/cocina/src/lib/data-access/actividad.service.ts
@@ -22,7 +22,7 @@ export type CreateActividadDTO = Omit<ActividadDTO, 'id' | 'estado'>;
 @Injectable({ providedIn: 'root' })
 export class ActividadService {
   private http = inject(HttpClient);
-  private readonly BASE = 'http://localhost:8082/api/actividades';
+  private readonly BASE = '/api/actividades';
 
   /** Obtiene todas las actividades ordenadas por fecha desc */
   getAll(): Observable<ActividadDTO[]> {

--- a/libs/cocina/cocina/src/lib/data-access/categoria.service.ts
+++ b/libs/cocina/cocina/src/lib/data-access/categoria.service.ts
@@ -5,7 +5,7 @@ import { Categoria } from "../models/receta.model";
 @Injectable({ providedIn: 'root'})
 export class CategoriaService {
     private http = inject(HttpClient);
-    private url = 'http://localhost:8082/api/categorias';
+    private url = '/api/categorias';
 
     categorias = signal<Categoria[]>([]);
 

--- a/libs/cocina/cocina/src/lib/data-access/comanda.service.ts
+++ b/libs/cocina/cocina/src/lib/data-access/comanda.service.ts
@@ -81,8 +81,8 @@ export class ComandaService {
   private http = inject(HttpClient);
   
   // Endpoints reales indicados por el usuario
-  private baseUrlComandas = 'http://localhost:8082/api/cocina/comandas';
-  private baseUrlEstadisticas = 'http://localhost:8082/api/cocina/estadisticas';
+  private baseUrlComandas = '/api/cocina/comandas';
+  private baseUrlEstadisticas = '/api/cocina/estadisticas';
 
   iniciarDetalle(idDetalle: string): Observable<any> {
     return this.http.patch(`${this.baseUrlComandas}/detalle/${idDetalle}/iniciar?idResponsable=550e8400-e29b-41d4-a716-446655440000`, {});
@@ -111,18 +111,18 @@ export class ComandaService {
   }
 
   getIncidenciasPorTipo(tipo: 'CANCELACION' | 'DEVOLUCION' | 'MODIFICACION'): Observable<any[]> {
-    return this.http.get<any[]>(`http://localhost:8082/api/cocina/incidencias/tipo/${tipo}`);
+    return this.http.get<any[]>(`/api/cocina/incidencias/tipo/${tipo}`);
   }
 
   getConteoIncidencias(): Observable<{ canceladas: number; devueltas: number }> {
     return this.http.get<{ canceladas: number; devueltas: number }>(
-      `http://localhost:8082/api/cocina/incidencias/conteo`
+      `/api/cocina/incidencias/conteo`
     );
   }
 
   getRecetaById(idReceta: string): Observable<Receta> {
     // Las recetas viven en el microservicio de cocina (puerto 8082), no en 8080.
-    return this.http.get<Receta>(`http://localhost:8082/api/recetas/${idReceta}`);
+    return this.http.get<Receta>(`/api/recetas/${idReceta}`);
   }
 
   limpiarComandas(fechaInicio: string, fechaFin: string): Observable<void> {
@@ -136,7 +136,7 @@ export class ComandaService {
   }
 
   // ── Incidencias (Cancelados / Devueltos): borran incidencia + comanda ──────────
-  private baseUrlIncidencias = 'http://localhost:8082/api/cocina/incidencias';
+  private baseUrlIncidencias = '/api/cocina/incidencias';
 
   eliminarIncidencia(idAuditoria: string): Observable<void> {
     return this.http.delete<void>(`${this.baseUrlIncidencias}/${idAuditoria}`);

--- a/libs/cocina/cocina/src/lib/data-access/evaluacion.service.ts
+++ b/libs/cocina/cocina/src/lib/data-access/evaluacion.service.ts
@@ -26,7 +26,7 @@ export interface EvaluacionRequestDTO {
 @Injectable({ providedIn: 'root' })
 export class EvaluacionService {
   private http = inject(HttpClient);
-  private readonly BASE = 'http://localhost:8082/api/actividades';
+  private readonly BASE = '/api/actividades';
 
   /**
    * Obtiene los registros de evaluación persistidos en BD para una actividad.

--- a/libs/cocina/cocina/src/lib/data-access/incidencia.service.ts
+++ b/libs/cocina/cocina/src/lib/data-access/incidencia.service.ts
@@ -8,7 +8,7 @@ import { AuditoriaIncidencia } from '../models/incidencia.model';
 })
 export class IncidenciaService {
   private http = inject(HttpClient);
-  private apiUrl = 'http://localhost:8082/api/cocina/incidencias';
+  private apiUrl = '/api/cocina/incidencias';
   obtenerPorTipo(tipo: 'CANCELACION' | 'DEVOLUCION' | 'MODIFICACION'): Observable<AuditoriaIncidencia[]> {
     return this.http.get<AuditoriaIncidencia[]>(`${this.apiUrl}/tipo/${tipo}`);
   }

--- a/libs/cocina/cocina/src/lib/data-access/ingrediente.service.ts
+++ b/libs/cocina/cocina/src/lib/data-access/ingrediente.service.ts
@@ -5,7 +5,7 @@ import { Ingrediente } from '../models/receta.model';
 @Injectable({ providedIn: 'root' })
 export class IngredienteService {
   private http = inject(HttpClient); 
-  private apiUrl = 'http://localhost:8082/api/ingredientes';
+  private apiUrl = '/api/ingredientes';
   private _ingredientes = signal<Ingrediente[]>([]);
   public ingredientes = this._ingredientes.asReadonly();
 

--- a/libs/cocina/cocina/src/lib/data-access/receta.service.ts
+++ b/libs/cocina/cocina/src/lib/data-access/receta.service.ts
@@ -6,7 +6,7 @@ import { Receta } from '../models/receta.model';
 export class RecetaService {
   private http = inject(HttpClient);
   // URL base para el backend de recetas
-  private url = 'http://localhost:8082/api/recetas';
+  private url = '/api/recetas';
   recetas = signal<Receta[]>([]);
 
   listar() {


### PR DESCRIPTION
Los services apuntaban directo a http://localhost:8082 (puerto cerrado en gateway-trust), por lo que todas las llamadas fallaban. Se cambian a rutas relativas (/api/...) para que pasen por nginx -> gateway. Solo afecta la capa data-access (services); no se modifican vistas ni contratos de datos.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
