### PR TITLE
fix(restaurante): corregir falso duplicado de nombre al editar mesa

### DIFF
--- a/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.ts
+++ b/libs/restaurante/restaurante/src/lib/pages/mesas-page/mesas-page.component.ts
@@ -312,7 +312,18 @@ export class MesasPageComponent {
     if (!mesa) return;
 
     const rawNombre = this.editNombre().trim();
-    const nombre    = rawNombre ? `MESA ${rawNombre}` : '';
+    
+    // Calcular el nombre original limpio igual que al abrir el modal
+    const nombreLimpioOriginal = mesa.nombre.toUpperCase().startsWith('MESA ') 
+      ? mesa.nombre.substring(5).trim() 
+      : mesa.nombre.trim();
+      
+    // Si el nombre ingresado es idéntico al original, enviar el nombre exacto de la base de datos
+    // para evitar que el backend lo vea diferente por espacios o mayúsculas y lance error de duplicado
+    const nombre = (rawNombre === nombreLimpioOriginal) 
+      ? mesa.nombre 
+      : (rawNombre ? `MESA ${rawNombre}` : '');
+
     const capacidad = this.editCapacidad();
     const zona = this.editZona().trim();
     const obs = this.editObservaciones().trim();


### PR DESCRIPTION
## Descripción
Este Pull Request soluciona un bug en el módulo de gestión de mesas que impedía editar las propiedades secundarias de una mesa (como la capacidad de personas, observaciones o zona) lanzando un falso error de "nombre duplicado".

## Tipo de cambio
- [ ] `feat` — nueva funcionalidad
- [ x] `fix` — corrección de bug
- [ ] `chore` — configuración, dependencias, refactor sin lógica
- [ ] `test` — tests únicamente

## Scope
<!-- Un solo scope por PR — ver ARQUITECTURA.md sección 10 -->
- [ ] `shell` · [ ] `auth` · [ ] `shared`
- [ ] `cocina` · [ ] `bar` · [ x] `restaurante`
- [ ] `inventario` · [ ] `abastecimiento` · [ ] `presupuesto`
- [ ] `requisiciones` · [ ] `reportes` · [ ] `usuarios`

## Checklist obligatorio
- [x ] `nx affected:lint --base=develop` → 0 errores
- [x ] `nx affected:test --base=develop` → 0 fallos
- [x ] PR tiene menos de 400 líneas modificadas
- [ x] Un solo scope tocado
- [x ] Todo componente nuevo tiene su `.spec.ts`
- [x ] Sin `any` en TypeScript
- [x ] Sin estilos inline en templates
- [x ] Sin colores/espaciados fuera de `_variables.scss`

## Cambios principales
- Se actualizó el método `guardarEdicion()` en `mesas-page.component.ts`.
- Ahora, antes de enviar la petición `PUT`, el sistema compara el número limpio ingresado en el formulario con el número limpio original de la mesa.
- Si ambos coinciden (es decir, el usuario no cambió realmente el número de la mesa), el frontend envía el nombre **exacto y original** traído desde la base de datos (`mesa.nombre`).
- Esto evita desencadenar la validación estricta del backend por temas de mayúsculas/minúsculas o espacios accidentales, permitiendo actualizar correctamente la capacidad o las zonas.