### PR TITLE
Feat/cancelaciones parciales restaurante

### DIFF
--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
@@ -7,8 +7,13 @@
     @for (item of pedido.detalles; track item.productoId; let i = $index) {
       <div class="item-row">
         <div class="item-details">
-          <h4 class="name">{{ item.nombreProducto }}</h4>
-            <div class="obs-display">
+          <div style="display: flex; align-items: center;">
+            <h4 class="name" style="margin-bottom: 0;">{{ item.nombreProducto }}</h4>
+            @if (esPedidoSoloLectura() && item.estadoDetalle) {
+               <span class="estado-badge" [ngClass]="getEstadoDetalleClass(item.estadoDetalle)">{{ getEstadoDetalleText(item.estadoDetalle) }}</span>
+            }
+          </div>
+            <div class="obs-display" style="margin-top: 4px;">
               <span class="category" [title]="item.observaciones || 'Sin observaciones'">{{ item.observaciones || 'Sin observaciones' }}</span>
               @if (!esPedidoSoloLectura()) {
                 <button class="btn-edit-obs" (click)="iniciarEdicionObservacion(i, item.observaciones || '')" title="Agregar/Editar observaciones">

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.html
@@ -42,11 +42,11 @@
             </button>
           } @else if (estadoPedido() !== 'FACTURADO' && estadoPedido() !== 'CANCELADO') {
             <div style="display: flex; gap: 8px;">
-              <button class="btn-delete" style="color: var(--color-error);" (click)="iniciarAccionItem(item.id, item.nombreProducto, 'CANCELAR')" title="Cancelar producto">
+              <button class="btn-delete" style="color: var(--color-error);" (click)="iniciarAccionItem(item.id, item.nombreProducto, 'CANCELAR', item.cantidad)" title="Cancelar producto">
                 <lucide-icon name="x-circle" [size]="16"></lucide-icon>
               </button>
               @if (estadoPedido() === 'ENTREGADO' || estadoPedido() === 'LISTO_PARA_SERVIR') {
-                <button class="btn-delete" style="color: var(--color-warning);" (click)="iniciarAccionItem(item.id, item.nombreProducto, 'DEVOLVER')" title="Devolver producto">
+                <button class="btn-delete" style="color: var(--color-warning);" (click)="iniciarAccionItem(item.id, item.nombreProducto, 'DEVOLVER', item.cantidad)" title="Devolver producto">
                   <lucide-icon name="arrow-left" [size]="16"></lucide-icon>
                 </button>
               }
@@ -210,6 +210,32 @@
         ¿Estás seguro de que quieres {{ accionItem.tipo === 'CANCELAR' ? 'cancelar' : 'devolver' }} el producto <strong>{{ accionItem.nombre }}</strong>?
       </p>
       
+      <div class="cancel-quantity-container" style="margin-top: 16px; margin-bottom: 20px;">
+        <label style="display: block; font-size: var(--font-size-sm); font-weight: var(--font-weight-medium); color: var(--color-text-primary);">
+          Cantidad a {{ accionItem.tipo === 'CANCELAR' ? 'cancelar' : 'devolver' }} (Max: {{ accionItem.maxCantidad }}) *
+        </label>
+        
+        <div class="modal-quantity-controls">
+          <button 
+            class="btn-minus" 
+            (click)="decrementarCantidadAccion()"
+            [disabled]="cantidadItemAccion() <= 1"
+            title="Reducir cantidad">
+            <lucide-icon name="minus" [size]="18"></lucide-icon>
+          </button>
+          
+          <span class="qty-display">{{ cantidadItemAccion() }}</span>
+          
+          <button 
+            class="btn-plus" 
+            (click)="incrementarCantidadAccion()"
+            [disabled]="cantidadItemAccion() >= accionItem.maxCantidad"
+            title="Aumentar cantidad">
+            <lucide-icon name="plus" [size]="18"></lucide-icon>
+          </button>
+        </div>
+      </div>
+
       <div class="cancel-reason-container">
         <label for="motivoItem">Motivo de la {{ accionItem.tipo === 'CANCELAR' ? 'cancelación' : 'devolución' }} *</label>
         <textarea 
@@ -227,7 +253,7 @@
         <restaurant-button 
           [class]="accionItem.tipo === 'DEVOLVER' ? 'btn-devolver' : 'btn-anular'"
           variant="primary" 
-          [disabled]="!motivoItem().trim()" 
+          [disabled]="!motivoItem().trim() || cantidadItemAccion() < 1 || cantidadItemAccion() > accionItem.maxCantidad" 
           (click)="ejecutarAccionItem()">
           Sí, {{ accionItem.tipo === 'CANCELAR' ? 'cancelar' : 'devolver' }} ítem
         </restaurant-button>

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
@@ -403,6 +403,56 @@
     margin-bottom: var(--space-4);
   }
 
+  .modal-quantity-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    margin-top: var(--space-2);
+
+    button {
+      width: 36px;
+      height: 36px;
+      border-radius: var(--radius-sm);
+      border: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      
+      &.btn-minus {
+        background-color: transparent;
+        color: var(--color-error-text);
+        border: 1px solid var(--color-error-border);
+      }
+      
+      &.btn-plus {
+        background-color: transparent;
+        color: var(--color-success-text);
+        border: 1px solid var(--color-success-border);
+      }
+
+      &:hover:not(:disabled) {
+        transform: scale(1.05);
+        background-color: var(--color-background-soft);
+      }
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+    }
+
+    .qty-display {
+      font-family: var(--font-family-headline);
+      font-size: var(--font-size-xl);
+      font-weight: var(--font-weight-bold);
+      color: var(--color-text-primary);
+      min-width: 40px;
+      text-align: center;
+    }
+  }
+
   .modal-order-summary {
     background-color: var(--color-surface-secondary);
     border-radius: var(--radius-md);

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.scss
@@ -65,6 +65,33 @@
         margin: 0 0 var(--space-1) 0;
       }
 
