### PR TITLE
fix(auth): botones crear/editar/borrar de fichas solo para ADMINISTRADOR

### DIFF
--- a/libs/auth/usuarios/src/lib/pages/fichas-page/fichas-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/fichas-page/fichas-page.component.html
@@ -6,12 +6,14 @@
       <h1 class="fichas-page__title">{{ i18n.t('fichas.titulo') }}</h1>
       <p class="fichas-page__subtitle">{{ i18n.t('fichas.subtitulo') }}</p>
     </div>
-    <div class="fichas-page__header-actions">
-      <button class="fichas-page__btn fichas-page__btn--primary" type="button" (click)="onNuevaFicha()">
-        <lucide-icon name="plus" [size]="16"></lucide-icon>
-        {{ i18n.t('fichas.nueva_ficha') }}
-      </button>
-    </div>
+    @if (esAdmin()) {
+      <div class="fichas-page__header-actions">
+        <button class="fichas-page__btn fichas-page__btn--primary" type="button" (click)="onNuevaFicha()">
+          <lucide-icon name="plus" [size]="16"></lucide-icon>
+          {{ i18n.t('fichas.nueva_ficha') }}
+        </button>
+      </div>
+    }
   </div>
 
   <!-- KPIs -->
@@ -108,25 +110,27 @@
                 >
                   <lucide-icon name="users" [size]="16"></lucide-icon>
                 </button>
-                <!-- BOTÓN EDITAR -->
-                <button
-                  class="fichas-page__action-btn"
-                  type="button"
-                  (click)="onEditarFicha(f)"
-                  aria-label="Editar ficha"
-                  title="Editar ficha"
-                >
-                  <lucide-icon name="pencil" [size]="16"></lucide-icon>
-                </button>
-                <!-- BOTÓN ELIMINAR -->
-                <button
-                  class="fichas-page__action-btn fichas-page__action-btn--danger"
-                  type="button"
-                  (click)="onEliminar(f.id)"
-aria-label="Eliminar ficha"
-                  title="Eliminar ficha"                >
-                  <lucide-icon name="trash-2" [size]="16"></lucide-icon>
-                </button>
+                @if (esAdmin()) {
+                  <!-- BOTÓN EDITAR -->
+                  <button
+                    class="fichas-page__action-btn"
+                    type="button"
+                    (click)="onEditarFicha(f)"
+                    aria-label="Editar ficha"
+                    title="Editar ficha"
+                  >
+                    <lucide-icon name="pencil" [size]="16"></lucide-icon>
+                  </button>
+                  <!-- BOTÓN ELIMINAR -->
+                  <button
+                    class="fichas-page__action-btn fichas-page__action-btn--danger"
+                    type="button"
+                    (click)="onEliminar(f.id)"
+                    aria-label="Eliminar ficha"
+                    title="Eliminar ficha"                >
+                    <lucide-icon name="trash-2" [size]="16"></lucide-icon>
+                  </button>
+                }
               </div>
             </td>
           

--- a/libs/auth/usuarios/src/lib/pages/fichas-page/fichas-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/fichas-page/fichas-page.component.ts
@@ -14,6 +14,8 @@ import {
   KpiCardComponent,
   LucideIconComponent,
 } from '@restaurant/shared/ui';
+import { AuthService } from '@restaurant/shared/auth';
+import { Rol } from '@restaurant/shared/models';
 import { FichasService } from '../../data-access/fichas.service';
 import { I18nService } from '../../i18n/i18n.service';
 import { Ficha } from '../../models/ficha.model';
@@ -37,7 +39,11 @@ type EstadoFiltro = 'todos' | 'activas' | 'inactivas';
 export class FichasPageComponent implements OnInit {
   private readonly fichasService = inject(FichasService);
   private readonly router = inject(Router);
+  private readonly auth = inject(AuthService);
   protected readonly i18n = inject(I18nService);
+
+  // Crear/editar/borrar fichas: solo ADMINISTRADOR. El INSTRUCTOR solo consulta.
+  readonly esAdmin = computed(() => this.auth.currentUser()?.rol === Rol.ADMINISTRADOR);
 
   readonly fichas = signal<Ficha[]>([]);
   readonly loading = signal(false);


### PR DESCRIPTION
En la pagina de fichas (/app/fichas) las acciones Nueva ficha / Editar / Eliminar se muestran solo si el usuario es ADMINISTRADOR (esAdmin); el INSTRUCTOR conserva el listado y 'Ver aprendices' (solo consulta). El home->carta de cocina y el gate del menu/ruta de fichas (ADMIN+INSTRUCTOR) ya estan en develop.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
