### PR TITLE
frefactor(inventario): eliminar llamada muerta de export de bienes

### DIFF
--- a/libs/inventario/inventario/src/lib/data-access/api/catalog.api.ts
+++ b/libs/inventario/inventario/src/lib/data-access/api/catalog.api.ts
@@ -71,18 +71,6 @@ export interface ImportarProductosRequest {
   productos: CrearProductoRequest[];
 }
 
-/** POST /catalog/productos/exportaciones (202 Accepted — async) */
-export interface SolicitarExportacionRequest {
-  formato: 'CSV';
-}
-
-export interface ExportacionProductosResponse {
-  exportId: string;
-  estado: string;
-  formato: 'CSV';
-  totalProductos: number;
-}
-
 // ── Contratos (/catalog/contratos) ─────────────────────────────────────────────
 
 export interface ItemContratoResponse {

--- a/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
+++ b/libs/inventario/inventario/src/lib/data-access/inventario.facade.ts
@@ -1,6 +1,5 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { Bien, BienFiltros, BienKpis, BienFormDto, BienPaginacion } from '../models/inventario.model';
-import { ExportacionProductosResponse } from './api/catalog.api';
 import { BienesService } from './services/bienes.service';
 import { finalize, catchError, of, switchMap, forkJoin } from 'rxjs';
 
@@ -17,7 +16,6 @@ export class InventarioFacade {
   private _filtros             = signal<BienFiltros>({ page: 0, size: 10 });
   private _paginacion          = signal<BienPaginacion>({ totalElements: 0, totalPages: 1, page: 0, size: 10 });
   private _bienSeleccionado    = signal<Bien | undefined>(undefined);
-  private _exportacionPendiente = signal<ExportacionProductosResponse | null>(null);
   private _error               = signal<string | null>(null);
 
   // Exposición pública (Solo lectura)
@@ -27,7 +25,6 @@ export class InventarioFacade {
   public filtros              = computed(() => this._filtros());
   public paginacion           = computed(() => this._paginacion());
   public bienSeleccionado     = computed(() => this._bienSeleccionado());
-  public exportacionPendiente = computed(() => this._exportacionPendiente());
   public error                = computed(() => this._error());
 
   /**
@@ -251,19 +248,5 @@ export class InventarioFacade {
         finalize(() => this._loading.set(false))
       )
       .subscribe(res => { if (res !== null) this.loadAll(); });
-  }
-
-  /** POST /catalog/productos/exportaciones (202 Accepted — async) */
-  solicitarExportacion(formato: 'CSV'): void {
-    this._loading.set(true);
-    this.bienesService.solicitarExportacion(formato)
-      .pipe(
-        catchError(() => {
-          this._error.set('Error al solicitar la exportación');
-          return of(null);
-        }),
-        finalize(() => this._loading.set(false))
-      )
-      .subscribe(res => { if (res !== null) this._exportacionPendiente.set(res); });
   }
 }

--- a/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
+++ b/libs/inventario/inventario/src/lib/data-access/services/bienes.service.ts
@@ -9,8 +9,6 @@ import {
   EliminarProductosMasivaRequest,
   EliminacionMasivaResponse,
   ImportarProductosRequest,
-  SolicitarExportacionRequest,
-  ExportacionProductosResponse,
 } from '../api/catalog.api';
 import { ExistenciaResponse } from '../api/inventory.api';
 import {
@@ -201,14 +199,6 @@ export class BienesService {
 
     return this.http
       .post<{ importados: number }>(`${API}/catalog/productos/importar-excel`, formData)
-      .pipe(catchError(err => throwError(() => err)));
-  }
-
-  /** POST /catalog/productos/exportaciones (202 Accepted — async) */
-  solicitarExportacion(formato: 'CSV'): Observable<ExportacionProductosResponse> {
-    const body: SolicitarExportacionRequest = { formato };
-    return this.http
-      .post<ExportacionProductosResponse>(`${API}/catalog/productos/exportaciones`, body)
       .pipe(catchError(err => throwError(() => err)));
   }
 }


### PR DESCRIPTION
El POST /catalog/productos/exportaciones fue removido del backend (endpoint inexistente en reportes). El export real de bienes usa BienExportService -> GET /api/reportes/inventario-general. Elimina solicitarExportacion de bienes.service y del facade, el estado exportacionPendiente y las interfaces SolicitarExportacionRequest/ExportacionProductosResponse.

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [ ] PR tiene menos de 400 líneas modificadas
- [ ] Un solo scope tocado
- [ ] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