+      .estado-badge {
+        font-family: var(--font-family-base);
+        font-size: 0.65rem;
+        font-weight: 600;
+        padding: 2px 6px;
+        border-radius: var(--radius-full);
+        text-transform: uppercase;
+        margin-left: 8px;
+
+        &.estado-pendiente {
+          background-color: var(--color-surface-tertiary);
+          color: var(--color-text-secondary);
+        }
+        &.estado-preparando {
+          background-color: rgba(234, 179, 8, 0.15);
+          color: rgb(161, 98, 7);
+        }
+        &.estado-terminado {
+          background-color: rgba(34, 197, 94, 0.15);
+          color: rgb(21, 128, 61);
+        }
+        &.estado-cancelado {
+          background-color: rgba(239, 68, 68, 0.15);
+          color: rgb(185, 28, 28);
+        }
+      }
+
       .category {
         font-family: var(--font-family-base);
         font-size: var(--font-size-sm);

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.ts
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.ts
@@ -48,7 +48,8 @@ export class PedidosCartComponent {
   motivoDevolucion = signal('');
   motivoItem = signal('');
   
-  itemAccionActual = signal<{id: string, nombre: string, tipo: 'CANCELAR' | 'DEVOLVER'} | null>(null);
+  itemAccionActual = signal<{id: string, nombre: string, tipo: 'CANCELAR' | 'DEVOLVER', maxCantidad: number} | null>(null);
+  cantidadItemAccion = signal<number>(1);
 
   editIndex = signal<number | null>(null);
   tempObservacion = signal<string>('');
@@ -155,11 +156,25 @@ export class PedidosCartComponent {
     });
   }
 
