### PR TITLE
fix(usuarios): reemplazar alert() por mensaje visual de error en cambio…

### DIFF
--- a/libs/auth/usuarios/src/lib/pages/perfil-page/perfil-page.component.html
+++ b/libs/auth/usuarios/src/lib/pages/perfil-page/perfil-page.component.html
@@ -211,6 +211,11 @@
     <div class="perfil-exito">{{ i18n.t('perfil.exito') }}</div>
   }
 
+  <!-- Mensaje de error -->
+  @if (errorMsg()) {
+  <div class="perfil-error">{{ errorMsg() }}</div>
+  }
+
   <!-- Botones de acción -->
   <div class="perfil-actions">
     <restaurant-button variant="surface" (click)="onCancelar()">

--- a/libs/auth/usuarios/src/lib/pages/perfil-page/perfil-page.component.scss
+++ b/libs/auth/usuarios/src/lib/pages/perfil-page/perfil-page.component.scss
@@ -252,6 +252,32 @@
   text-align: center;
 }
 
+// ── Mensaje de error ──────────────────────────────────────────────────────────
+
+.perfil-error {
+  padding: var(--space-3) var(--space-4);
+  background: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-align: center;
+  width: 100%;
+  animation: fadeSlide 0.3s ease;
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 // ── Campo de contraseña con toggle (ojo) ───────────────────────────────────
 
 .password-field {

--- a/libs/auth/usuarios/src/lib/pages/perfil-page/perfil-page.component.ts
+++ b/libs/auth/usuarios/src/lib/pages/perfil-page/perfil-page.component.ts
@@ -56,6 +56,7 @@ export class PerfilPageComponent implements OnInit {
 readonly mostrarContrasenaActual = signal(false);
 readonly mostrarNuevaContrasena = signal(false);
 readonly mostrarConfirmarContrasena = signal(false);
+readonly errorMsg = signal('');
 
   readonly iniciales = computed(() => {
     const nombre = this.usuario?.nombre ?? '';
@@ -172,32 +173,37 @@ readonly mostrarConfirmarContrasena = signal(false);
   }
 
   onCambiarContrasena(): void {
-    const form = this.seguridadForm;
-    if (form.invalid) {
-      form.markAllAsTouched();
-      return;
-    }
-    const { contrasenaActual, nuevaContrasena, confirmar } = form.value;
-    if (nuevaContrasena !== confirmar) {
-      alert('Las contraseñas nuevas no coinciden');
-      return;
-    }
-    this.guardando.set(true);
-    this.usuariosService
-      .cambiarContrasena(contrasenaActual!, nuevaContrasena!)
-      .subscribe({
-        next: () => {
-          this.guardando.set(false);
-          this.exito.set(true);
-          form.reset();
-          setTimeout(() => this.exito.set(false), 3000);
-        },
-        error: () => {
-          this.guardando.set(false);
-          alert('Error al cambiar contraseña. Verifique la contraseña actual.');
-        },
-      });
+  const form = this.seguridadForm;
+  if (form.invalid) {
+    form.markAllAsTouched();
+    return;
   }
+  const { contrasenaActual, nuevaContrasena, confirmar } = form.value;
+  if (nuevaContrasena !== confirmar) {
+    this.errorMsg.set('Las contraseñas nuevas no coinciden');
+    return;
+  }
+  this.guardando.set(true);
+  this.errorMsg.set('');
+  this.exito.set(false);
+
+  this.usuariosService
+    .cambiarContrasena(contrasenaActual!, nuevaContrasena!)
+    .subscribe({
+      next: () => {
+        this.guardando.set(false);
+        this.exito.set(true);
+        this.errorMsg.set('');
+        form.reset();
+        setTimeout(() => this.exito.set(false), 3000);
+      },
+      error: () => {
+        this.guardando.set(false);
+        this.errorMsg.set('Error al cambiar contraseña. Verifique la contraseña actual.');
+      },
+    });
+}
+
 
   onCancelar(): void {
     this.cargarPerfil();


### PR DESCRIPTION
… de contraseña

## Descripción
<!-- Qué hace este PR y por qué es necesario -->

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [x] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ ] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [x] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [ ] `nx affected:lint --base=develop` → 0 errores
- [ ] `nx affected:test --base=develop` → 0 fallos
- [x] PR tiene menos de 400 líneas modificadas
- [x] Un solo scope tocado
- [x] Todo componente nuevo tiene su `.spec.ts`
- [ ] Sin `any` en TypeScript
- [ ] Sin estilos inline en templates
- [ ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
<!--
- Agregué X porque Y
- Modifiqué Z para resolver W
-->

## RF relacionado
<!-- Ej: RF-C4.2.1 — Recipe card component -->