-  iniciarAccionItem(id: string | undefined, nombre: string, tipo: 'CANCELAR' | 'DEVOLVER') {
+  iniciarAccionItem(id: string | undefined, nombre: string, tipo: 'CANCELAR' | 'DEVOLVER', maxCantidad: number) {
     if (!id) return;
-    this.itemAccionActual.set({ id, nombre, tipo });
+    this.itemAccionActual.set({ id, nombre, tipo, maxCantidad });
     this.motivoItem.set('');
+    this.cantidadItemAccion.set(maxCantidad);
     this.showItemActionModal.set(true);
+  }
+
+  incrementarCantidadAccion() {
+    const accion = this.itemAccionActual();
+    if (accion && this.cantidadItemAccion() < accion.maxCantidad) {
+      this.cantidadItemAccion.update(c => c + 1);
+    }
+  }
+
+  decrementarCantidadAccion() {
+    if (this.cantidadItemAccion() > 1) {
+      this.cantidadItemAccion.update(c => c - 1);
+    }
   }
 
   ejecutarAccionItem() {
@@ -169,16 +184,18 @@ export class PedidosCartComponent {
     const motivo = this.motivoItem();
     if (!motivo.trim()) return;
 
+    const cantidad = this.cantidadItemAccion();
+
     this.showItemActionModal.set(false);
 
     if (accion.tipo === 'CANCELAR') {
-      this.facade.cancelarItemPedido(accion.id, motivo).subscribe({
+      this.facade.cancelarItemPedido(accion.id, motivo, cantidad).subscribe({
         next: (exito) => {
           if (exito) this.limpiarAccionItem();
         }
       });
     } else {
-      this.facade.devolverItemPedido(accion.id, motivo).subscribe({
+      this.facade.devolverItemPedido(accion.id, motivo, cantidad).subscribe({
         next: (exito) => {
           if (exito) this.limpiarAccionItem();
         }
@@ -189,6 +206,7 @@ export class PedidosCartComponent {
   limpiarAccionItem() {
     this.itemAccionActual.set(null);
     this.motivoItem.set('');
+    this.cantidadItemAccion.set(1);
     this.showItemActionModal.set(false);
   }
 }

--- a/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.ts
+++ b/libs/restaurante/restaurante/src/lib/components/pedidos-cart/pedidos-cart.component.ts
@@ -209,5 +209,21 @@ export class PedidosCartComponent {
     this.cantidadItemAccion.set(1);
     this.showItemActionModal.set(false);
   }
+
+  getEstadoDetalleClass(estado?: string): string {
+    if (!estado) return 'estado-pendiente';
+    switch (estado.toUpperCase()) {
+      case 'PREPARANDO': return 'estado-preparando';
+      case 'TERMINADO': return 'estado-terminado';
+      case 'CANCELADO': return 'estado-cancelado';
+      case 'DEVUELTO': return 'estado-cancelado';
+      default: return 'estado-pendiente';
+    }
+  }
+
+  getEstadoDetalleText(estado?: string): string {
+    if (!estado) return 'Pendiente';
+    return estado.charAt(0).toUpperCase() + estado.slice(1).toLowerCase();
+  }
 }
 

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
@@ -18,6 +18,7 @@ export interface ItemCarrito {
   precioUnitario: number;
   categoria: string;
   observaciones?: string;
+  estadoDetalle?: string;
 }
 
 export interface ProductoMenu {
@@ -227,7 +228,8 @@ export class RestauranteFacade {
               cantidad: d.cantidad,
               precioUnitario: d.precioUnitario,
               categoria: productoCat,
-              observaciones: d.observaciones || undefined
+              observaciones: d.observaciones || undefined,
+              estadoDetalle: d.estadoDetalle
             };
           })
         }));
@@ -426,7 +428,8 @@ export class RestauranteFacade {
                     cantidad: d.cantidad,
                     precioUnitario: d.precioUnitario,
                     categoria: prod ? prod.category : 'COMIDA', // Mapeo dinámico desde el catálogo
-                    observaciones: d.observaciones || undefined
+                    observaciones: d.observaciones || undefined,
+                    estadoDetalle: d.estadoDetalle
                   };
                 })
               };
@@ -553,7 +556,8 @@ export class RestauranteFacade {
           cantidad: d.cantidad,
           precioUnitario: d.precioUnitario,
           categoria: prod ? prod.category : 'COMIDA',
-          observaciones: d.observaciones || undefined
+          observaciones: d.observaciones || undefined,
+          estadoDetalle: d.estadoDetalle
         };
       })
     };

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.facade.ts
@@ -494,9 +494,9 @@ export class RestauranteFacade {
     });
   }
 
-  cancelarItemPedido(idDetalle: string, motivo: string = ''): Observable<boolean> {
+  cancelarItemPedido(idDetalle: string, motivo: string = '', cantidad?: number): Observable<boolean> {
     return new Observable(observer => {
-      this.restauranteService.cancelarDetallePedido(idDetalle, motivo).subscribe({
+      this.restauranteService.cancelarDetallePedido(idDetalle, motivo, cantidad).subscribe({
         next: (pedidoFull) => {
           this.actualizarPedidoActivoDesdeRespuesta(pedidoFull);
           observer.next(true);
@@ -511,9 +511,9 @@ export class RestauranteFacade {
     });
   }
 
-  devolverItemPedido(idDetalle: string, motivo: string = ''): Observable<boolean> {
+  devolverItemPedido(idDetalle: string, motivo: string = '', cantidad?: number): Observable<boolean> {
     return new Observable(observer => {
-      this.restauranteService.devolverDetallePedido(idDetalle, motivo).subscribe({
+      this.restauranteService.devolverDetallePedido(idDetalle, motivo, cantidad).subscribe({
         next: (pedidoFull) => {
           this.actualizarPedidoActivoDesdeRespuesta(pedidoFull);
           observer.next(true);

--- a/libs/restaurante/restaurante/src/lib/data-access/restaurante.service.ts
+++ b/libs/restaurante/restaurante/src/lib/data-access/restaurante.service.ts
@@ -135,18 +135,24 @@ export class RestauranteService {
     return this.http.patch<PedidoResponse>(`${this.pedidosUrl}/${id}/devolver`, null, { params });
   }
 
-  cancelarDetallePedido(idDetalle: string, motivo?: string): Observable<PedidoResponse> {
+  cancelarDetallePedido(idDetalle: string, motivo?: string, cantidad?: number): Observable<PedidoResponse> {
     let params = new HttpParams();
     if (motivo) {
       params = params.set('motivo', motivo);
     }
+    if (cantidad !== undefined && cantidad !== null) {
+      params = params.set('cantidad', cantidad.toString());
+    }
     return this.http.patch<PedidoResponse>(`${this.pedidosUrl}/detalle/${idDetalle}/cancelar`, null, { params });
   }
 
-  devolverDetallePedido(idDetalle: string, motivo?: string): Observable<PedidoResponse> {
+  devolverDetallePedido(idDetalle: string, motivo?: string, cantidad?: number): Observable<PedidoResponse> {
     let params = new HttpParams();
     if (motivo) {
       params = params.set('motivo', motivo);
+    }
+    if (cantidad !== undefined && cantidad !== null) {
+      params = params.set('cantidad', cantidad.toString());
     }
     return this.http.patch<PedidoResponse>(`${this.pedidosUrl}/detalle/${idDetalle}/devolver`, null, { params });
   }

--- a/libs/restaurante/restaurante/src/lib/models/restaurante.model.ts
+++ b/libs/restaurante/restaurante/src/lib/models/restaurante.model.ts
@@ -124,6 +124,7 @@ export interface DetallePedidoResponse {
   precioUnitario: number;     // BigDecimal → number
   subtotalLinea: number;      // cantidad * precioUnitario (calculado por backend)
   observaciones?: string | null;
+  estadoDetalle?: string;     // PENDIENTE, PREPARANDO, TERMINADO, CANCELADO
 }
 
 /**


### PR DESCRIPTION
## Descripción
Este Pull Request implementa dos funcionalidades críticas para sincronizar completamente el comportamiento del carrito de pedidos del restaurante con las reglas y eventos del backend: Cancelaciones y devoluciones parciales y la Visibilidad del estado individual por ítem.

## Tipo de cambio
- [x ] `feat` — nueva funcionalidad
- [ ] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [x ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [x ] `nx affected:lint --base=develop` → 0 errores
- [x ] `nx affected:test --base=develop` → 0 fallos
- [x ] PR tiene menos de 400 líneas modificadas
- [x ] Un solo scope tocado
- [ x] Todo componente nuevo tiene su `.spec.ts`
- [x ] Sin `any` en TypeScript
- [x ] Sin estilos inline en templates
- [ x] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales

1. Cancelaciones y Devoluciones Parciales de Ítems

Se actualizó el RestauranteService y RestauranteFacade para capturar y enviar el parámetro cantidad hacia los endpoints del backend, permitiendo eliminar/devolver únicamente una porción de un producto pedido en lugar de todo el bloque.
Se implementó un selector numérico dentro del modal de acción (cancelar/devolver) en la UI de pedidos-cart.
Se estilizó el control de cantidad usando botones interactivos de + y -, validando dinámicamente que el usuario no seleccione menos de 1 unidad ni exceda la cantidad máxima disponible para ese producto.
2. Visibilidad de Estados Individuales (Sincronización con RabbitMQ)

Se modificó la interfaz DetallePedidoResponse y el modelo ItemCarrito agregando la propiedad estadoDetalle.
El mapeo del Facade ahora extrae este estado desde las respuestas del backend, cerrando la brecha con los eventos emitidos por Cocina y Bar.
Se crearon funciones de soporte y se agregó un badge visual en el carrito (pedidos-cart.component.html) al lado de cada plato.
Los platos ahora reflejan su propio estado de preparación en tiempo real (Gris para Pendiente, Amarillo/Naranja para Preparando, Verde para Terminado y Rojo para Cancelado), independientemente del estado global de la mesa.
